### PR TITLE
Add mapping: linear-scales-are-paths

### DIFF
--- a/catalog/frames/measurement.md
+++ b/catalog/frames/measurement.md
@@ -1,0 +1,23 @@
+---
+slug: measurement
+name: "Measurement"
+related:
+  - embodied-experience
+  - physics
+roles:
+  - scale
+  - unit
+  - degree
+  - zero-point
+  - endpoint
+  - interval
+  - reading
+---
+
+Quantification of properties along ordered dimensions. Linear scales assign
+degree values to qualities like temperature, intelligence, beauty, or
+difficulty. The frame encompasses both the abstract structure of scales
+(zero points, endpoints, intervals, orderings) and the practical activity
+of measuring. As a target domain, measurement inherits spatial structure
+from multiple source domains -- paths give it directionality, verticality
+gives it orientation, and containers give it boundaries.

--- a/catalog/mappings/linear-scales-are-paths.md
+++ b/catalog/mappings/linear-scales-are-paths.md
@@ -1,0 +1,144 @@
+---
+slug: linear-scales-are-paths
+name: "Linear Scales Are Paths"
+kind: conceptual-metaphor
+source_frame: journeys
+target_frame: measurement
+categories:
+  - cognitive-science
+  - linguistics
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - more-is-up
+  - purposes-are-destinations
+  - action-is-motion
+---
+
+## What It Brings
+
+Every linear scale -- temperature, intelligence, beauty, difficulty -- is
+understood as a path stretching from one end to the other. Points on the
+scale are locations along this path. Moving along the scale is traversal.
+Comparing two values is measuring the distance between two points. This
+mapping is so fundamental to scalar reasoning that it is nearly impossible
+to talk about degree without spatial language borrowed from paths.
+
+Key structural parallels:
+
+- **Points on a scale as locations on a path** -- "Where does this fall on
+  the spectrum?" "She's at the top of the scale." "He's somewhere in the
+  middle." Each value on a linear scale corresponds to a point along a
+  directed path, and locating a value is placing it at a position on that
+  path. The metaphor converts abstract degree into concrete place.
+- **Scalar change as movement** -- "Temperatures climbed steadily." "His
+  grades slipped." "Inflation crept up." When a quantity changes, it moves
+  along the path from one location to another. The metaphor preserves
+  directionality: increasing is moving forward (or upward, when combined
+  with MORE IS UP), and decreasing is moving back.
+- **Scalar distance as path distance** -- "The gap between rich and poor
+  is widening." "These two candidates are close on the issue." "Far above
+  average." The difference between two scalar values is the distance
+  between two points on the path. This makes comparison spatial and
+  intuitive -- closeness means similarity of degree, distance means
+  difference.
+- **Scale endpoints as path boundaries** -- "Off the charts." "At the
+  extreme end of the spectrum." "The lowest point on the scale." Scales
+  have endpoints just as paths have starting points and destinations. The
+  metaphor gives abstract continua a bounded, navigable structure.
+- **Norms as landmarks** -- "Above average." "Below the threshold."
+  "Crossing the line into dangerous territory." Reference points on a
+  scale function like landmarks on a path -- they are places you pass
+  through, aim for, or avoid. Norms, thresholds, and benchmarks are all
+  spatial features of the scalar path.
+
+The Master Metaphor List (Lakoff, Espenson, and Schwartz 1991) documents
+this mapping as part of the broader system in which abstract structures
+inherit spatial logic. LINEAR SCALES ARE PATHS works in concert with MORE
+IS UP to give quantity and degree a two-dimensional spatial geometry: the
+path provides the horizontal axis of traversal, while verticality provides
+the evaluative axis.
+
+## Where It Breaks
+
+- **Scales need not be linear** -- the metaphor imposes the geometry of a
+  straight path onto all scales, but many real-world dimensions are
+  logarithmic (decibels, Richter magnitude), exponential (compound
+  interest), or have diminishing returns (marginal utility). The path
+  metaphor makes every increment feel like the same step forward, hiding
+  the nonlinearity. Moving from 3.0 to 4.0 on the Richter scale is not
+  the same "distance" as moving from 1.0 to 2.0, but the path metaphor
+  treats them identically.
+- **Multidimensional qualities get flattened** -- intelligence, beauty,
+  health, and quality of life are all multidimensional, but the path
+  metaphor forces them onto a single line. You can be "further along" or
+  "behind" on the path, but you cannot be in a different direction. The
+  metaphor eliminates the possibility that two things are simply different
+  rather than greater or lesser.
+- **The path implies continuity** -- on a path, you pass through every
+  point between start and destination. But some scales are discrete (shoe
+  sizes, academic grades, credit ratings) or have natural gaps. The path
+  metaphor makes all scales feel continuous, which can create the illusion
+  of precision where none exists. The difference between a B+ and an A-
+  is not a smooth stretch of road.
+- **Directionality is imposed, not inherent** -- paths have a forward and
+  a backward. The metaphor assigns direction to scales that may not have
+  one. Political ideology is often placed on a left-right "spectrum," but
+  the choice of which end is which is cultural convention, not structural
+  necessity. The path metaphor makes the convention feel natural.
+- **The metaphor obscures cyclical and bounded phenomena** -- a path goes
+  from here to there, but some scalar quantities loop back (pH scale
+  behavior near extremes, circular hue scales in color theory). The
+  path metaphor has no vocabulary for wrapping around; it only knows
+  forward and backward.
+
+## Expressions
+
+- "Where does this fall on the scale?" -- scalar value as location on a
+  path
+- "She's far above average" -- scalar difference as distance along the
+  path
+- "The gap between rich and poor is widening" -- scalar divergence as
+  increasing distance between two travelers
+- "Temperatures climbed steadily" -- scalar increase as forward motion on
+  the path
+- "His grades slipped" -- scalar decrease as backward movement
+- "Off the charts" -- exceeding the scale as passing beyond the path's
+  endpoint
+- "At the extreme end of the spectrum" -- scale boundary as path terminus
+- "Crossing the threshold" -- passing a reference point as reaching a
+  landmark
+- "These two candidates are close on the issue" -- small scalar
+  difference as proximity on the path
+- "A long way from normal" -- large deviation as great distance traveled
+
+## Origin Story
+
+The mapping of linear scales onto paths appears in the Master Metaphor List
+compiled by Lakoff, Espenson, and Schwartz (1991) and archived in hypertext
+form at the Osaka University Conceptual Metaphor Home Page. It is part of a
+broader family of spatial metaphors for abstract structure that includes
+MORE IS UP, STATES ARE LOCATIONS, and CHANGE IS MOTION.
+
+The metaphor is grounded in early spatial experience. Children learn about
+degree partly through physical extent -- a longer stick, a taller tower, a
+further throw. The correlation between spatial extent and scalar magnitude
+is reinforced thousands of times before formal measurement is ever
+introduced. By the time a child encounters a thermometer or a ruler, the
+path-to-scale mapping is already deeply established.
+
+Lakoff and Johnson discuss the broader principle in *Philosophy in the Flesh*
+(1999): abstract reasoning systematically inherits the structure of spatial
+reasoning, and linear scales are one of the clearest cases. The path source
+domain provides the inferential structure -- directionality, distance,
+landmarks, traversal -- that makes scalar reasoning possible.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Linear Scales Are Paths"
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999), Chapter 4
+- Lakoff, G. & Johnson, M. *Metaphors We Live By* (1980), Chapter 4
+- Osaka University Conceptual Metaphor Home Page,
+  Linear_Scales_Are_Paths.html


### PR DESCRIPTION
## Summary

- Adds mapping `linear-scales-are-paths` -- the conceptual metaphor that maps path/journey structure onto linear scales (degree, magnitude, measurement)
- Creates new `measurement` frame for the target domain (scales, degrees, intervals, thresholds)
- Source: Osaka archive `Linear_Scales_Are_Paths.html`; Master Metaphor List (Lakoff, Espenson & Schwartz 1991)

Refs #443

## Validation

```
uv run scripts/validate.py validate
All content valid.
```
Zero errors. (16 pre-existing dangling-reference warnings, none from this PR)

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors
- [ ] Review mapping body sections for accuracy and depth
- [ ] Verify frame roles are appropriate

Generated with [Claude Code](https://claude.com/claude-code)