### PR TITLE
Add mapping: a-force-is-a-moving-object

### DIFF
--- a/catalog/mappings/a-force-is-a-moving-object.md
+++ b/catalog/mappings/a-force-is-a-moving-object.md
@@ -1,0 +1,139 @@
+---
+slug: a-force-is-a-moving-object
+name: "A Force Is a Moving Object"
+kind: conceptual-metaphor
+source_frame: embodied-experience
+target_frame: physics
+categories:
+  - cognitive-science
+  - linguistics
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - causes-are-forces
+  - psychological-forces-are-physical-forces
+  - obligations-are-forces
+  - love-is-a-physical-force
+  - difficulties-are-impediments-to-motion
+---
+
+## What It Brings
+
+Forces come at you. They hit you, push you, knock you over, sweep you
+along. This metaphor takes one of the most abstract concepts in physics
+-- force as an invisible interaction between bodies -- and maps it onto
+one of the most concrete experiences available to embodied beings: seeing
+and feeling things move toward you, collide with you, and carry you
+with them.
+
+The mapping makes forces tractable by giving them the properties of
+moving objects:
+
+- **Forces have direction and trajectory** -- "A wave of pressure hit
+  the building." "The force of the explosion swept through the valley."
+  Because moving objects travel along paths, forces inherit
+  directionality. We understand forces as going somewhere, coming from
+  somewhere, and following a route through space.
+- **Forces have momentum and mass** -- "The sheer weight of public
+  opinion." "An unstoppable force." "A groundswell of support." Moving
+  objects have heft, speed, and inertia. When force is understood as a
+  moving object, it becomes something with quantity -- big forces are
+  heavy, fast-moving objects; small forces are light, slow ones.
+- **Forces can be blocked, deflected, or absorbed** -- "He withstood
+  the force of the blow." "She deflected the criticism." "The wall
+  absorbed the impact." Because moving objects interact with obstacles,
+  the metaphor gives us a vocabulary for resisting and redirecting
+  forces. You can put something in the way of a force, just as you
+  can block a thrown ball.
+- **Forces arrive** -- "The full force of the recession hit in March."
+  "When it hits you, you'll understand." Forces are not always present;
+  they come. The moving-object mapping gives forces a temporal structure:
+  a force is something that was not here, then approached, then arrived,
+  then made impact.
+- **Forces can be sent** -- "He directed all his energy at the problem."
+  "She hurled accusations." "They launched an attack." If forces are
+  moving objects, then agents can propel them. This extends the metaphor
+  into causation: to exert force is to throw something at a target.
+
+## Where It Breaks
+
+- **Forces are not objects** -- in physics, a force is an interaction
+  between two bodies, not a third entity traveling between them. Gravity
+  does not fly from the Earth to the Moon. The moving-object metaphor
+  reifies forces into discrete things with independent existence, which
+  obscures the relational nature of physical interaction. This is not
+  merely a pedagogical nuisance; it actively misleads students of physics
+  who think of forces as substances that bodies emit and receive.
+- **Fields have no good moving-object representation** -- gravitational
+  and electromagnetic fields pervade space continuously. They do not
+  travel from source to target (except in the special case of radiation).
+  The moving-object metaphor handles impact forces well but struggles
+  with fields, which is why field theory required a conceptual revolution
+  that explicitly broke with the projectile model of force.
+- **The metaphor implies delay** -- if a force is a moving object, it
+  takes time to arrive. This is actually true for some forces (light
+  has a finite speed) but misleading for others (gravity in Newtonian
+  mechanics is instantaneous). The metaphor imports a temporal gap that
+  may or may not exist.
+- **Continuous forces become episodic** -- a moving object arrives once,
+  makes impact, and is done. But many forces are continuous and sustained:
+  gravity never stops pulling, tension never stops pulling the rope taut.
+  The metaphor's event structure (approach, impact, aftermath) fits
+  impulsive forces but distorts sustained ones.
+- **The metaphor obscures equilibrium** -- when two forces balance, the
+  moving-object frame suggests two objects colliding and stopping each
+  other. But equilibrium in physics is not a frozen collision; it is a
+  condition where net interaction is zero. The dynamic imagery of moving
+  objects makes static balance harder to conceptualize.
+
+## Expressions
+
+- "The force of the blow knocked him down" -- force as a moving thing
+  that strikes
+- "A wave of nausea hit her" -- an internal sensation arriving like a
+  moving object
+- "The full force of the storm swept through" -- weather force as a
+  moving mass
+- "He couldn't withstand the pressure" -- resisting force as blocking
+  a moving object
+- "She deflected the criticism" -- redirecting social force as deflecting
+  a projectile
+- "An unstoppable force" -- extreme force as an object with irresistible
+  momentum
+- "The news hit him hard" -- information impact as physical collision
+- "A groundswell of support" -- collective social force as a rising,
+  moving mass
+- "They launched an attack" -- initiating force as sending a projectile
+- "The force came out of nowhere" -- unexpected force as an object with
+  no visible origin
+
+## Origin Story
+
+The Master Metaphor List (Lakoff, Espenson, and Schwartz 1991) catalogs
+A FORCE IS A MOVING OBJECT as a basic mapping in the Event Structure
+metaphor system. It is closely related to the CAUSES ARE FORCES metaphor
+but operates at a lower level: where CAUSES ARE FORCES maps causation
+onto physical force, A FORCE IS A MOVING OBJECT maps force itself onto
+the more concrete domain of visible, tangible moving things.
+
+The metaphor reflects a deep cognitive strategy: we understand invisible
+interactions by mapping them onto visible motion. This is why early
+physics (Aristotle through the medieval impetus theorists) modeled force
+as a substance transferred from mover to moved. Newton's third law and
+the concept of action at a distance were hard-won precisely because they
+required breaking with the moving-object intuition that this metaphor
+encodes. Even today, introductory physics students routinely make errors
+that trace back to the folk model of force as a traveling substance.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "A Force Is a Moving Object"
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999), Chapter 11
+  -- the Event Structure metaphor system
+- Talmy, L. *Toward a Cognitive Semantics* (2000), Vol. 1 -- force
+  dynamics and the conceptualization of causation
+- McCloskey, M. "Naive theories of motion" in Gentner, D. & Stevens, A.
+  (eds.) *Mental Models* (1983) -- evidence that folk physics treats
+  force as a moving substance


### PR DESCRIPTION
## Summary

- Adds mapping for A FORCE IS A MOVING OBJECT from the cognitive linguistics canon (Master Metaphor List, Lakoff et al. 1991)
- Maps forces onto moving objects, giving invisible interactions the properties of visible projectiles
- Corrects frame assignment: source_frame `embodied-experience` (concrete moving objects) rather than `physics` for both

Closes #331
Sub-issue of #4 (cognitive-linguistics-canon)

## Validation

✓ `uv run scripts/validate.py` — 0 errors