### PR TITLE
Add mapping: breadcrumb-trail

### DIFF
--- a/catalog/mappings/breadcrumb-trail.md
+++ b/catalog/mappings/breadcrumb-trail.md
@@ -1,0 +1,120 @@
+---
+slug: breadcrumb-trail
+name: "Breadcrumb Trail"
+kind: conceptual-metaphor
+source_frame: journeys
+target_frame: software-programs
+categories:
+  - software-engineering
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - life-is-a-journey
+  - data-flow-is-fluid-flow
+---
+
+## What It Brings
+
+Hansel and Gretel dropped breadcrumbs to mark their path through the
+forest so they could find their way home. The metaphor maps this act of
+leaving recoverable trail markers onto two distinct software practices:
+UI navigation aids that show users where they are in a hierarchy, and
+debug logging that records the path of execution through a system. In
+both cases, the breadcrumb serves the same function -- it answers the
+question "how did I get here?" by preserving a record of the journey.
+
+Key structural parallels:
+
+- **Sequential markers on a path** -- breadcrumbs are dropped one at a
+  time, in order, as you move forward. UI breadcrumbs work the same way:
+  Home > Products > Electronics > Headphones. Each element represents a
+  step in the navigation path, and the sequence encodes the history. The
+  mapping is structurally tight: position in the fairy-tale forest maps
+  onto position in an information hierarchy.
+- **Reversibility** -- the entire point of breadcrumbs is to enable
+  backtracking. In UI design, breadcrumb navigation lets users jump back
+  to any ancestor page without using the browser's back button. In
+  debugging, a log trail lets developers trace execution backward from a
+  failure to its cause. The metaphor maps physical return-along-a-path
+  onto logical traversal of a recorded history.
+- **Minimal footprint** -- breadcrumbs are small, cheap, and
+  unobtrusive. A breadcrumb navigation bar takes a single line of screen
+  real estate. Debug breadcrumbs are lightweight log entries, not full
+  stack traces. The metaphor encodes an economy principle: the trail
+  should cost almost nothing to leave and everything to have when you
+  need it.
+- **Path, not map** -- breadcrumbs record a single traversal, not the
+  full topology. A breadcrumb trail tells you where *you* went, not
+  where you *could have* gone. This maps onto the difference between a
+  sitemap (full structure) and breadcrumbs (your specific path), or
+  between a full system trace and a single-request log trail.
+
+## Where It Breaks
+
+- **The birds ate the breadcrumbs** -- in the fairy tale, the trail
+  fails: birds eat the crumbs, and the children are lost. The metaphor
+  carries this vulnerability but software breadcrumbs usually don't
+  acknowledge it. Log rotation deletes old entries. Browser history
+  clears. Session data expires. The metaphor's origin story is
+  literally about the failure mode of the technique, but developers use
+  it as if breadcrumbs are reliable -- which they are, until the birds
+  come.
+- **Breadcrumbs are passive; navigation is active** -- dropping
+  breadcrumbs is something you do while walking, almost unconsciously.
+  But implementing breadcrumb navigation requires deliberate architectural
+  decisions: hierarchical URL structures, metadata on every page,
+  consistent taxonomy. The metaphor implies effortlessness, but the
+  engineering is anything but.
+- **Hierarchical breadcrumbs are not path breadcrumbs** -- most UI
+  breadcrumbs show the hierarchical position of the current page, not
+  the user's actual navigation path. Home > Products > Headphones appears
+  whether you navigated there from the homepage or from a search result.
+  The fairy-tale breadcrumbs record the actual path taken; UI breadcrumbs
+  often record the canonical position. The metaphor conflates history
+  with hierarchy.
+- **The forest is not a tree** -- Hansel and Gretel's forest is an
+  undifferentiated space where you can get lost. A website's information
+  architecture is (ideally) a well-structured hierarchy. Breadcrumbs are
+  most useful when the structure is already clear; in the fairy tale,
+  they were necessary because the structure was opaque. The metaphor's
+  setting implies confusion, but the technique works best in ordered
+  environments.
+
+## Expressions
+
+- "Add breadcrumbs to that page" -- requesting breadcrumb navigation in
+  UI design, treating it as a standard component
+- "Follow the breadcrumb trail" -- tracing a sequence of log entries or
+  debug markers to find a bug's origin
+- "Breadcrumb navigation" -- the UI pattern itself, now a standard term
+  in web design with its own W3C accessibility guidelines
+- "Drop some breadcrumbs in the logging" -- adding trace markers to code,
+  explicitly invoking the fairy-tale act of marking a path
+- "The breadcrumbs don't match the URL" -- a common bug where the
+  displayed hierarchy diverges from the actual page location
+
+## Origin Story
+
+The fairy-tale source is "Hansel and Gretel," collected by the Brothers
+Grimm in 1812 (though the oral tradition is older). In the story, the
+children first mark their path with white pebbles (which works) and
+then with breadcrumbs (which fails, because birds eat them). The
+software community adopted the successful connotation and ignored the
+cautionary one.
+
+The UI pattern was formalized in web design in the late 1990s, as
+websites grew complex enough to require navigational aids. Jakob Nielsen
+championed breadcrumbs in his usability work, and the pattern became a
+standard element of e-commerce and content management systems. The
+term's adoption in debugging and logging is more diffuse, emerging from
+developer vernacular rather than any single formalization.
+
+## References
+
+- Grimm, J. & W. *Children's and Household Tales* (1812) -- the
+  original fairy tale that provides the source domain
+- Nielsen, J. "Breadcrumb Navigation Increasingly Useful," *Nielsen
+  Norman Group* (2007) -- usability research validating the UI pattern
+- W3C WAI. "Breadcrumb Navigation," *ARIA Authoring Practices Guide*
+  -- the accessibility standard that institutionalized the metaphor


### PR DESCRIPTION
## Summary

- Adds `breadcrumb-trail` mapping: Hansel and Gretel's breadcrumbs as a metaphor for UI navigation and debug logging
- Source frame: `journeys` (path markers enabling backtracking)
- Target frame: `software-programs`
- Kind: `conceptual-metaphor`

Closes #193

## Validation

```
uv run scripts/validate.py validate — 0 errors
```