### PR TITLE
Add mappings: cognitive-linguistics-canon batch 12 (2 entries)

### DIFF
--- a/catalog/mappings/harm-is-having-a-harmful-possession.md
+++ b/catalog/mappings/harm-is-having-a-harmful-possession.md
@@ -1,0 +1,139 @@
+---
+slug: harm-is-having-a-harmful-possession
+name: "Harm Is Having a Harmful Possession"
+kind: conceptual-metaphor
+source_frame: economics
+target_frame: event-structure
+categories:
+  - cognitive-science
+  - linguistics
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - harm-is-lacking-a-needed-possession
+  - harm-is-being-in-a-harmful-location
+  - harm-is-causing-functional-objects-to-be-nonfunctional
+  - properties-are-possessions
+  - action-is-control-over-possessions
+---
+
+## What It Brings
+
+To be harmed is to have something bad. This metaphor maps the possession
+of a harmful object onto the experience of harm, turning abstract suffering
+into an unwanted thing you carry. Where HARM IS BEING IN A HARMFUL LOCATION
+places the person inside the harm, this metaphor places the harm inside the
+person -- or at least in their hands. It belongs to the object case of the
+Event Structure metaphor system, where states are possessions rather than
+locations. You do not go to harm; harm comes to you, as something you
+receive, acquire, or are burdened with.
+
+Key structural parallels:
+
+- **Harm as unwanted possession** -- "She has a problem." "He's got
+  troubles." "They carry a lot of pain." The harmed person is someone who
+  holds something they do not want. Harm is not an environment they
+  inhabit but an object they possess. This makes harm feel personal and
+  portable -- it goes where you go, because you are the one holding it.
+- **Becoming harmed as receiving a harmful thing** -- "She got a raw deal."
+  "He caught a disease." "They were given a burden." The onset of harm is
+  modeled as acquisition: someone hands you something bad, or it falls
+  into your possession. The metaphor gives harm a transactional structure,
+  implying a giver (even if anonymous) and a receiver.
+- **Recovery as getting rid of a harmful thing** -- "She got rid of her
+  guilt." "He shed his grief." "They unloaded their burdens." If harm is
+  something you have, then recovery is divestment. You drop it, throw it
+  away, pass it on, or set it down. The metaphor makes recovery feel like
+  a disposal problem -- the harm-object must go somewhere.
+- **Severity as weight or size of the possession** -- "She carries a heavy
+  burden." "He's weighed down by regret." "They bear an enormous load."
+  The worse the harm, the bigger or heavier the thing you possess. This
+  imports the physics of carrying: heavier loads slow you down, exhaust
+  you, and eventually make movement impossible.
+- **Spreading harm as transfer of possession** -- "She passed her anxiety
+  on to the children." "He gave everyone a scare." "They spread misery
+  wherever they went." Harm moves from person to person the way objects
+  change hands. This makes harm feel contagious in a commercial sense --
+  it is redistributed, not just experienced.
+
+## Where It Breaks
+
+- **Not all harm is possessable** -- the metaphor requires harm to be a
+  discrete, bounded thing you can hold. But many forms of harm are diffuse
+  and systemic: structural racism, environmental degradation, generational
+  trauma. These resist being packaged as objects. You cannot "get rid of"
+  systemic harm the way you discard an unwanted object, because the harm
+  is woven into systems rather than located in any one person's hands.
+- **The possession frame implies control** -- if harm is something you
+  have, the metaphor suggests you could choose to set it down. "Just let
+  it go" is the possession metaphor's prescription for recovery, and it
+  is often cruel -- it implies the harmed person is voluntarily holding
+  onto their suffering. The metaphor can shade into victim-blaming: why
+  do you still have that pain? Put it down.
+- **Receiving harm is not always passive** -- the acquisition model
+  (getting, catching, receiving) makes the onset of harm feel like a
+  transaction in which the person is the passive recipient. But some
+  harm is self-inflicted or emerges from one's own actions. The metaphor
+  handles self-harm awkwardly: did you give it to yourself?
+- **Disposal creates a conservation problem** -- if recovery means getting
+  rid of the harm-object, then where does it go? "She dumped her problems
+  on him" makes harm a zero-sum commodity that must be held by someone.
+  The metaphor struggles with forms of healing that dissolve harm rather
+  than transfer it. True recovery -- where harm diminishes rather than
+  relocates -- has no natural expression in the possession frame.
+- **The metaphor individualizes collective harm** -- by making harm a
+  personal possession, the metaphor makes collective suffering hard to
+  conceptualize. A community does not "have" an injustice the way a
+  person has a headache. The possession frame fragments shared harm into
+  individual holdings, obscuring solidarity and collective experience.
+
+## Expressions
+
+- "She has a lot of problems" -- harm as possession of unwanted objects
+- "He's got a chip on his shoulder" -- resentment as carrying a visible
+  harmful object
+- "They carry a heavy burden" -- ongoing harm as bearing a weighty
+  possession
+- "She caught a disease" -- onset of illness as involuntary acquisition
+- "He got a raw deal" -- being harmed as receiving an unfavorable
+  exchange
+- "Get rid of your anger" -- recovery as disposal of a harmful possession
+- "She was given a death sentence" -- severe harm as receiving a terrible
+  object
+- "He's weighed down by guilt" -- psychological harm as possession of a
+  heavy thing
+- "They bear the scars" -- lasting harm as permanent possessions that
+  cannot be discarded
+- "She passed her trauma on to the next generation" -- intergenerational
+  harm as transfer of possession
+
+## Origin Story
+
+This metaphor is documented in the Master Metaphor List (Lakoff, Espenson
+& Schwartz, 1991) and preserved in the Osaka University Conceptual Metaphor
+archive. It is one of several harm metaphors within the Event Structure
+metaphor system, representing the object case: where HARM IS BEING IN A
+HARMFUL LOCATION treats harm as a state the person occupies (location case),
+this metaphor treats harm as a thing the person holds (object case). The
+two are complementary -- English speakers move between "She's in pain"
+(location) and "She has pain" (possession) without noticing the frame
+shift.
+
+The metaphor is grounded in early bodily experience: infants learn that
+some objects hurt to hold -- sharp things, hot things, heavy things.
+The correlation between possessing certain objects and experiencing
+discomfort provides the embodied basis for understanding abstract harm
+as a kind of unwanted ownership. The mapping extends through the
+economics frame, where harmful possessions include debts, liabilities,
+penalties, and burdens -- the commercial vocabulary of things you would
+rather not have.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Harm Is Having A Harmful Possession"
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999) -- Event
+  Structure metaphor system, object case
+- Osaka University Conceptual Metaphor Home Page:
+  Harm_Is_Having_A_Harmful_Possession.html

