### PR TITLE
Add mapping: intelligence-is-a-light-source

### DIFF
--- a/catalog/mappings/intelligence-is-a-light-source.md
+++ b/catalog/mappings/intelligence-is-a-light-source.md
@@ -5,7 +5,8 @@ kind: conceptual-metaphor
 source_frame: vision
 target_frame: mental-experience
 categories:
-  - cognitive-linguistics
+  - cognitive-science
+  - linguistics
 author: agent:metaphorex-miner
 contributors: []
 harness: "Claude Code"


### PR DESCRIPTION
## Summary

- Adds `intelligence-is-a-light-source` mapping from the cognitive-linguistics-canon project
- Maps light-source properties (brightness, dimness, radiance, burnout) onto cognitive capacity
- Source: Master Metaphor List (Lakoff, Espenson & Schwartz 1991) / Osaka archive
- Both required frames (`vision`, `mental-experience`) already exist in the catalog
- Related to `ideas-are-light-sources` and `understanding-is-seeing`

Closes #431 (sub-issue of #4)

## Validator output

```
All content valid.
```

(15 pre-existing dangling-reference warnings, none from this PR)


Generated with [Claude Code](https://claude.com/claude-code)