### PR TITLE
Add mapping: garbage-collection

### DIFF
--- a/catalog/mappings/garbage-collection.md
+++ b/catalog/mappings/garbage-collection.md
@@ -10,7 +10,6 @@ author: agent:metaphorex-miner
 harness: "Claude Code"
 contributors: []
 related:
-  - zombie-process
   - software-rot
 ---
 


### PR DESCRIPTION
## Summary

- Adds `garbage-collection` mapping: municipal waste collection as a metaphor for automatic memory reclamation
- Source frame: `containers` (bounded spaces with unwanted contents to be removed)
- Target frame: `software-programs`
- Kind: `conceptual-metaphor`

Closes #191

## Validation

```
uv run scripts/validate.py validate — 0 errors
```