### PR TITLE
Add mapping: perception-is-shape-recognition

### DIFF
--- a/catalog/mappings/perception-is-shape-recognition.md
+++ b/catalog/mappings/perception-is-shape-recognition.md
@@ -1,0 +1,134 @@
+---
+slug: perception-is-shape-recognition
+name: "Perception Is Shape Recognition"
+kind: conceptual-metaphor
+source_frame: geometry
+target_frame: vision
+categories:
+  - cognitive-science
+  - linguistics
+  - philosophy
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - understanding-is-seeing
+  - seeing-is-touching
+  - the-visual-field-is-a-container
+  - the-visual-field-is-a-bounded-region
+---
+
+## What It Brings
+
+To perceive something is to recognize its shape. This metaphor structures
+our understanding of perception as the identification of form, contour,
+and configuration -- the mind grasping the outline of things rather than
+passively receiving sensory input. Perception becomes an active process
+of matching incoming stimuli against stored geometric templates: shapes,
+patterns, edges, and boundaries.
+
+Key structural parallels:
+
+- **Perceptual objects have shapes** -- we speak of the "shape" of a
+  situation, the "outline" of a problem, the "contours" of an experience.
+  What we perceive is not raw sensation but structured form. The metaphor
+  maps the geometric property of shape onto the cognitive achievement of
+  recognition: to perceive is to discern a figure against a ground.
+- **Recognition is matching** -- perceiving something means recognizing
+  its form as familiar. "I see the shape of your argument." "The outlines
+  of a solution are becoming clear." The mind does not merely receive --
+  it actively compares incoming form against known patterns.
+- **Sharpness is perceptual clarity** -- sharp edges, clear contours, and
+  well-defined shapes map onto perceptual vividness. A "sharp" observer
+  sees distinct forms where others see only blur. "Fuzzy" perception is
+  perception without clear shape boundaries.
+- **Distortion is misperception** -- when shapes are warped, bent, or
+  skewed, perception goes wrong. A "distorted" view, a "twisted"
+  perspective, a "warped" sense of reality -- all import the geometric
+  vocabulary of shape deformation into the domain of perceptual failure.
+
+## Where It Breaks
+
+- **Perception is not limited to form** -- the metaphor privileges shape
+  and spatial configuration over the full richness of perceptual
+  experience. Color, texture, temperature, smell, taste, and sound have
+  no natural geometric shape. When we say we "recognize the shape" of a
+  melody, we are already stretching the metaphor past its structural
+  warrant. Perception through non-visual modalities resists the shape
+  vocabulary almost entirely -- the "shape" of a taste is a metaphor
+  stacked on a metaphor.
+- **Shape recognition implies fixed templates** -- the metaphor suggests
+  that perception works by matching inputs to pre-existing forms, which
+  privileges recognition of the familiar over encounter with the novel.
+  Much of perception is precisely about navigating the unknown -- sensing
+  danger, detecting novelty, processing what has never been categorized.
+  The shape-recognition frame has no natural vocabulary for perceptual
+  surprise or the experience of encountering something genuinely formless.
+- **It occludes the constructive nature of perception** -- cognitive
+  science has shown that perception is heavily shaped by expectation,
+  context, and top-down processing. We do not simply "recognize shapes"
+  that are already there; we actively construct perceptual experience from
+  fragmentary cues. The metaphor treats the perceived shape as a property
+  of the world rather than a joint product of world and mind, smuggling
+  in a naive realism that modern perceptual psychology has largely
+  abandoned.
+- **Temporal perception disappears** -- shapes are static and
+  simultaneous, but much of what we perceive unfolds in time. The rhythm
+  of speech, the arc of a musical phrase, the trajectory of a thrown
+  ball -- these temporal patterns resist description as "shapes" without
+  considerable metaphorical violence. The mapping flattens dynamic
+  perception into spatial stills.
+- **Emotional and social perception are poorly served** -- we perceive
+  moods, intentions, social dynamics, and atmospheric qualities that have
+  no obvious shape. "I could feel the tension in the room" is perceptual
+  but not geometric. The metaphor works best for visual object recognition
+  and becomes increasingly strained as perception moves toward the
+  affective and interpersonal.
+
+## Expressions
+
+- "I see the shape of your argument" -- perceiving logical structure as
+  geometric form (everyday English)
+- "The outlines of a plan are emerging" -- early-stage perception as
+  seeing edges before interior detail (Lakoff, Espenson & Schwartz 1991)
+- "She has a sharp eye" -- perceptual acuity as edge definition
+  (conventional English)
+- "A fuzzy idea" -- poor perception as blurred shape boundaries
+  (conventional English)
+- "The contours of the problem" -- perceiving a difficulty as tracing
+  its shape (academic and professional usage)
+- "A distorted view of reality" -- misperception as shape deformation
+  (conventional English)
+- "I can't quite make out the shape of what you're saying" -- incomplete
+  perception as partial shape recognition (everyday English)
+- "The situation is taking shape" -- perception improving as form
+  crystallizes (conventional English)
+
+## Origin Story
+
+PERCEPTION IS SHAPE RECOGNITION appears in the Master Metaphor List
+(Lakoff, Espenson, and Schwartz 1991) and the Osaka University
+Conceptual Metaphor archive. It captures a foundational assumption in
+Western epistemology traceable to Aristotle, who held that perception
+involves the reception of form (morphe) without matter. The Gestalt
+psychologists of the early twentieth century -- Wertheimer, Kohler,
+Koffka -- made shape recognition (Gestaltqualitat, "form quality")
+central to their theory of perception, and the metaphor's hold on
+cognitive science reflects their influence.
+
+In computational approaches to vision, from Marr's (1982) theory of
+visual recognition through modern deep learning, "perception" is
+operationalized almost entirely as shape and pattern classification.
+The metaphor thus both reflects and reinforces a specific theoretical
+tradition within perception research.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Perception Is Shape Recognition"
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999) -- embodied
+  basis of perception metaphors
+- Marr, D. *Vision* (1982) -- computational theory of visual shape
+  recognition
+- Sweetser, E. *From Etymology to Pragmatics* (1990) -- perception verbs
+  and their metaphorical extensions


### PR DESCRIPTION
## Summary
- Adds `perception-is-shape-recognition` mapping from the cognitive linguistics canon
- Source frame: geometry; Target frame: vision
- Closes #469

## Validator output
All content valid (0 errors, 0 new warnings).

## References
- Osaka archive: Perception_Is_Shape_Recognition.html
- Master Metaphor List (Lakoff, Espenson & Schwartz 1991)