### PR TITLE
Add mapping: loved-one-is-a-possession

### DIFF
--- a/catalog/mappings/loved-one-is-a-possession.md
+++ b/catalog/mappings/loved-one-is-a-possession.md
@@ -1,0 +1,141 @@
+---
+slug: loved-one-is-a-possession
+name: "Loved One Is A Possession"
+kind: conceptual-metaphor
+source_frame: economics
+target_frame: love-and-relationships
+categories:
+  - cognitive-science
+  - linguistics
+  - psychology
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - love-is-a-journey
+  - love-is-madness
+  - love-is-war
+  - love-is-a-unity
+---
+
+## What It Brings
+
+People as property. The metaphor maps ownership onto romantic attachment:
+the beloved is something you have, can lose, can fight to keep, and can
+have taken from you. It is one of the most structurally productive love
+metaphors in English, generating expressions for jealousy, breakup, grief,
+and infidelity that would be incoherent without it.
+
+Key structural parallels:
+
+- **Having a partner as owning a possession** -- "She's mine" and "I have
+  a boyfriend" treat the romantic partner as something possessed. The verb
+  "have" is the same one used for cars, houses, and money. The metaphor
+  makes partnership feel like acquisition: you didn't always have this
+  person, now you do, and the having is the point.
+- **Breakup as loss of a possession** -- "I lost her" maps the end of a
+  relationship onto the misplacement or theft of property. The grammar of
+  loss imports the grief structure of losing something valuable. You don't
+  just stop being in a relationship; something is taken from you.
+- **Jealousy as possessiveness** -- the word itself says it. "He's very
+  possessive" maps the guarding of property onto the monitoring of a
+  partner. The rival is a thief. Jealousy becomes rational in this frame:
+  if your partner is your property, then protecting them from others is
+  just good stewardship.
+- **Infidelity as theft** -- "She stole my husband" treats the unfaithful
+  partner as stolen goods and the third party as the thief. The betrayed
+  person is the victim of a property crime. The metaphor assigns clear
+  villain roles: someone took what was yours.
+- **Pursuit as acquisition** -- "He's trying to win her" and "she's
+  playing hard to get" map courtship onto a transaction or contest for
+  a prize. The beloved is the object to be obtained. Success is measured
+  by whether you get the person, not by whether the relationship is good.
+- **Commitment as a claim** -- "He asked for her hand" and "she gave
+  herself to him" map marriage onto the transfer of property. The
+  language of proposals, engagements, and weddings is saturated with
+  possession metaphors: giving away the bride, taking a wife, belonging
+  to someone.
+
+## Where It Breaks
+
+- **People are not property** -- the most fundamental failure. The entire
+  metaphor rests on treating a person with their own desires, agency, and
+  interior life as an object that can be owned. Every expression it
+  generates subtly erodes the beloved's autonomy. "She's mine" sounds
+  romantic until you notice it uses the same grammar as "that car is mine."
+- **The metaphor underwrites jealous violence** -- if your partner is your
+  possession, then someone else's interest in them is a property crime,
+  and violence in defense of property has deep legal and cultural
+  sanction. "Crime of passion" defenses in court rely on exactly this
+  logic: he took what was mine, so I was justified. The metaphor does
+  not cause domestic violence, but it provides a cognitive frame that
+  makes possessive behavior feel rational rather than controlling.
+- **Loss without agency** -- "I lost her" obscures the fact that the other
+  person chose to leave. You lose a wallet; a person walks away. The
+  metaphor erases the beloved's decision by framing departure as
+  something that happened to the possessor, not something the departing
+  person did. This makes it harder to accept breakups because the frame
+  offers no account of the other person's reasons.
+- **It makes love zero-sum** -- possessions can only have one owner. The
+  metaphor struggles with polyamory, close friendships, family bonds, or
+  any situation where love is shared without being divided. "She's mine"
+  implies exclusivity as a structural requirement, not a choice.
+- **The metaphor conflates attachment with control** -- wanting to be near
+  someone and wanting to control them are different things, but the
+  possession frame collapses them. "I don't want to lose you" can
+  express genuine attachment or a controlling threat, and the metaphor
+  provides no way to distinguish them.
+
+## Expressions
+
+- "She's mine" -- romantic partnership as ownership, the possessive
+  pronoun doing heavy structural work
+- "I lost her" -- breakup or death as loss of property, grief coded as
+  dispossession
+- "He stole my wife" -- infidelity as theft, the rival as criminal
+- "She's playing hard to get" -- courtship as acquisition challenge, the
+  beloved as a difficult purchase
+- "He won her heart" -- romantic success as winning a prize, the heart as
+  transferable property
+- "She gave herself to him" -- sexual or romantic commitment as property
+  transfer, the self as gift
+- "He asked for her hand" -- marriage proposal as formal property request,
+  synecdoche reducing person to body part
+- "You belong to me" -- the most explicit statement of the metaphor,
+  belonging as the relational mode
+- "I'm taken" -- unavailability framed as already-acquired, the person as
+  a commodity off the market
+- "He's a keeper" -- evaluation of a partner using the language of objects
+  worth retaining
+
+## Origin Story
+
+The Master Metaphor List (Lakoff, Espenson, and Schwartz, 1991) documents
+LOVED ONE IS A POSSESSION as part of the love metaphor cluster. Its roots
+are older than conceptual metaphor theory. In most Indo-European legal
+traditions, marriage was literally a property transaction: the bride was
+transferred from father to husband, with a bride-price or dowry marking
+the exchange. Roman *manus* marriage placed the wife under the husband's
+legal ownership. English common law's doctrine of coverture (not fully
+abolished until the Married Women's Property Acts of the 1880s) treated a
+wife's legal identity as subsumed into her husband's.
+
+The metaphor's expressions preserve this history. "Giving away the bride"
+is still a standard wedding ritual. "Asking for her hand" literalizes the
+property transfer. These are not dead metaphors -- they remain structurally
+active in how English speakers conceptualize romantic relationships, even
+among people who would explicitly reject the idea that partners are property.
+
+Kovecses (2000) notes that the possession metaphor interacts with other
+love metaphors: LOVE IS A JOURNEY provides the narrative arc, LOVE IS
+MADNESS provides the phenomenology of infatuation, and LOVED ONE IS A
+POSSESSION provides the structure of jealousy and commitment. Together they
+form a coherent but internally contradictory system.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991)
+- Lakoff, G. & Johnson, M. *Metaphors We Live By* (1980) -- love metaphor
+  cluster
+- Kovecses, Z. *Metaphor and Emotion* (2000) -- love metaphors as a system
+- Pateman, C. *The Sexual Contract* (1988) -- historical analysis of
+  marriage as property transfer


### PR DESCRIPTION
## Summary
- Adds `loved-one-is-a-possession` mapping from the Master Metaphor List (Lakoff, Espenson & Schwartz 1991)
- Maps ownership/property onto romantic partners, generating expressions for jealousy, breakup, and commitment
- Resolves #448

## Validator output
All content valid. 16 pre-existing warnings (dangling references, unrelated to this PR).

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [ ] Assayer review of mapping quality

Generated with [Claude Code](https://claude.com/claude-code)