### PR TITLE
Add mapping: morality-is-straightness

### DIFF
--- a/catalog/mappings/morality-is-straightness.md
+++ b/catalog/mappings/morality-is-straightness.md
@@ -1,0 +1,156 @@
+---
+slug: morality-is-straightness
+name: "Morality Is Straightness"
+kind: conceptual-metaphor
+source_frame: geometry
+target_frame: ethics-and-morality
+categories:
+  - cognitive-science
+  - linguistics
+  - philosophy
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - morality-is-purity
+  - morality-is-cleanliness
+  - moral-accounting
+  - life-is-a-journey
+---
+
+## What It Brings
+
+The moral person walks the straight and narrow. The immoral person is crooked,
+devious, bent. MORALITY IS STRAIGHTNESS maps the geometric property of
+linearity -- the shortest distance between two points, the path that does not
+deviate -- onto moral character. The metaphor is grounded in embodied
+experience: a straight path is easy to follow, easy to see ahead on, and
+efficient. A crooked path hides what lies ahead, wastes effort, and suggests
+someone has been diverted from their proper course.
+
+Key structural parallels:
+
+- **Moral rectitude is a straight line** -- "rectitude" itself comes from
+  Latin *rectus* (straight). A person of upright character is aligned,
+  unbent, not leaning to one side or the other. The straight line maps onto
+  moral consistency: the person who acts the same in public and private, who
+  does not deviate from principle, who goes directly from intention to
+  action without detour or evasion.
+- **Deviance is curvature** -- to "deviate" is literally to leave the
+  straight path (Latin *de-* + *via*, off the road). Moral deviance is
+  spatial deviance: the person who departs from the straight path of
+  accepted behavior has gone crooked. "Perversion" maps the same way --
+  Latin *pervertere*, to turn thoroughly aside. The metaphor makes
+  nonconformity a geometric property.
+- **Deception is indirectness** -- a "straight answer" is an honest one.
+  A "crooked" person is dishonest. The mapping is between the directness
+  of a line and the directness of communication. The honest person goes
+  straight from question to answer; the dishonest person curves, deflects,
+  goes around. "Straightforward" means both geometrically direct and
+  morally transparent.
+- **Moral correction is straightening** -- to "correct" someone is to make
+  them straight again (Latin *corrigere*, to make right/straight). Reform
+  is re-alignment. Rehabilitation "straightens out" the deviant. The
+  metaphor provides a mechanism for moral restoration that the purity
+  metaphor lacks: you can bend something back to straight without
+  destroying and replacing it.
+- **Uprightness is vertical straightness** -- the moral person stands
+  "upright." The immoral person is "low," "base," or "fallen." This
+  variant adds a vertical axis to the horizontal straightness metaphor,
+  connecting moral standing to the embodied experience of erect posture.
+  Standing straight requires effort and alertness; slouching is easy and
+  associated with negligence.
+
+## Where It Breaks
+
+- **Moral life is not a straight line** -- the metaphor assumes there is
+  one correct path and all deviation is error. But genuine moral reasoning
+  often requires navigating between competing goods, making compromises,
+  and adapting to circumstances. A person who rigidly follows one principle
+  regardless of consequences is "straight" by the metaphor's logic but may
+  be morally obtuse. The metaphor has no vocabulary for justified
+  flexibility.
+- **Crookedness is not always vice** -- the metaphor equates indirectness
+  with dishonesty and deviance with wrongdoing. But diplomacy requires
+  indirectness. Tact is a form of curvature. A person who is always
+  "blunt" and "straight" in their communication may be cruel rather than
+  virtuous. The metaphor valorizes a particular communication style
+  (direct, unadorned) and pathologizes others (subtle, contextual,
+  indirect) in ways that are culturally biased.
+- **The metaphor naturalizes conformity** -- if the straight path is the
+  moral path, then anyone who departs from the common direction is suspect.
+  "Going straight" in criminal rehabilitation means returning to
+  conventional behavior. The metaphor makes social conformity look like
+  moral achievement and nonconformity look like moral failure. It cannot
+  distinguish between a crooked swindler and a crooked innovator.
+- **Straightening implies an external standard** -- a line is only
+  "straight" relative to a reference. The metaphor hides the question of
+  who defines the straight path. Whose moral standard is the reference
+  line? The metaphor naturalizes the dominant culture's norms by making
+  them look like geometric facts rather than social conventions.
+- **The metaphor conflates multiple virtues** -- honesty (straight talk),
+  consistency (straight path), conformity (going straight), and courage
+  (standing upright) are distinct virtues that the straightness metaphor
+  collapses into one. A person can be honest but inconsistent, conformist
+  but cowardly. The metaphor's unifying geometry hides these distinctions.
+
+## Expressions
+
+- "The straight and narrow" -- the morally correct path, from Matthew 7:14
+  ("strait is the gate and narrow is the way"; later reinterpreted as
+  "straight")
+- "A crooked politician" -- dishonesty as geometric curvature (common
+  usage since at least the 19th century)
+- "He's on the straight and level" -- honest and trustworthy (common
+  idiom, especially British English)
+- "She went straight" -- reformed criminal behavior as return to a direct
+  path (common usage; "going straight" in criminal justice contexts)
+- "Give me a straight answer" -- honesty as geometric directness (common
+  usage)
+- "That's a deviant act" -- departure from moral norms as departure from a
+  straight path (from Latin *deviare*, to turn from the road)
+- "Moral rectitude" -- moral correctness, from Latin *rectus*, straight
+  (formal and literary usage)
+- "A person of upright character" -- moral virtue as vertical straightness
+  (common usage)
+- "He was bent" -- British slang for corrupt, dishonest (common informal
+  British English)
+
+## Origin Story
+
+MORALITY IS STRAIGHTNESS appears in the Master Metaphor List (Lakoff,
+Espenson, and Schwartz 1991) and reflects one of the oldest conceptual
+metaphors in Indo-European languages. The Latin root *rectus* (straight)
+gives English "rectitude," "correct," "direct," and "erect" -- all carrying
+moral overtones that derive from the original geometric sense. The Greek
+*orthos* (straight, upright) produces "orthodox" (straight belief) and
+"orthopraxy" (straight practice).
+
+The metaphor appears across unrelated language families, suggesting embodied
+grounding rather than mere historical accident. Walking a straight path
+requires intention and attention; deviation results from distraction, obstacle,
+or deliberate evasion. Children learn early that the direct route is the
+honest route and that going around (sneaking, hiding, circling) is associated
+with transgression. Lakoff and Johnson discuss this class of orientational
+metaphors in *Metaphors We Live By* (1980), noting that spatial orientation
+metaphors (up/down, straight/crooked, center/periphery) provide the
+foundational structure for moral reasoning.
+
+The metaphor's influence on legal language is pervasive. "Right" itself
+derives from Old English *riht* (straight, direct), cognate with Latin
+*rectus*. To have a "right" is to be aligned with the straight standard.
+"Wrong" derives from Old Norse *rangr* (crooked, twisted). The very
+vocabulary of justice encodes the straightness metaphor.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Morality Is Straightness"
+- Lakoff, G. & Johnson, M. *Metaphors We Live By* (1980), Chapter 4 --
+  orientational metaphors including straight/crooked
+- Lakoff, G. *Moral Politics* (1996, 2nd ed. 2002) -- straightness in the
+  moral metaphor system
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999), Chapter 14 --
+  moral metaphors
+- Sweetser, E. *From Etymology to Pragmatics* (1990) -- Indo-European
+  etymological patterns linking spatial terms to moral concepts


### PR DESCRIPTION
## Summary
- Extracts MORALITY IS STRAIGHTNESS from the cognitive linguistics canon (Master Metaphor List, Lakoff et al. 1991)
- Maps geometric linearity (straight/crooked) onto moral character (rectitude/deviance)
- Traces Indo-European etymological roots: Latin *rectus*, Greek *orthos*, Old English *riht*/*rangr*
- Source frame: `geometry` (more precise than the issue's suggested `embodied-experience`)

Closes #460

## Validator output
```
All content valid.
```

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [ ] Review mapping content for accuracy and tone

Generated with [Claude Code](https://claude.com/claude-code)