### PR TITLE
Add mapping: logic-is-gravity

### DIFF
--- a/catalog/mappings/logic-is-gravity.md
+++ b/catalog/mappings/logic-is-gravity.md
@@ -1,0 +1,143 @@
+---
+slug: logic-is-gravity
+name: "Logic Is Gravity"
+kind: conceptual-metaphor
+source_frame: physics
+target_frame: intellectual-inquiry
+categories:
+  - cognitive-science
+  - linguistics
+  - philosophy
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - psychological-forces-are-physical-forces
+  - ideas-are-perceptions
+  - understanding-is-seeing
+---
+
+## What It Brings
+
+Logical conclusions pull. A valid argument does not merely suggest its
+conclusion -- it compels it, drags the mind downward with the same
+inevitability that gravity drags objects toward the earth. This metaphor
+maps the irresistible, directional force of gravity onto the binding
+power of logical entailment, making rational necessity feel like a
+physical force acting on the thinker.
+
+Key structural parallels:
+
+- **Logical necessity as gravitational pull** -- "The evidence points
+  inexorably to that conclusion." "The argument pulls you toward this
+  position." "You can't resist the logic." Just as objects fall toward
+  the earth unless something holds them up, conclusions follow from
+  premises unless something blocks the inference. The metaphor makes
+  logical force feel automatic and impersonal -- it is not the arguer
+  who compels, but the argument itself.
+- **Weight of evidence** -- "The weight of the argument is overwhelming."
+  "That's a heavy claim." "The evidence is substantial." Evidence has
+  mass in this mapping: more evidence means more gravitational pull,
+  and a conclusion supported by heavy evidence is one that the mind
+  cannot help falling toward. Weak arguments are "light" or "flimsy" --
+  they lack the mass to generate pull.
+- **Foundations as support against collapse** -- "The argument has a
+  solid foundation." "The whole theory rests on that assumption." "If
+  that premise falls, everything collapses." Gravity means that
+  structures need foundations, and logical structures are no different.
+  An argument rests on its premises the way a building rests on its
+  base, and removing the base causes everything above to fall.
+- **Falling into error** -- "He fell into a logical trap." "Her
+  reasoning collapsed." "The argument fell apart." Logical failure is
+  a fall -- a surrender to gravity that a well-supported structure
+  would have prevented. Error is what happens when the foundations
+  give way.
+- **Levels of abstraction as height** -- "Higher-order reasoning."
+  "A deeper analysis." "Elevating the discourse." Logical abstraction
+  maps onto vertical position, and gravity becomes the force that makes
+  abstract thought require effort: rising above the concrete takes work,
+  while falling back to surface-level thinking is effortless.
+
+## Where It Breaks
+
+- **Logic is not unidirectional** -- gravity pulls in one direction:
+  down. But logical entailment is not directional in this way. From a
+  set of premises you can derive multiple conclusions in multiple
+  directions, and contrapositive reasoning runs "upward" from conclusion
+  to premises. The gravity metaphor makes logic feel like a one-way
+  descent toward a single inevitable endpoint, which misrepresents the
+  multidirectional character of inferential reasoning.
+- **Gravitational force is proportional to mass, but logical validity
+  is binary** -- an argument is either valid or invalid. There is no
+  "almost valid" the way there is "almost heavy enough to pull."
+  The metaphor smuggles in a continuum where logic demands a threshold:
+  the "weight" of evidence is a useful heuristic for inductive reasoning,
+  but it distorts the all-or-nothing character of deductive validity.
+- **Gravity is inescapable; logic is defeasible** -- in everyday
+  reasoning, conclusions that seem logically compelled can be overturned
+  by new information. Nonmonotonic reasoning, pragmatic implicature, and
+  simple mistakes mean that the "pull" of an argument is rarely as
+  irresistible as gravity. The metaphor overstates the binding force of
+  real-world reasoning by borrowing from a domain where no exceptions
+  exist.
+- **The metaphor privileges deduction over other reasoning styles** --
+  abductive reasoning (inference to the best explanation), analogical
+  reasoning, and probabilistic reasoning do not feel like gravitational
+  pull. They feel like leaps, guesses, or approximations. By mapping
+  logic onto gravity, the metaphor makes deductive proof the paradigm
+  of rationality and relegates other reasoning styles to the status
+  of imprecise or weak versions of the real thing.
+- **No account of creative reasoning** -- gravity pulls things down;
+  it does not generate new structures. But reasoning often produces
+  genuinely novel ideas -- combinations, reframings, leaps. The gravity
+  metaphor casts the thinker as passive, pulled by forces rather than
+  actively constructing. It describes why conclusions seem compelled
+  but cannot describe where new premises come from.
+
+## Expressions
+
+- "The weight of the evidence" -- evidential strength as gravitational mass
+- "A weighty argument" -- logical force as heaviness
+- "The conclusion is inescapable" -- logical necessity as gravitational
+  inevitability
+- "His reasoning collapsed" -- logical failure as structural fall
+- "The theory rests on that assumption" -- premises as foundations
+  supporting weight
+- "She was drawn to that conclusion" -- logical compulsion as
+  gravitational attraction
+- "The argument fell apart" -- logical disintegration as structural
+  collapse under gravity
+- "That's a groundless claim" -- unsupported assertion as a structure
+  without foundation
+- "Higher-order logic" -- abstraction as elevation against gravitational
+  pull
+- "The bottom line" -- the most fundamental point as the lowest,
+  most gravity-bound level
+
+## Origin Story
+
+LOGIC IS GRAVITY appears in the Master Metaphor List (Lakoff, Espenson
+& Schwartz 1991) as part of a cluster of metaphors that map physical
+forces onto rational necessity. It is closely related to the more general
+PSYCHOLOGICAL FORCES ARE PHYSICAL FORCES metaphor, but specialized to
+the domain of logical reasoning. The metaphor draws on the embodied
+experience of weight and fall: we learn from infancy that unsupported
+objects fall, that heavy things exert pull, and that resisting gravity
+requires effort. These bodily experiences are mapped onto the feeling
+of being compelled by a logical argument -- the sense that a conclusion
+"must" follow, that it is "unavoidable," that resisting it requires a
+counterforce (a counter-argument).
+
+The metaphor connects to THEORIES ARE BUILDINGS (arguments have
+foundations and can collapse) and to the orientational metaphor system
+(RATIONAL IS UP, which is in productive tension with gravity -- being
+rational means resisting the pull toward easy, ground-level thinking).
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Logic Is Gravity"
+- Lakoff, G. & Johnson, M. *Metaphors We Live By* (1980), Chapter 4 --
+  orientational metaphors and the UP/DOWN schema
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999) -- force
+  dynamics in reasoning


### PR DESCRIPTION
## Summary

- Adds `catalog/mappings/logic-is-gravity.md` -- maps gravitational force onto logical necessity
- Source: Osaka archive / Master Metaphor List (Lakoff, Espenson & Schwartz 1991)
- Closes #444 (sub-issue of #4, cognitive-linguistics-canon)

## Validator output

```
All content valid.
```

## Test plan

- [x] Validator passes with zero errors
- [ ] Review mapping quality (Assayer)