--- a/catalog/mappings/harm-is-lacking-a-needed-possession.md
+++ b/catalog/mappings/harm-is-lacking-a-needed-possession.md
@@ -1,0 +1,141 @@
+---
+slug: harm-is-lacking-a-needed-possession
+name: "Harm Is Lacking a Needed Possession"
+kind: conceptual-metaphor
+source_frame: economics
+target_frame: event-structure
+categories:
+  - cognitive-science
+  - linguistics
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - harm-is-having-a-harmful-possession
+  - harm-is-being-in-a-harmful-location
+  - harm-is-causing-functional-objects-to-be-nonfunctional
+  - properties-are-possessions
+  - action-is-control-over-possessions
+---
+
+## What It Brings
+
+To be harmed is to lack what you need. This metaphor maps the absence of
+a needed possession onto the experience of harm, turning suffering into
+deprivation -- not having something that is rightfully or necessarily
+yours. It is the mirror image of HARM IS HAVING A HARMFUL POSSESSION:
+where that metaphor burdens you with something bad, this one strips you
+of something good. Both belong to the object case of the Event Structure
+metaphor system, but they structure harm through opposite economic
+logics -- surplus of the unwanted versus deficit of the essential.
+
+Key structural parallels:
+
+- **Harm as deprivation** -- "She lacks confidence." "He's missing
+  something." "They don't have what they need." The harmed person is
+  someone whose inventory is incomplete. Harm is not the presence of
+  something bad but the absence of something necessary. This makes harm
+  feel like emptiness, a gap in the self where a vital resource should be.
+- **Becoming harmed as losing a needed thing** -- "She lost her health."
+  "He was robbed of his dignity." "They were stripped of their rights."
+  The onset of harm is modeled as dispossession: something you once had
+  is taken from you or slips away. The metaphor gives harm a before-and-
+  after structure -- you had it, now you do not, and the difference is
+  the harm.
+- **Recovery as regaining the missing thing** -- "She found her voice
+  again." "He got his strength back." "They reclaimed their rights."
+  If harm is lacking something, then recovery is reacquisition. The
+  metaphor makes healing feel like a search-and-retrieval operation:
+  the lost thing is somewhere, and you must find it or earn it back.
+- **Severity as importance of what is lacking** -- "She lost everything."
+  "He's missing the most basic necessities." "They were deprived of
+  their livelihood." The more essential the missing possession, the
+  worse the harm. Losing a luxury is minor; losing your health, your
+  freedom, your loved ones is catastrophic. The metaphor provides a
+  natural severity scale based on the hierarchy of needs.
+- **Causing harm as taking from someone** -- "She was robbed of her
+  childhood." "He took away their hope." "They deprived her of the
+  chance to succeed." The agent of harm is a thief, a robber, an
+  expropriator. The metaphor gives harmful agency a specific moral
+  color: harming someone is stealing from them.
+
+## Where It Breaks
+
+- **Not all harm is absence** -- the metaphor requires harm to be a
+  deficit, but many forms of harm involve unwanted presence: intrusive
+  thoughts, chronic pain, harassment. These are additions, not
+  subtractions. The deprivation frame cannot capture the harm of having
+  too much of something bad -- it only speaks the language of not
+  having enough of something good.
+- **The metaphor implies a prior state of wholeness** -- "She lost her
+  confidence" presupposes she once had it. But some people have never
+  had the thing they are said to lack. A child raised in poverty did not
+  "lose" resources; they never possessed them. The metaphor frames all
+  deprivation as loss, which can obscure the difference between losing
+  something and never having had it.
+- **Recovery as retrieval assumes the thing still exists** -- "Find your
+  voice" implies the voice is somewhere, waiting to be discovered. But
+  some losses are permanent -- a deceased loved one cannot be recovered,
+  a lost limb cannot be found. The retrieval model of recovery sets up
+  false hope for irreversible harms.
+- **The ownership model distorts collective goods** -- "They were deprived
+  of justice" treats justice as a possession that belongs to specific
+  people. But justice, dignity, and rights are relational and
+  institutional, not personal property. The possession frame makes
+  collective goods feel like private assets, which can distort how we
+  think about restoring them. You do not "give someone back" their
+  dignity the way you return a stolen wallet.
+- **The thief model oversimplifies causation** -- when causing harm is
+  mapped onto taking, the metaphor requires an identifiable agent who
+  performs the taking. But much deprivation-harm is structural (poverty,
+  inequality, systemic exclusion) and has no single thief. The metaphor
+  demands a perpetrator where there may be only a system.
+
+## Expressions
+
+- "She lost her health" -- becoming ill as losing a vital possession
+- "He was robbed of his dignity" -- harm to self-worth as theft
+- "They lack the resources to recover" -- ongoing deprivation as empty
+  inventory
+- "She was stripped of her title" -- punishment as forced dispossession
+- "He's missing something" -- a vague harm as an unspecified absent
+  possession
+- "They were deprived of their rights" -- injustice as having needed
+  things taken away
+- "She found her voice again" -- recovery as retrieval of a lost
+  possession
+- "He got his confidence back" -- emotional recovery as reacquisition
+- "They took everything from her" -- total harm as complete
+  dispossession
+- "She needs to regain her strength" -- recovery as earning back a
+  depleted resource
+
+## Origin Story
+
+This metaphor appears in the Master Metaphor List (Lakoff, Espenson &
+Schwartz, 1991) and is preserved in the Osaka University Conceptual
+Metaphor archive. It forms a complementary pair with HARM IS HAVING A
+HARMFUL POSSESSION: together, they cover the two ways the economics
+frame can structure harm -- as unwanted surplus and as unwanted deficit.
+Both are object-case instantiations of the Event Structure metaphor
+system, parallel to the location-case HARM IS BEING IN A HARMFUL
+LOCATION.
+
+The embodied grounding lies in the infant's experience of need: hunger
+is the lack of food, cold is the lack of warmth, isolation is the lack
+of a caregiver. These early correlations between lacking a needed thing
+and feeling distress provide the primary scene from which the metaphor
+generalizes. As the mapping extends, abstract harms -- loss of status,
+deprivation of opportunity, absence of love -- inherit the felt quality
+of material want. The metaphor is reinforced by the broader PROPERTIES
+ARE POSSESSIONS mapping, which establishes the general convention that
+attributes, qualities, and states are things people own.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Harm Is Lacking A Needed Possession"
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999) -- Event
+  Structure metaphor system, object case
+- Osaka University Conceptual Metaphor Home Page:
+  Harm_Is_Lacking_A_Needed_Possession.html


### PR DESCRIPTION
## Summary

- Add **harm-is-having-a-harmful-possession** (closes #419) -- harm as unwanted surplus in the economics/possession frame
- Add **harm-is-lacking-a-needed-possession** (closes #420) -- harm as deprivation/deficit in the economics/possession frame

These two entries form a complementary pair within the object case of the Event Structure metaphor system, parallel to the existing location-case entry `harm-is-being-in-a-harmful-location`.

Both frames (`economics`, `event-structure`) already exist in the catalog. No new frames or categories needed.

## Validator output

```
All content valid.
```

15 pre-existing dangling-reference warnings (none from these entries).

## Sub-issue of #4 -- cognitive-linguistics-canon

Generated with Claude Code (Opus 4.6)