### PR TITLE
Use native GitHub sub-issues for parent/child relationships

### DIFF
--- a/.github/workflows/project-summary.yml
+++ b/.github/workflows/project-summary.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   post-summary:
-    if: contains(github.event.issue.labels.*.name, 'import-project') && contains(github.event.issue.labels.*.name, 'parent')
+    if: contains(github.event.issue.labels.*.name, 'import-project')
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -23,15 +23,28 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
-          gh issue list -R "$GITHUB_REPOSITORY" \
-            --label import-project --state all \
-            --json number,state --limit 200 \
+          gh api graphql \
+            -f owner="$REPO_OWNER" \
+            -f name="$REPO_NAME" \
+            -F number="$ISSUE_NUMBER" \
+            -f query='query($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                issue(number: $number) {
+                  subIssues(first: 200) { nodes { number state } }
+                }
+              }
+            }' --jq '.data.repository.issue.subIssues.nodes' \
             | python3 -c "
           import json, os, sys
-          issues = json.load(sys.stdin)
-          parent = int(os.environ['ISSUE_NUMBER'])
-          subs = [i for i in issues if i['number'] != parent]
+          subs = json.load(sys.stdin)
+          if not subs:
+              # Not a parent issue (no sub-issues) — skip
+              with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+                  f.write('complete=false\n')
+              sys.exit(0)
           open_count = sum(1 for i in subs if i['state'] == 'OPEN')
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
               f.write(f'total={len(subs)}\n')

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,24 @@ source active vs dormant):
    in the catalog.
 5. **Review** — entries go through editorial review before merging.
 
+## Import projects and sub-issues
+
+Large-scale imports are organized as **import projects** — a parent issue
+describing the source, with individual mapping candidates tracked as native
+GitHub sub-issues of that parent.
+
+- **Parent issues** are labeled `import-project` and describe the source
+  (a book, a pattern catalog, a field of study).
+- **Sub-issues** are created as children of the parent using GitHub's native
+  sub-issue relationship (`addSubIssue` GraphQL mutation). Each sub-issue
+  represents one mapping candidate.
+- **Do not use body text** like "Parent issue: #3" to express parent/child
+  relationships. Use GitHub's native sub-issue feature so the relationship
+  is visible in the UI and queryable via the API.
+
+The pipeline agents (Prospector, Miner, Assayer, Smelter) use native
+sub-issue queries to discover and track work.
+
 ## Editorial guide for mapping entries
 
 This section encodes the editorial standards that all mapping entries must

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -204,20 +204,17 @@ def query_project_timeline(repo: str, issue: int) -> dict | None:
         )
         created_at = result.stdout.strip()
 
-        # Get all sub-issues (issues that reference this parent)
-        # We use the comments to find stats lines with issue numbers,
-        # then check those issues for closed_at
+        # Get sub-issues using native GitHub sub-issue relationships
+        owner, name = repo.split("/")
         result = subprocess.run(
-            ["gh", "issue", "list", "-R", repo,
-             "--label", "import-project", "--state", "all",
-             "--json", "number,title,state,closedAt,createdAt",
-             "--limit", "200"],
+            ["gh", "api", "graphql",
+             "-f", f"owner={owner}", "-f", f"name={name}",
+             "-F", f"number={issue}",
+             "-f", "query=query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { issue(number: $number) { subIssues(first: 100) { nodes { number title state closedAt createdAt } } } } }",
+             "--jq", ".data.repository.issue.subIssues.nodes"],
             capture_output=True, text=True, check=True,
         )
-        sub_issues = json.loads(result.stdout)
-
-        # Filter to sub-issues (exclude parent itself)
-        subs = [s for s in sub_issues if s["number"] != issue]
+        subs = json.loads(result.stdout)
 
         total = len(subs)
         closed = [s for s in subs if s["state"] == "CLOSED"]


### PR DESCRIPTION
## Summary
- project-summary.yml: Use GraphQL `subIssues` query instead of label-based filtering. Remove `parent` label requirement from trigger.
- stats.py: `query_project_timeline()` uses `subIssues` GraphQL query instead of listing all issues and excluding the parent.
- CONTRIBUTING.md: Add section documenting native sub-issue relationships for import projects.

Companion to metaphorex/agents#2 which updates the agent definitions and survey script.

## Test plan
- [ ] Close a sub-issue and verify the workflow uses GraphQL correctly
- [ ] Verify `stats.py summary` still works with the new query

🤖 Generated with [Claude Code](https://claude.com/claude-code)