### PR TITLE
Add mapping: responsibilities-are-possessions

### DIFF
--- a/catalog/mappings/responsibilities-are-possessions.md
+++ b/catalog/mappings/responsibilities-are-possessions.md
@@ -1,0 +1,137 @@
+---
+slug: responsibilities-are-possessions
+name: "Responsibilities Are Possessions"
+kind: conceptual-metaphor
+source_frame: economics
+target_frame: social-roles
+categories:
+  - cognitive-science
+  - linguistics
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - properties-are-possessions
+  - obligations-are-forces
+  - obligations-are-containers
+  - action-is-control-over-possessions
+---
+
+## What It Brings
+
+Responsibilities are things you have, hold, carry, and sometimes drop.
+This metaphor maps the economics of possession -- acquiring, bearing,
+transferring, and losing objects -- onto the domain of social and moral
+obligation. Where PROPERTIES ARE POSSESSIONS makes qualities into
+inventory, this metaphor makes duties into cargo. The person who has
+responsibilities is a person loaded down with things to carry; the person
+who shirks them has set those things down or passed them to someone else.
+
+Key structural parallels:
+
+- **Having responsibilities as holding objects** -- "She has a lot on her
+  plate." "He's carrying the weight of the department." "They hold the
+  responsibility for this decision." Obligations are physical objects that
+  occupy your hands, your plate, your shoulders. The more you have, the
+  heavier the load.
+- **Accepting responsibility as taking an object** -- "She took on the
+  project." "He accepted the burden of leadership." "They assumed
+  responsibility." To become obligated is to reach out and grasp something,
+  or to have it placed in your hands. The voluntary nature of taking
+  distinguishes it from having something thrust upon you.
+- **Avoiding responsibility as refusing or dropping an object** -- "He
+  dodged the responsibility." "She shirked her duties." "They dropped
+  the ball." Irresponsibility is physically letting go of, or refusing
+  to pick up, an object. The metaphor makes negligence feel concrete --
+  you can almost hear the thud of the dropped obligation.
+- **Transferring responsibility as giving or passing** -- "She handed off
+  the project." "He delegated his responsibilities." "They passed the buck."
+  When responsibility moves from one person to another, it moves the way
+  objects do: from one set of hands to another. Delegation is a transfer
+  of cargo.
+- **Shared responsibility as co-possession** -- "They share the burden."
+  "We all have a stake in this." "The responsibility is ours." Joint
+  obligation is joint ownership. The metaphor enables talk about
+  distributed duty by distributing the possessed object across multiple
+  holders.
+
+## Where It Breaks
+
+- **Responsibilities are not discrete objects** -- the metaphor treats
+  duties as countable, separable things. But responsibilities are often
+  diffuse and overlapping. A parent's responsibility for a child is not
+  a single object that can be cleanly picked up or set down; it is a
+  pervasive condition that infiltrates every aspect of life. The
+  possession frame makes responsibilities feel more bounded and
+  manageable than they often are.
+- **Dropping a responsibility does not make it disappear** -- if you
+  drop a physical object, it lies on the ground until someone picks it
+  up. But when someone shirks a responsibility, the consequences do not
+  wait passively. Unmet obligations generate cascading failures, erode
+  trust, and create new obligations for others. The possession metaphor
+  underestimates the damage that neglected duties cause.
+- **The weight metaphor implies that responsibilities are inherently
+  burdensome** -- "carrying the weight" and "bearing the burden" make
+  duty feel like suffering. But many responsibilities are sources of
+  meaning, identity, and satisfaction. The parent who "bears the burden"
+  of childcare may also find it the most fulfilling part of their life.
+  The possession-as-weight variant cannot express this duality.
+- **Transfer does not always reduce the giver's load** -- "passing the
+  buck" implies the original holder is now free. But in many social
+  contexts, delegating responsibility does not eliminate accountability.
+  A manager who delegates a task still bears responsibility for its
+  completion. The possession metaphor imports a conservation law (what
+  is given is no longer held) that misrepresents how accountability
+  actually works in hierarchies.
+- **The metaphor obscures structural origins** -- responsibilities framed
+  as possessions seem like things that individuals happen to have, rather
+  than obligations that social structures impose. This makes it easy to
+  blame individuals for having too many responsibilities ("She took on
+  too much") rather than questioning systems that distribute duties
+  unevenly.
+
+## Expressions
+
+- "She has a lot of responsibilities" -- duties as possessed quantities
+  (Master Metaphor List, Lakoff, Espenson & Schwartz 1991)
+- "He carries the weight of the whole team" -- obligation as heavy cargo
+  borne on the body (common English usage)
+- "They took on more than they could handle" -- accepting duty as
+  acquiring objects beyond one's carrying capacity (common English usage)
+- "She dropped the ball" -- failing in a duty as releasing a held object
+  (American English idiom)
+- "He passed the buck" -- transferring responsibility as passing an object
+  to someone else (American English, from poker)
+- "They share the burden equally" -- joint obligation as co-possession of
+  a heavy object (common English usage)
+- "She shouldered the responsibility" -- accepting duty as physically
+  lifting cargo onto one's shoulders (common English usage)
+- "He dumped his responsibilities on her" -- irresponsible transfer as
+  careless unloading of cargo (common English usage)
+
+## Origin Story
+
+RESPONSIBILITIES ARE POSSESSIONS appears in the Master Metaphor List
+(Lakoff, Espenson & Schwartz 1991) as part of the broader family of
+possession metaphors that structure English thinking about abstract
+entities. It is closely related to PROPERTIES ARE POSSESSIONS and
+OBLIGATIONS ARE FORCES, forming a cluster in which social and moral
+life is understood through the vocabulary of physical objects and their
+management. The metaphor is grounded in early childhood experiences of
+being given things to hold and carry -- being entrusted with objects is
+one of the earliest forms of responsibility that children encounter.
+
+The metaphor's pervasiveness in institutional language ("job responsibilities,"
+"taking ownership," "accountability") reflects its centrality to how
+English-speaking cultures conceptualize duty. It enables the entire
+vocabulary of project management, corporate governance, and legal
+liability.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Responsibilities Are Possessions"
+- Lakoff, G. & Johnson, M. *Metaphors We Live By* (1980) -- ontological
+  metaphors and the possession schema
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999) -- the Event
+  Structure metaphor system, object case


### PR DESCRIPTION
## Summary
- Adds mapping for RESPONSIBILITIES ARE POSSESSIONS (conceptual-metaphor)
- Source frame: economics, Target frame: social-roles
- Maps possession economics onto social and moral obligation
- Closes #479

## Validator output
All content valid (0 errors, 0 new warnings).

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [ ] Review mapping content for accuracy and depth

Generated with [Claude Code](https://claude.com/claude-code)