### PR TITLE
Add mapping: properties-are-contents

### DIFF
--- a/catalog/mappings/properties-are-contents.md
+++ b/catalog/mappings/properties-are-contents.md
@@ -1,0 +1,129 @@
+---
+slug: properties-are-contents
+name: "Properties Are Contents"
+kind: conceptual-metaphor
+source_frame: containers
+target_frame: event-structure
+categories:
+  - cognitive-science
+  - linguistics
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - properties-are-possessions
+  - activities-are-containers
+  - states-are-locations
+  - properties-are-physical-properties
+---
+
+## What It Brings
+
+When we talk about properties and attributes of things, we routinely
+treat them as contents inside a container. A rock has hardness in it. A
+person has courage in them. A theory has elegance in it. The properties
+do not sit on the surface -- they are inside, contained by the thing
+that possesses them. This metaphor maps the physical structure of
+containment onto the abstract relationship between an entity and its
+attributes.
+
+Key structural parallels:
+
+- **The entity is a container** -- the thing that has properties is
+  understood as a bounded enclosure. A person, an object, a situation --
+  each is a vessel that holds its qualities within. "There's a lot of
+  goodness in that child." "I see real potential in this project."
+- **Properties are substances inside** -- attributes fill the container
+  the way liquids or objects fill a vessel. They can be abundant or
+  scarce, deep or shallow. "She is full of energy." "There's no
+  originality in this work." The scalar mapping is important: more
+  contents means more of the property.
+- **Discovering properties is looking inside** -- to learn what something
+  is like, you look into it, probe its contents, see what is there.
+  "When you look deeper into his character, you find real integrity."
+  "There's more to this problem than meets the eye." Knowledge of
+  properties requires penetrating the container boundary.
+- **Change of properties is change of contents** -- when something
+  gains or loses a property, contents enter or leave the container.
+  "The joy went out of her." "Confidence crept into his voice." This
+  connects to the broader Event Structure system where changes are
+  movements.
+
+## Where It Breaks
+
+- **Properties are not separable from their bearers** -- a container's
+  contents can be removed while the container persists. But you cannot
+  extract the redness from a rose and leave the rose otherwise intact.
+  Properties are constitutive of the entity, not independent objects
+  sitting inside it. The metaphor treats attributes as separable
+  substances when they are often essential features without which the
+  entity would not be what it is.
+- **The container metaphor implies fixed capacity** -- containers have
+  limits. "She's so full of anger there's no room for love." This zero-
+  sum framing distorts the nature of properties: a person can be
+  simultaneously courageous, kind, anxious, and creative without any of
+  these "filling up" the available space. Properties do not compete for
+  volume.
+- **It obscures relational properties** -- many important properties are
+  not intrinsic to a single entity but emerge from relationships.
+  "Expensive" depends on a market; "tall" depends on a comparison class;
+  "compatible" depends on what you are compatible with. The container
+  frame locates all properties inside a single entity, hiding the
+  relational structure that gives many properties their meaning.
+- **The depth metaphor privileges hidden properties** -- because contents
+  are inside, the metaphor suggests that the most important properties
+  are the deepest, most hidden ones. "Deep down, she's a good person."
+  This creates a surface/depth hierarchy that may not reflect reality:
+  visible behavior is not necessarily less "real" than hidden character.
+- **It conflates quantity with intensity** -- "full of joy" and "a
+  little sadness in him" use amount of contents to map intensity of
+  a property. But many properties are not scalar in this simple way:
+  being wise is not about having a large quantity of wisdom-substance
+  inside you.
+
+## Expressions
+
+- "There's a lot of good in that person" -- moral properties as
+  contained substance (Lakoff, Espenson & Schwartz 1991)
+- "She's full of energy" -- abundance of a property as a full container
+  (common usage)
+- "There's no originality in this work" -- absence of property as
+  empty container (common critical usage)
+- "He has a lot of anger in him" -- emotional property as contained
+  substance (Master Metaphor List 1991)
+- "The joy went out of her" -- loss of property as contents leaving a
+  container (common usage)
+- "I see real potential in this project" -- discovering properties by
+  looking inside (common usage)
+- "Deep down, she's a kind person" -- essential properties as deep
+  contents (common usage)
+- "There's more to this problem than meets the eye" -- hidden
+  properties as unseen contents (common usage)
+
+## Origin Story
+
+PROPERTIES ARE CONTENTS appears in the Master Metaphor List (Lakoff,
+Espenson, and Schwartz 1991) as part of the Event Structure metaphor
+system's location case. It works alongside PROPERTIES ARE POSSESSIONS
+(the object case variant) to provide two complementary ways of
+understanding how entities relate to their attributes: properties are
+either contained within the entity or owned by it.
+
+The containment version is grounded in the CONTAINER image schema, one
+of Lakoff and Johnson's foundational cognitive structures identified in
+*Metaphors We Live By* (1980). We experience our own bodies as
+containers (emotions are inside us, thoughts are in our heads) and
+extend this to all entities and their qualities. The metaphor is
+productive across nearly every domain of discourse -- from character
+assessment to literary criticism to scientific description.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Properties Are Contents"
+- Lakoff, G. & Johnson, M. *Metaphors We Live By* (1980) -- the
+  CONTAINER image schema
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999) -- the
+  Event Structure metaphor system
+- Osaka University Conceptual Metaphor Home Page,
+  Properties_Are_Contents.html


### PR DESCRIPTION
## Summary
- Adds mapping for PROPERTIES ARE CONTENTS from the cognitive-linguistics-canon project
- Source: Master Metaphor List (Lakoff, Espenson & Schwartz 1991) / Osaka archive
- Part of the Event Structure system (location case): properties as contained substances

Closes #475

## Validator output
All content valid. (0 errors, 22 warnings -- all pre-existing or forward refs)

## Test plan
- [x] `uv run scripts/validate.py validate` passes with zero errors

Generated with [Claude Code](https://claude.com/claude-code)