### PR TITLE
Add mapping: shotgun-debugging

### DIFF
--- a/catalog/mappings/shotgun-debugging.md
+++ b/catalog/mappings/shotgun-debugging.md
@@ -1,0 +1,131 @@
+---
+slug: shotgun-debugging
+name: "Shotgun Debugging"
+kind: conceptual-metaphor
+source_frame: war
+target_frame: software-programs
+categories:
+  - software-engineering
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - rubber-duck-debugging
+  - heisenbug
+  - cargo-cult-programming
+---
+
+## What It Brings
+
+A shotgun fires a wide spray of pellets rather than a single aimed
+bullet. You do not need to know exactly where the target is; you
+saturate the area and hope something hits. Shotgun debugging maps this
+onto the practice of making many simultaneous changes to a broken
+program -- adding null checks everywhere, updating all dependencies,
+restarting every service -- without understanding which specific change
+fixes the bug. The metaphor names a strategy that every developer
+recognizes and most have used.
+
+Key structural parallels:
+
+- **Spread over precision** -- a shotgun sacrifices accuracy for
+  coverage. The debugger sacrifices understanding for speed. Both
+  operate under the same logic: if you do not know exactly what to
+  target, target everything. The metaphor captures a genuine tradeoff
+  that exists in both domains -- sometimes spray-and-pray is faster
+  than methodical aiming, especially when the cost of each pellet
+  (each code change) is low.
+- **The problem of attribution** -- when a shotgun kills a bird, you
+  do not know which pellet did it. When shotgun debugging fixes a bug,
+  you do not know which change was the fix. This is not just an
+  academic concern: the unidentified fix means you cannot explain the
+  bug to others, cannot write a regression test for the specific
+  failure, and cannot be confident you have not introduced new
+  problems with the non-essential changes. The metaphor encodes the
+  epistemological cost of the strategy.
+- **Weapon choice signals desperation** -- choosing a shotgun over a
+  rifle implies you cannot aim well enough for precision, or that
+  the target is moving too fast. Choosing shotgun debugging over
+  systematic analysis implies similar conditions: the codebase is too
+  opaque, the deadline too close, or the developer too exhausted for
+  careful reasoning. The weapon metaphor imports the judgment of the
+  situation, not just the technique.
+- **The hunting/military frame** -- debugging-as-combat is a rich
+  metaphor family. Bugs are the enemy, tools are weapons, and the
+  developer is a hunter or soldier. The shotgun variant sits within
+  this frame as the low-skill, high-desperation option, contrasted
+  with "surgical" fixes (precise, expert) and "sniper" debugging
+  (patient, targeted). The weapon taxonomy creates a vocabulary for
+  debugging strategies ranked by precision.
+
+## Where It Breaks
+
+- **Shotguns are effective at close range; shotgun debugging often is
+  not** -- a real shotgun is a devastating weapon within its intended
+  range. Shotgun debugging, by contrast, frequently fails entirely:
+  the random changes do not happen to address the actual bug, and the
+  developer has wasted time and polluted the codebase with unnecessary
+  modifications. The metaphor imports a success rate that the
+  debugging strategy does not possess.
+- **The metaphor moralizes a sometimes-rational strategy** -- calling
+  it "shotgun" debugging implies it is always inferior to careful
+  analysis. But in some situations -- intermittent failures, unclear
+  reproduction steps, enormous codebases with no documentation -- a
+  scattershot approach is genuinely the best use of limited time. The
+  military framing makes it sound reckless when it might be pragmatic.
+- **Shotgun pellets do not create new problems; code changes do** -- a
+  pellet that misses the target harmlessly embeds in the ground. A
+  code change that does not fix the bug may still introduce a new bug,
+  change performance characteristics, or create a dependency that
+  complicates future work. The metaphor underestimates the collateral
+  damage of the non-fixing changes by mapping them onto inert misses.
+- **The metaphor is individualistic** -- shotgun debugging is framed as
+  a single developer's technique. But in modern development, the
+  "shotgun" is often organizational: multiple engineers independently
+  attempting fixes, multiple hotfixes deployed simultaneously, multiple
+  config changes applied at once. The individual-weapon framing misses
+  the coordination failure that organizational shotgun debugging
+  represents.
+
+## Expressions
+
+- "They're just shotgun debugging" -- the pejorative diagnosis,
+  implying a lack of systematic approach
+- "Stop shotgunning and read the logs" -- the corrective injunction
+  from a senior developer
+- "Spray and pray" -- the military slang variant, emphasizing the
+  hope-based nature of the approach
+- "Shotgun surgery" -- a related but distinct term from refactoring
+  literature (Martin Fowler), meaning a single change that requires
+  modifications in many unrelated places. The direction is reversed:
+  shotgun debugging is many changes to fix one bug; shotgun surgery is
+  one change that touches many places.
+- "I just tried everything until it worked" -- the honest
+  retrospective admission that shotgun debugging has occurred
+
+## Origin Story
+
+The term appears in developer culture at least as early as the 1990s
+and is codified in the Jargon File. It belongs to a broader tradition
+of military and hunting metaphors in computing: "targeting" bugs,
+"killing" processes, "nuking" caches. The shotgun variant specifically
+emerged to name the experience of desperation-driven, comprehension-free
+debugging that becomes more common as systems grow more complex and
+time pressure intensifies.
+
+Martin Fowler's "Shotgun Surgery" code smell, introduced in
+*Refactoring* (1999), uses the same weapon but maps a different
+phenomenon: a design flaw where a single conceptual change requires
+modifications scattered across many classes. The two uses of "shotgun"
+in software -- one about debugging, one about design -- both exploit
+the weapon's defining characteristic of wide dispersal.
+
+## References
+
+- Raymond, E. S. *The New Hacker's Dictionary* (1996) -- codifies
+  shotgun debugging in hacker vocabulary
+- Fowler, M. *Refactoring: Improving the Design of Existing Code*
+  (1999) -- introduces "Shotgun Surgery" as a code smell, the design
+  counterpart to the debugging metaphor
+- Zeller, A. *Why Programs Fail* (2009) -- systematic debugging
+  methods that represent the opposite of the shotgun approach


### PR DESCRIPTION
## Summary

- Adds `shotgun-debugging` mapping: maps wide-spray weapon fire onto making random code changes to fix bugs
- Source frame: `war`, Target frame: `software-programs`
- Categories: `software-engineering`

Closes #179

## Validator output

```
All content valid.
```

Generated with [Claude Code](https://claude.com/claude-code)