### PR TITLE
Add mapping: subjects-are-areas

### DIFF
--- a/catalog/mappings/subjects-are-areas.md
+++ b/catalog/mappings/subjects-are-areas.md
@@ -1,0 +1,122 @@
+---
+slug: subjects-are-areas
+name: "Subjects Are Areas"
+kind: conceptual-metaphor
+source_frame: spatial-location
+target_frame: intellectual-inquiry
+categories:
+  - cognitive-science
+  - linguistics
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - ideas-are-locations
+  - states-are-locations
+  - difficult-subjects-are-adversaries
+---
+
+## What It Brings
+
+An academic subject, intellectual discipline, or topic of study is a
+bounded region of space -- a territory you can enter, explore, survey,
+and eventually master. This metaphor structures how we talk about
+knowledge acquisition as spatial navigation: you move into a field, cover
+ground within it, and discover what lies at its center or its periphery.
+
+Key structural parallels:
+
+- **Subject as bounded region** -- "She works in the field of linguistics."
+  "He entered the area of machine learning." Every discipline has borders
+  that distinguish it from neighboring fields. To study something is to be
+  inside its boundaries; to be ignorant of it is to be outside. The
+  metaphor creates a territorial logic for knowledge: you can claim an area,
+  defend it, or trespass on someone else's.
+- **Depth as expertise** -- "She has a deep knowledge of the subject."
+  "He has only a surface understanding." The spatial metaphor gives
+  subjects vertical structure: the surface is introductory knowledge,
+  accessible to anyone who enters the area, while the depths contain
+  specialized, difficult material that requires sustained exploration.
+- **Breadth as scope** -- "The course covers a wide area." "Her research
+  is narrow but thorough." A subject can be wide or narrow, and a scholar
+  can range broadly across many areas or focus intensely on a small patch
+  of intellectual territory.
+- **Exploration as research** -- "This is uncharted territory in physics."
+  "We need to map out the field." Research is the act of moving through
+  the space of a subject, discovering what is there. Pioneer researchers
+  open new areas; survey courses give overviews of the whole terrain.
+- **Boundaries as disciplinary limits** -- "That question falls outside
+  the scope of biology." "Interdisciplinary work crosses traditional
+  boundaries." The borders between areas are not natural features but
+  conventional lines, and one of the recurring tensions in academic life
+  is whether to respect or transgress them.
+
+## Where It Breaks
+
+- **Subjects do not have fixed borders** -- the spatial metaphor implies
+  that disciplines have clear edges, but in practice the boundary between,
+  say, psychology and neuroscience is contested and constantly shifting.
+  The metaphor makes interdisciplinary work look like border-crossing when
+  it is often more like discovering that two supposedly separate territories
+  were always the same land.
+- **Knowledge is not evenly distributed in space** -- a real area can be
+  surveyed exhaustively, but a subject cannot. You can "cover the ground"
+  of an introductory course, but the metaphor breaks down for research,
+  where new questions multiply faster than old ones are resolved. The space
+  of a subject grows as you explore it, unlike any physical territory.
+- **The metaphor hides power relations** -- "entering a field" sounds like
+  a free choice, but access to academic subjects is gatekept by
+  institutions, credentials, and social capital. The spatial metaphor makes
+  knowledge look like open land anyone can explore, obscuring the barriers
+  to entry that are social rather than cognitive.
+- **Depth is not always the valuable direction** -- the metaphor privileges
+  vertical descent (depth equals expertise) and treats breadth as
+  superficiality. But some of the most important intellectual work happens
+  at the surface, in synthesis, connection, and translation between fields.
+  The spatial metaphor has no way to value the person who stands at the
+  intersection of three areas without being deep in any of them.
+- **Subjects are not static landscapes** -- a field in 1950 is not the
+  same field in 2025. The spatial metaphor tends to freeze disciplines in
+  place, making it hard to express how the very terrain of a subject
+  changes as new paradigms emerge. You cannot really "return to" the
+  physics you left twenty years ago, because the ground has moved.
+
+## Expressions
+
+- "She works in the field of biology" -- a discipline as a spatial region
+  (Lakoff, Espenson & Schwartz, *Master Metaphor List*, 1991)
+- "He's an expert in the area of contract law" -- specialization as
+  location within a region (common academic usage)
+- "The course covers a lot of ground" -- breadth of study as spatial
+  extent (Lakoff & Johnson, *Metaphors We Live By*, 1980)
+- "This is unexplored territory" -- unstudied topics as unmapped space
+  (Master Metaphor List, 1991)
+- "She has a deep understanding of the subject" -- expertise as spatial
+  depth (common academic usage)
+- "He's only scratching the surface" -- superficial study as touching only
+  the top of a region (common academic usage)
+- "The boundaries between disciplines are blurring" -- interdisciplinarity
+  as border erosion (common academic usage)
+- "We need to map out the field" -- research planning as cartography
+  (common academic usage)
+
+## Origin Story
+
+SUBJECTS ARE AREAS appears in the Master Metaphor List (Lakoff, Espenson
+& Schwartz, 1991) as part of the broader mapping of abstract concepts
+onto spatial locations. It is closely related to the IDEAS ARE LOCATIONS
+metaphor and to the general EVENT STRUCTURE system's mapping of states
+onto locations. The metaphor draws on a more basic image schema: the
+CONTAINER schema (Johnson, 1987), where bounded regions have interiors,
+exteriors, and boundaries. When applied to intellectual life, this schema
+produces the familiar language of academic "fields," "areas," and
+"domains" -- spatial terms so thoroughly conventionalized that they
+rarely register as metaphorical.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Subjects Are Areas"
+- Lakoff, G. & Johnson, M. *Metaphors We Live By* (1980)
+- Johnson, M. *The Body in the Mind* (1987) -- the CONTAINER image schema
+- Kovecses, Z. *Metaphor: A Practical Introduction* (2nd ed. 2010)


### PR DESCRIPTION
## Summary
- Adds `subjects-are-areas` mapping from the cognitive-linguistics-canon project
- Source frame: `spatial-location`, target frame: `intellectual-inquiry`
- All existing frames reused; no new frames needed

Closes #489

Validator output: `All content valid.` (24 pre-existing dangling-reference warnings, non-blocking)

Generated with [Claude Code](https://claude.com/claude-code)