### PR TITLE
Add mapping: theoretical-debate-is-competition

### DIFF
--- a/catalog/mappings/theoretical-debate-is-competition.md
+++ b/catalog/mappings/theoretical-debate-is-competition.md
@@ -1,0 +1,128 @@
+---
+slug: theoretical-debate-is-competition
+name: "Theoretical Debate Is Competition"
+kind: conceptual-metaphor
+source_frame: competition
+target_frame: intellectual-inquiry
+categories:
+  - cognitive-science
+  - linguistics
+  - philosophy
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - argument-is-war
+  - theories-are-buildings
+---
+
+## What It Brings
+
+Academic discourse is framed as a contest with winners and losers. Scholars
+compete for dominance, theories vie for acceptance, and intellectual
+disputes are settled by determining which side prevails. The Master Metaphor
+List (Lakoff, Espenson & Schwartz 1991) catalogs this mapping as part of
+the cluster of theory metaphors, and it sits alongside ARGUMENT IS WAR as
+one of the adversarial frames through which we understand intellectual
+exchange.
+
+Key structural parallels:
+
+- **Competitors** -- theorists are rivals. "Darwin's theory competed with
+  Lamarck's." "The two camps have been battling for decades." Each school
+  of thought is a team, and individual scholars are players whose
+  contributions are measured by whether they advance their side's position.
+- **Arena** -- the field of study becomes a bounded space where the
+  competition plays out. Journals, conferences, and peer review constitute
+  the arena. "The debate played out in the pages of *Nature*." The
+  metaphor gives intellectual exchange a spatial setting with spectators
+  and participants.
+- **Strategy** -- theorists deploy evidence strategically, timing their
+  publications, choosing which objections to address, anticipating
+  opponents' moves. "She outmaneuvered the critics." "They preempted the
+  objection." The competition frame makes tactical thinking feel like a
+  natural part of scholarship.
+- **Outcome** -- debates produce winners. "The cognitivists won that
+  debate." "Behaviorism lost." The metaphor demands a resolution: one side
+  must prevail, or the contest is still ongoing. A draw feels like a
+  failure, not a nuanced outcome.
+- **Prize** -- the reward is disciplinary influence, citations, prestige.
+  "They were competing for the dominant paradigm." The metaphor converts
+  epistemic progress into something that can be won and possessed.
+
+## Where It Breaks
+
+- **Competition requires opponents; inquiry does not** -- the metaphor
+  forces intellectual work into an adversarial frame even when the scholars
+  involved are working on complementary aspects of the same problem.
+  Researchers who are genuinely collaborating get cast as competitors
+  because the frame demands it. This discourages synthesis and encourages
+  unnecessary polarization within academic fields.
+- **Winning is not truth** -- the competition metaphor conflates persuasive
+  success with being correct. A theory can "win" a debate through
+  rhetorical skill, institutional power, or sheer persistence without
+  being closer to the truth. The metaphor provides no vocabulary for the
+  common situation where the losing position was actually more accurate.
+- **The metaphor obscures cumulative progress** -- in competition, the
+  previous contest is over when a winner is declared. In science, old
+  results remain relevant. Newtonian mechanics did not "lose" to
+  relativity -- it was subsumed. The competition frame makes it hard to
+  express how theoretical progress typically works: not replacement of
+  losers by winners, but integration and refinement.
+- **Rules of engagement are assumed, not examined** -- competitions have
+  rules. The metaphor imports the assumption that academic debate has
+  clear, shared rules (logic, evidence, peer review). But the rules of
+  theoretical debate are themselves contested -- what counts as evidence,
+  which methods are legitimate, who gets to participate. The competition
+  frame naturalizes rules that are actually political and historical.
+- **The metaphor individualizes what is collective** -- competition
+  highlights individual or team achievement. But theoretical understanding
+  is a collective, distributed accomplishment. The competition frame
+  makes it difficult to recognize that both "sides" of a debate often
+  contribute to the eventual synthesis.
+
+## Expressions
+
+- "Competing theories of consciousness" -- rival explanations as
+  contestants in the same event (Lakoff, Espenson & Schwartz 1991)
+- "Darwin's theory won out over Lamarck's" -- theoretical acceptance
+  as victory (common academic usage)
+- "The debate between rationalists and empiricists" -- intellectual
+  history as a series of matches (philosophy textbook convention)
+- "She outperformed the opposition at the conference" -- scholarly
+  persuasion as competitive performance
+- "The race to explain superconductivity" -- parallel research programs
+  as a footrace with a finish line
+- "They were no match for the weight of evidence" -- evidential strength
+  as competitive superiority
+- "The leading theory in the field" -- theoretical acceptance as being
+  ahead in a race
+- "His argument knocked out the competing hypothesis" -- refutation as
+  elimination from a tournament
+
+## Origin Story
+
+The metaphor is cataloged in the Master Metaphor List (Lakoff, Espenson &
+Schwartz 1991) under the theory/intellectual life cluster. It is closely
+related to ARGUMENT IS WAR but narrower in scope: where ARGUMENT IS WAR
+covers all argumentation, THEORETICAL DEBATE IS COMPETITION specifically
+frames academic and intellectual disputes as structured contests with
+rules, participants, and outcomes.
+
+The competition frame is arguably gentler than the war frame -- competitors
+operate under shared rules and the outcome is less than total destruction.
+But it still imposes an adversarial structure on what could be a
+cooperative endeavor. Thomas Kuhn's *The Structure of Scientific
+Revolutions* (1962) effectively theorized this metaphor by treating
+paradigm shifts as competitive victories of one framework over another.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Theoretical Debate Is Competition"
+- Kuhn, T.S. *The Structure of Scientific Revolutions* (1962) -- the
+  paradigm shift framework embodies this metaphor
+- Latour, B. & Woolgar, S. *Laboratory Life* (1979) -- sociological
+  analysis of how competition structures scientific practice
+- Merton, R.K. *The Sociology of Science* (1973) -- priority disputes and
+  the reward system of science as competitive arenas


### PR DESCRIPTION
## Summary
- Adds mapping for THEORETICAL DEBATE IS COMPETITION from the Master Metaphor List (Lakoff, Espenson & Schwartz 1991)
- Source frame: competition, target frame: intellectual-inquiry (both existing)
- Closes #494

## Validator output
All content valid. (0 errors, pre-existing warnings only)

## Test plan
- [x] `uv run scripts/validate.py validate` passes

Generated with [Claude Code](https://claude.com/claude-code)