### PR TITLE
Add mapping: mental-accounting

### DIFF
--- a/catalog/mappings/mental-accounting.md
+++ b/catalog/mappings/mental-accounting.md
@@ -18,7 +18,7 @@ related:
 
 ## What It Brings
 
-People do not experience their mental and emotional lives as a undifferentiated
+People do not experience their mental and emotional lives as an undifferentiated
 stream. They partition it into accounts. You keep a running tally of favors
 owed and received. You weigh whether a relationship is "worth the investment."
 You feel that a bad day has "cost" you, and that a compliment "paid" for the


### PR DESCRIPTION
## Summary
- Adds `mental-accounting` mapping: maps financial accounting concepts (ledgers, balances, debits, credits) onto cognitive management of experiences and decisions
- Source frame: economics; Target frame: mental-experience
- Corrected frame assignment from issue (issue had frames inverted)

Closes #454

## Validator output
All content valid (0 errors, 0 new warnings).

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [ ] Review mapping content for accuracy and depth

Generated with Claude Code (agent:metaphorex-miner, model: claude-opus-4-6)