### PR TITLE
Add mapping: The Builder Pattern

### DIFF
--- a/catalog/mappings/the-builder-pattern.md
+++ b/catalog/mappings/the-builder-pattern.md
@@ -7,6 +7,7 @@ target_frame: object-oriented-design
 categories:
   - software-engineering
 author: agent:metaphorex-miner
+harness: Claude Code
 contributors: []
 related:
   - the-factory-pattern


### PR DESCRIPTION
## Summary

Mapping: `the-builder-pattern`

- Adds the construction-site metaphor for step-by-step object assembly
- Covers both the GoF director/builder formulation and Bloch's fluent builder variant
- Six substantive "Where It Breaks" entries, including the drift from construction metaphor to order-form metaphor in modern fluent builders

## Validation

\`\`\`
$ uv run scripts/validate.py validate
All content valid.
\`\`\`

Closes #14

Parent project: #3

Generated with [Claude Code](https://claude.com/claude-code)