### PR TITLE
Add mapping: deep-magic

### DIFF
--- a/catalog/mappings/deep-magic.md
+++ b/catalog/mappings/deep-magic.md
@@ -1,0 +1,142 @@
+---
+slug: deep-magic
+name: "Deep Magic"
+kind: conceptual-metaphor
+source_frame: mythology
+target_frame: software-programs
+categories:
+  - software-engineering
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - heisenbug
+  - cargo-cult-programming
+---
+
+## What It Brings
+
+Arcane mystical knowledge -- spells known only to initiates, power
+derived from secrets older than the current order -- mapped onto code
+and technical knowledge so obscure that it might as well be sorcery.
+Deep magic is the kernel hack that no one understands but everyone
+depends on, the compiler flag discovered by trial and error, the
+incantation in the build script that must not be changed. The metaphor
+frames technical expertise as a form of occult power, with all the
+reverence and danger that implies.
+
+Key structural parallels:
+
+- **Knowledge as power, and power as dangerous** -- in mythological
+  traditions, magical knowledge is both potent and hazardous. The
+  wizard who knows the true names of things can command them, but that
+  knowledge exacts a cost. In software, deep magic operates identically:
+  the developer who understands the memory allocator's edge cases or
+  the networking stack's undocumented behavior has real power over the
+  system, but that knowledge is fragile, non-transferable, and often
+  acquired through painful experience rather than study.
+- **Initiation and hierarchy** -- magic traditions distinguish between
+  apprentices, journeymen, and masters. The deep magic metaphor imports
+  this hierarchy into software culture: there are developers who use
+  the framework, developers who understand the framework, and developers
+  who understand the thing the framework is built on top of. Each layer
+  deeper is a level of initiation. The metaphor naturalizes expertise
+  hierarchies by casting them as mystical rather than merely technical.
+- **Here be dragons** -- the cartographic variant marks unknown or
+  dangerous territory on maps. In code, "here be dragons" comments
+  mark sections where the logic is correct but incomprehensible, where
+  modifications will cause failures that cannot be predicted by reading
+  the code. The dragons are not bugs -- the code works -- but the
+  understanding of *why* it works has been lost or was never
+  articulated.
+- **Incantation over understanding** -- magic spells work by exact
+  recitation, not by the caster's understanding of mechanism. Deep
+  magic in code has the same property: the specific sequence of
+  operations, the exact flags, the precise order of initialization
+  must be preserved, and no one can explain why from first principles.
+  The metaphor captures code that is functionally correct and
+  epistemically opaque.
+
+## Where It Breaks
+
+- **Magic is supernatural; software is deterministic** -- the
+  fundamental asymmetry. Deep magic in mythology operates outside
+  natural law. Deep magic in code operates entirely within it: every
+  behavior has a causal chain that could, in principle, be traced.
+  Calling it "magic" concedes understanding prematurely. What feels
+  like sorcery is usually undocumented behavior, undefined behavior
+  that happens to produce consistent results, or emergent effects of
+  interacting subsystems. The metaphor dignifies ignorance as mystery.
+- **The metaphor romanticizes obscurity** -- calling impenetrable code
+  "deep magic" makes it sound impressive rather than problematic. The
+  wizard-developer who maintains the deep magic accrues status from
+  their monopoly on comprehension. This creates perverse incentives:
+  writing clear, well-documented code reduces your mystique, while
+  writing opaque code that only you understand increases your perceived
+  value. The metaphor rewards the disease it purports to merely
+  describe.
+- **It discourages investigation** -- labeling code as deep magic
+  signals to other developers that they should not try to understand
+  it. This creates a self-reinforcing knowledge silo: the code stays
+  opaque because everyone treats opacity as a permanent property rather
+  than a solvable problem. The mythological framing converts an
+  engineering failure (inadequate documentation, unclear abstractions)
+  into an inherent property of the code itself.
+- **Magic has no tests** -- in mythology, you know a spell works
+  because you tried it and it worked. There is no test suite for
+  sorcery. In software, "deep magic" code could be made less magical
+  by characterization tests, formal specifications, or systematic
+  documentation. The metaphor provides no vocabulary for the
+  de-enchantment process that good engineering practices enable.
+
+## Expressions
+
+- "That's deep magic" -- acknowledging that a piece of code or
+  technique is beyond the speaker's understanding, with a tone of
+  respect rather than alarm
+- "Here be dragons" -- the code comment warning that the following
+  section is dangerous to modify, borrowed from medieval cartography's
+  notation for unexplored territory
+- "Black magic" -- a more pejorative variant implying the code is not
+  just obscure but actively dangerous or ill-intentioned
+- "It works by magic" -- the admission that a system's correct behavior
+  cannot be explained by anyone currently on the team
+- "Wizard" / "code wizard" -- the practitioner of deep magic, a
+  developer whose expertise in a particular domain appears supernatural
+  to colleagues
+- "Do not touch this code" -- the pragmatic translation of "here be
+  dragons," stripped of the mythological framing
+
+## Origin Story
+
+The Jargon File, compiled by Raphael Finkel and later maintained by
+Eric S. Raymond, codified "deep magic" as hacker slang by the early
+1980s. The term references both mythological traditions broadly and
+C.S. Lewis's *The Lion, the Witch and the Wardrobe* (1950)
+specifically, where the "Deep Magic from the Dawn of Time" refers to
+fundamental laws that even the most powerful beings must obey -- a
+fitting analogy for hardware constraints and protocol specifications
+that no amount of clever coding can circumvent.
+
+The "here be dragons" variant draws on the Latin phrase *hic sunt
+dracones*, which appears on the Hunt-Lenox Globe (c. 1510) and has
+become a general marker for dangerous unknown territory. In code, the
+phrase entered common usage through comments in C and Unix source
+code, where maintainers would warn future readers away from sections
+whose correctness was empirical rather than reasoned.
+
+The broader magic metaphor family in computing -- wizards, spells,
+incantations, grimoires (man pages) -- reflects a deep structural
+parallel between programming and ceremonial magic: both involve
+precise symbolic manipulation where exact syntax matters and small
+errors have disproportionate consequences.
+
+## References
+
+- Raymond, E. S. *The New Hacker's Dictionary* (1996) -- codifies
+  "deep magic," "black magic," and "wizard" in hacker vocabulary
+- Lewis, C. S. *The Lion, the Witch and the Wardrobe* (1950) -- the
+  literary source for "Deep Magic from the Dawn of Time"
+- Knuth, D. E. *The Art of Computer Programming* (1968-) -- the
+  canonical grimoire, itself treated as deep magic by most developers
+  who own but have not read it


### PR DESCRIPTION
## Summary

- Adds `deep-magic` mapping: maps arcane mystical knowledge onto obscure, undocumented technical expertise
- Source frame: `mythology`, Target frame: `software-programs`
- Categories: `software-engineering`

Closes #180

## Validator output

```
All content valid.
```

Generated with [Claude Code](https://claude.com/claude-code)