### PR TITLE
Add mapping: intense-emotions-are-heat

### DIFF
--- a/catalog/mappings/intense-emotions-are-heat.md
+++ b/catalog/mappings/intense-emotions-are-heat.md
@@ -1,0 +1,146 @@
+---
+slug: intense-emotions-are-heat
+name: "Intense Emotions Are Heat"
+kind: conceptual-metaphor
+source_frame: embodied-experience
+target_frame: mental-experience
+categories:
+  - cognitive-science
+  - linguistics
+  - psychology
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - fear-is-cold
+  - emotions-are-forces
+  - emotions-are-entities-within-a-person
+  - desire-is-hunger
+  - love-is-a-physical-force
+---
+
+## What It Brings
+
+When emotions intensify, they become hot. You burn with desire, seethe
+with anger, feel the heat of shame. This metaphor maps the bodily
+experience of elevated temperature -- the flushing, the sweating, the
+felt warmth that accompanies physiological arousal -- onto the subjective
+intensity of emotional states. The mapping is not restricted to a single
+emotion the way ANGER IS HEAT or LUST IS HEAT might be. It operates at
+a higher level: any emotion, when it becomes intense enough, becomes hot.
+
+Key structural parallels:
+
+- **Emotional intensity is temperature** -- mild emotions are cool or
+  lukewarm; extreme emotions are hot, burning, or scorching. "A warm
+  affection" versus "a burning passion." The metaphor provides a scalar
+  mapping: the more intense the emotion, the higher the temperature.
+- **The body as a container of heated substance** -- intense emotion heats
+  the body from within. You feel it rising, building, threatening to boil
+  over. The person is a vessel; the emotion is the heat source or heated
+  fluid inside. This connects to the broader BODY IS A CONTAINER FOR
+  EMOTIONS system, but adds a thermal dimension.
+- **Loss of control is overheating** -- when emotions become too intense,
+  you "boil over," "blow your top," "lose your cool." The metaphor maps
+  the physical behavior of heated substances -- steam, explosion,
+  rupture -- onto emotional breakdown. Control is maintaining temperature;
+  loss of control is exceeding the container's thermal limits.
+- **Heat is visible and contagious** -- heated emotions show on the body
+  (flushed face, sweating) and spread to others. "The crowd's anger was
+  incendiary." "Her enthusiasm was infectious, and soon the whole room
+  was fired up." Heat radiates outward; so do intense emotions.
+
+## Where It Breaks
+
+- **Not all intense emotions feel hot** -- grief can be overwhelming
+  without any thermal quality. Deep sadness is more often described as
+  heavy, dark, or cold than as hot. The metaphor privileges the arousal
+  dimension of emotion (high activation states like anger, lust, and
+  excitement) and obscures high-intensity low-arousal states like
+  profound despair or awe. FEAR IS COLD directly contradicts this
+  mapping for one of the most intense emotions humans experience.
+- **The mapping conflates distinct emotions** -- by reducing all intense
+  emotions to "heat," the metaphor obscures the radical differences
+  between anger, passion, shame, and excitement. A person burning with
+  rage and a person burning with desire are having vastly different
+  experiences, but the thermal language makes them sound similar. The
+  metaphor trades emotional specificity for a convenient intensity scale.
+- **Heat implies danger and destruction** -- the thermal frame carries
+  connotations of damage: burns, fires, explosions. This makes intense
+  emotion seem inherently dangerous and in need of control. But intense
+  joy, love, and creative inspiration are not destructive forces. The
+  metaphor pathologizes emotional intensity by associating it with a
+  physical process that causes harm.
+- **Cultural variation in thermal mapping** -- while many languages use
+  heat for emotional intensity, the specific emotions mapped to heat
+  differ. In some East Asian contexts, shame and embarrassment are more
+  strongly thermal than anger. The metaphor appears near-universal at
+  the abstract level but culture-specific in its applications, which
+  complicates the claim that it is purely grounded in physiology.
+- **The cool-control opposition is ideological** -- "Keep your cool."
+  "Don't get heated." The metaphor implicitly valorizes emotional
+  coolness as rational self-mastery and frames emotional heat as a
+  failure of control. This reflects a particular cultural stance toward
+  emotion -- one that privileges restraint over expression -- and
+  naturalizes it as physics.
+
+## Expressions
+
+- "She was burning with anger" -- anger as combustion
+- "He was seething" -- contained rage as liquid at the boiling point
+- "A heated argument" -- emotional intensity mapped onto temperature of
+  the exchange itself
+- "His passion was all-consuming, like a fire" -- desire as destructive
+  heat
+- "She was hot with embarrassment" -- shame as a thermal event
+- "Keep your cool" -- emotional control as temperature regulation
+- "Don't get hot under the collar" -- anger as localized body heat
+- "A fiery temper" -- dispositional anger as a persistent heat source
+- "She blew her top" -- emotional overload as steam explosion
+- "The tension was simmering" -- pre-eruption emotional state as liquid
+  near boiling
+- "He was fired up about the project" -- enthusiasm as combustion
+- "A burning desire" -- intense want as sustained heat
+
+## Origin Story
+
+INTENSE EMOTIONS ARE HEAT appears in the Master Metaphor List (Lakoff,
+Espenson, and Schwartz 1991) and in the Osaka archive as a
+superordinate mapping that subsumes more specific instances like ANGER
+IS HEAT, LUST IS HEAT, and ENTHUSIASM IS FIRE. Kovecses (1990, 2000)
+analyzed it as part of a systematic temperature-emotion correspondence:
+heat maps onto emotional intensity across multiple emotion types, while
+cold maps onto either emotional absence or specific emotions like fear.
+
+The mapping is grounded in real physiology. Emotional arousal activates
+the sympathetic nervous system, producing measurable increases in skin
+temperature, core body temperature, and blood flow to the face and
+extremities. Nummenmaa et al. (2014) produced body maps of where
+subjects reported feeling different emotions, and the high-arousal
+emotions (anger, anxiety, love, happiness) consistently lit up as warm
+across the torso and head. The embodied correlation is real; the
+metaphor systematizes it.
+
+Grady (1997) would classify this as a primary metaphor: INTENSITY IS
+HEAT, with emotional intensity as one of its most productive
+applications. The cross-linguistic evidence is strong. Chinese, Zulu,
+Hungarian, Japanese, and Wolof all use heat imagery for intense
+emotions, though which emotions get the thermal treatment varies
+culturally.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Intense Emotions Are Heat"
+- Kovecses, Z. *Emotion Concepts* (1990) -- temperature metaphors across
+  emotion categories
+- Kovecses, Z. *Metaphor and Emotion* (2000) -- cross-linguistic analysis
+  of emotion-temperature mappings
+- Nummenmaa, L. et al. "Bodily maps of emotions" *PNAS* 111(2), 2014 --
+  topographical body maps of felt temperature in emotional states
+- Grady, J.E. *Foundations of Meaning: Primary Metaphors and Primary
+  Scenes* (1997) -- INTENSITY IS HEAT as a primary metaphor
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999) -- the
+  embodied basis of emotion metaphors
+- Lakoff, G. *Women, Fire, and Dangerous Things* (1987) -- anger as a
+  case study for emotion metaphors grounded in heat


### PR DESCRIPTION
## Summary

- Adds `intense-emotions-are-heat` mapping from the cognitive-linguistics-canon project
- Maps bodily heat onto emotional intensity across emotion types (anger, desire, shame, enthusiasm)
- Source: Master Metaphor List / Osaka archive (Lakoff, Espenson & Schwartz 1991)
- Frames `embodied-experience` and `mental-experience` already exist

Closes #432

## Validator output

```
All content valid.
```

(15 pre-existing dangling-reference warnings, none from this PR)

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors
- [ ] Review mapping body sections for accuracy and depth
- [ ] Verify expressions are attested in real usage

Generated with [Claude Code](https://claude.com/claude-code)