### PR TITLE
Add mapping: hydra-code

### DIFF
--- a/catalog/mappings/hydra-code.md
+++ b/catalog/mappings/hydra-code.md
@@ -1,0 +1,123 @@
+---
+slug: hydra-code
+name: "Hydra Code"
+kind: conceptual-metaphor
+source_frame: mythology
+target_frame: software-programs
+categories:
+  - software-engineering
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - spaghetti-code
+  - big-ball-of-mud
+  - software-rot
+---
+
+## What It Brings
+
+The Lernaean Hydra of Greek mythology: a serpentine monster whose heads
+regenerate when severed -- cut one off and two grow back. Heracles could
+only defeat it by cauterizing each stump immediately after cutting. This
+maps onto codebases where fixing one bug introduces two new ones, where
+patching a defect in one module triggers failures in others, and where
+incremental repair makes things worse rather than better.
+
+Key structural parallels:
+
+- **Regenerative failure** -- the Hydra's defining property is that
+  the natural response (cutting) makes the problem worse. In code, the
+  natural response to a bug is a targeted fix, but in a hydra codebase,
+  each fix disturbs hidden dependencies and creates new defects. The
+  metaphor captures the specific dread of a system where effort is
+  inversely correlated with progress.
+- **Interconnected heads** -- the Hydra's heads share a single body.
+  The bugs in hydra code are not independent; they are symptoms of a
+  shared structural disease. Fixing the visible head (the reported bug)
+  without addressing the body (the architectural rot beneath) is
+  futile. The metaphor implicitly argues that local fixes to global
+  problems are worse than no fixes at all.
+- **Cauterization as the only remedy** -- Heracles needed fire, not a
+  sharper sword. The metaphor maps this onto the developer's painful
+  realization that incremental patching will not work and that the only
+  real solution is radical intervention: a rewrite, a redesign, or
+  ripping out the affected subsystem entirely. "Cauterize" in developer
+  usage means scorched-earth refactoring -- destroying the substrate
+  that allows regrowth.
+- **The heroic framing** -- the Hydra was one of Heracles' twelve
+  labors, a task of legendary difficulty. Calling code "hydra code"
+  elevates the debugging task from mundane maintenance to mythic
+  struggle, which validates the developer's frustration and signals
+  to others that this is not ordinary difficulty.
+
+## Where It Breaks
+
+- **Hydras are alive; code is not** -- the Hydra regenerates because
+  it is a living organism with biological processes. Code does not
+  spontaneously generate new bugs. What actually happens is that a
+  developer's fix interacts with existing latent defects or
+  unrecognized coupling. The metaphor suggests autonomous malice where
+  there is only hidden complexity. This can mystify what is actually a
+  tractable engineering problem.
+- **The metaphor discourages incremental improvement** -- if the only
+  solution is cauterization (rewrite), then anything short of that is
+  futile. This is often false. Many "hydra" codebases can be improved
+  incrementally through systematic testing, dependency injection, and
+  gradual decoupling. The mythological framing can become a
+  self-fulfilling prophecy: developers stop trying small fixes because
+  the metaphor told them only fire works.
+- **It externalizes responsibility** -- the Hydra is an external
+  monster that attacks the hero. But hydra code is usually authored by
+  the same team that now faces it. The mythological framing casts the
+  code as an adversary to be slain rather than a consequence of past
+  decisions to be understood. This prevents the root-cause analysis
+  (inadequate testing, missing specifications, time pressure) that
+  would prevent future hydras.
+- **Two-for-one is too precise** -- the Hydra's ratio (cut one, grow
+  two) implies exponential growth. Real bug multiplication is messier:
+  sometimes a fix introduces zero new bugs, sometimes three, sometimes
+  a different class of failure entirely. The neat doubling ratio
+  imports a mathematical inevitability that real codebases do not
+  exhibit.
+
+## Expressions
+
+- "This codebase is a hydra" -- the diagnosis, usually delivered after
+  a developer's third attempt to fix the same area has created new
+  regressions
+- "Every time I fix one bug, two more appear" -- the experiential
+  description that the hydra label formalizes
+- "We need to cauterize this module" -- the prescription for radical
+  rewrite, directly borrowing the mythological solution
+- "Whack-a-mole code" -- a related but distinct metaphor (from arcade
+  games) that captures bug recurrence without the regeneration aspect
+- "It's growing heads faster than we can cut them" -- the crisis
+  state, when the bug-introduction rate exceeds the bug-fix rate
+
+## Origin Story
+
+The metaphor draws on one of the oldest stories in Western literature.
+The Lernaean Hydra appears in Hesiod's *Theogony* (circa 700 BCE) and
+was elaborated in later accounts of the Twelve Labors of Heracles.
+The programming usage emerged organically in developer culture,
+particularly in blog posts and conference talks from the 2000s onward,
+as codebases grew large enough for the regenerative-failure pattern to
+become a recognized phenomenon.
+
+The related "whack-a-mole" metaphor (from the arcade game where
+hitting one mole causes another to pop up) covers similar ground but
+lacks the hydra's implication of growth -- whack-a-mole bugs reappear
+but do not multiply. The hydra metaphor specifically captures the
+escalation dynamic where intervention makes things worse.
+
+## References
+
+- Hesiod, *Theogony* (c. 700 BCE) -- the earliest literary account of
+  the Hydra
+- Spolsky, J. "Things You Should Never Do, Part I," *Joel on Software*
+  (2000) -- argues against the "cauterize and rewrite" instinct that
+  hydra code provokes
+- Feathers, M. *Working Effectively with Legacy Code* (2004) -- the
+  definitive guide to incremental improvement of codebases that
+  resist change


### PR DESCRIPTION
## Summary

- Adds `hydra-code` mapping: maps the Lernaean Hydra's regenerating heads onto bugs that multiply when fixed
- Source frame: `mythology`, Target frame: `software-programs`
- Categories: `software-engineering`

Closes #177

## Validator output

```
All content valid.
```

Generated with [Claude Code](https://claude.com/claude-code)