### PR TITLE
Add mapping: Seeing Is Touching

### DIFF
--- a/catalog/mappings/seeing-is-touching.md
+++ b/catalog/mappings/seeing-is-touching.md
@@ -1,0 +1,124 @@
+---
+slug: seeing-is-touching
+name: "Seeing Is Touching"
+kind: conceptual-metaphor
+source_frame: embodied-experience
+target_frame: vision
+categories:
+  - cognitive-science
+  - linguistics
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - understanding-is-seeing
+  - the-visual-field-is-a-container
+  - the-visual-field-is-a-bounded-region
+---
+
+## What It Brings
+
+Vision as contact. The eyes do not passively receive light -- they reach
+out and touch the world. This metaphor reverses the direction of
+perception: instead of photons arriving at the retina, the gaze travels
+outward and makes contact with its object. The result is an entire
+vocabulary for vision built from the language of manual manipulation.
+
+Key structural parallels:
+
+- **Gaze as grasp** -- "I can't take my eyes off her." "His eyes
+  fastened on the door." "She fixed her gaze on the horizon." The act of
+  looking becomes an act of seizing. Attention is not reception but
+  prehension -- the eyes grab hold of what they see and don't let go.
+- **Visual scanning as tactile exploration** -- "His eyes picked out
+  every detail." "Her gaze swept the room." "He ran his eyes over the
+  document." Looking carefully maps onto the hands moving across a
+  surface, feeling for features. The metaphor makes careful observation
+  feel like the systematic touch of a craftsman inspecting material.
+- **Eye contact as physical contact** -- "Their eyes met." "She felt
+  his gaze on her." "His stare bore into her." Two people looking at
+  each other is construed as a physical encounter, with all the intimacy
+  and intrusiveness that touch implies. This is why unwanted staring
+  feels like a violation -- the metaphor makes it one.
+- **Visual impact as physical impact** -- "A striking image." "An
+  eye-catching display." "A sight that hit me." Things that are
+  visually arresting are construed as things that physically contact
+  the viewer. Beauty strikes; horror hits; the sublime overwhelms.
+- **Directing vision as pointing** -- "Cast your eyes over there." "Throw
+  a glance." "Shoot a look." The eyes project force outward, like a hand
+  extending to point or a projectile launched at a target.
+
+## Where It Breaks
+
+- **Vision is bidirectional; touch is not symmetric** -- when you touch
+  something, you feel it and it feels you. When you see something, it
+  does not see you back (unless it has eyes). The metaphor imports a
+  reciprocity from touch that vision lacks, which is why "she felt his
+  gaze" works metaphorically but is physically impossible. This
+  asymmetry matters: the metaphor can make looking feel more invasive
+  than it is, or conversely, more intimate than it is.
+- **Touch requires proximity; vision does not** -- the metaphor
+  collapses distance. You can see a mountain from fifty miles away, but
+  you cannot touch it. By mapping vision onto touch, the metaphor makes
+  distant observation feel like close encounter. This distortion is
+  useful in poetry ("my eyes caressed the landscape") but misleading in
+  epistemology, where it can make remote observation feel as reliable as
+  hands-on inspection.
+- **The metaphor makes the viewer active and the object passive** --
+  in touch, the agent acts on the patient. "His eyes picked out every
+  detail" construes the scene as waiting to be examined, not as emitting
+  information. This underplays the role of light, contrast, and the
+  object's own visibility. Some things are hard to see not because the
+  gaze hasn't touched them, but because they aren't emitting useful
+  signals.
+- **Cultural freight of touch and gaze** -- the metaphor inherits the
+  ethics of touch. If looking is touching, then looking without
+  permission is touching without permission. This has real consequences
+  for how cultures regulate the gaze (lowering eyes as deference, the
+  "male gaze" as violation). The metaphor is not neutral -- it carries
+  moral weight from its source domain that may or may not be warranted
+  in the target domain.
+
+## Expressions
+
+- "I can't take my eyes off her" -- sustained attention as physical grip
+- "His eyes picked out every detail" -- selective attention as manual
+  selection
+- "Her gaze swept the room" -- visual scanning as a hand sweeping a surface
+- "Their eyes met" -- mutual gaze as physical contact
+- "She felt his gaze on her" -- being looked at as being touched
+- "Cast your eyes over there" -- redirecting vision as throwing something
+- "He ran his eyes over the document" -- reading as fingers moving across
+  a surface
+- "A striking image" -- visual impact as physical blow
+- "He shot her a look" -- a glance as a projectile directed at a target
+- "Her eyes lingered on the painting" -- sustained looking as prolonged
+  touch
+
+## Origin Story
+
+Lakoff and Johnson discuss SEEING IS TOUCHING in *Metaphors We Live By*
+as an example of how one physical domain (touch) can structure our
+understanding of another (vision). The metaphor has ancient roots: the
+Greek extramission theory of vision, held by Empedocles and Plato, posited
+that the eyes literally emit rays that contact objects. This was not merely
+a scientific hypothesis -- it reflected the deep intuition, preserved in
+the metaphor, that vision is an active, outward-reaching process rather
+than passive reception.
+
+The metaphor persists because the embodied experience supports it. When
+you stare at someone, they often feel it. When you "look someone up and
+down," the scanning pattern mimics touch. The correlation between visual
+attention and physical interaction in early development -- infants reach
+for what they see -- grounds the metaphor in bodily experience, making it
+one of Lakoff and Johnson's primary metaphors.
+
+## References
+
+- Lakoff, G. & Johnson, M. *Metaphors We Live By* (1980), Chapter 10
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999) -- primary
+  metaphors and their experiential grounding
+- Sweetser, E. *From Etymology to Pragmatics* (1990) -- cross-domain
+  mappings among the senses
+- Gross, C. G. "Genealogy of the 'Grandmother Cell'" (2002) -- history
+  of extramission theories of vision


### PR DESCRIPTION
## Summary

- Adds `seeing-is-touching` mapping from Lakoff & Johnson's *Metaphors We Live By*
- Vision structured through the embodied experience of physical contact/touch
- Covers gaze-as-grasp, visual scanning as tactile exploration, eye contact as physical contact

Closes #127

## Validator output

```
All content valid.
```

## Test plan

- [x] Validator passes with no errors
- [x] Frontmatter follows schema (kind: conceptual-metaphor, frames exist)
- [x] Body sections complete: What It Brings, Where It Breaks, Expressions, Origin Story, References