### PR TITLE
Add mapping: lust-is-heat

### DIFF
--- a/catalog/mappings/lust-is-heat.md
+++ b/catalog/mappings/lust-is-heat.md
@@ -3,7 +3,7 @@ slug: lust-is-heat
 name: "Lust Is Heat"
 kind: conceptual-metaphor
 source_frame: embodied-experience
-target_frame: love-and-relationships
+target_frame: mental-experience
 categories:
   - cognitive-science
   - linguistics


### PR DESCRIPTION
## Summary

- Extracts **LUST IS HEAT** from the cognitive-linguistics-canon project (sub-issue of #4)
- Maps bodily heat onto sexual desire, a specific instance of INTENSE EMOTIONS ARE HEAT with strong physiological grounding
- Sources: Osaka archive `Lust_Is_Heat.html`, Master Metaphor List (1991)

Closes #449

## Validator output

```
All content valid.
```

(16 pre-existing dangling-reference warnings, none introduced by this PR)

## Test plan

- [x] Validator passes with zero errors
- [ ] Review mapping content for accuracy and tone
- [ ] Verify frame references resolve

Generated with [Claude Code](https://claude.com/claude-code)