### PR TITLE
Add mapping: economic-moats

### DIFF
--- a/catalog/mappings/economic-moats.md
+++ b/catalog/mappings/economic-moats.md
@@ -1,0 +1,194 @@
+---
+slug: economic-moats
+name: "Economic Moats"
+kind: paradigm
+source_frame: war
+target_frame: competition
+categories:
+  - organizational-behavior
+  - systems-thinking
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - survival-of-the-fittest
+---
+
+## What It Brings
+
+A medieval castle moat -- a water-filled trench surrounding a fortification --
+mapped onto the structural advantages that protect a business from competition.
+The metaphor reframes competitive advantage as a defensive engineering problem:
+what stands between your castle and the attackers?
+
+Key structural parallels:
+
+- **Width determines durability** -- a narrow moat can be crossed with a
+  plank; a wide one requires siege engineering. A business with a thin
+  advantage (slightly lower costs, one patent) is vulnerable to any
+  well-resourced competitor. A business with a wide moat (network effects,
+  regulatory capture, deep brand loyalty) forces competitors to invest
+  massively just to reach the walls.
+- **Moats must be maintained** -- a real moat silts up without dredging. A
+  competitive advantage erodes without reinvestment. Kodak had a moat in film
+  chemistry; they stopped maintaining it when digital arrived.
+- **Different moat types serve different threats** -- just as a castle might
+  combine a water moat with walls, towers, and a drawbridge, businesses layer
+  advantages: switching costs plus brand plus scale plus patents. The
+  metaphor naturally supports thinking about defense in depth.
+- **The castle matters too** -- a moat protects something worth protecting.
+  A wide moat around a worthless castle is still a bad investment. The metaphor
+  links defensive advantage to the underlying economics of the business itself.
+
+Buffett coined the term; Munger refined the analytical framework for
+classifying moat types and assessing moat durability. Together they made
+"moat analysis" a standard tool in value investing.
+
+## Where It Breaks
+
+The moat metaphor carries serious structural distortions that practitioners
+must actively resist.
+
+- **Moats are static; advantages are dynamic** -- a medieval moat doesn't
+  change after construction. Real competitive advantages shift constantly.
+  Amazon's moat in 2000 (first-mover in e-commerce) is completely different
+  from its moat in 2024 (logistics infrastructure plus AWS plus marketplace
+  network effects). The metaphor encourages thinking about advantage as a
+  fixed thing rather than an evolving system.
+- **Defense bias** -- the metaphor frames strategy as fundamentally defensive.
+  But some of the most valuable businesses win through offense: creating new
+  markets, not defending old ones. Apple's iPhone didn't defend a moat; it
+  rendered Nokia's moat irrelevant. Overweighting defense leads to
+  complacency.
+- **Binary thinking** -- moats are either there or not (you can't have
+  half a moat). Real advantages exist on a spectrum and can be partially
+  bridged. The metaphor pushes toward binary judgments ("does it have a moat
+  or not?") when the reality is graded.
+- **The aggressor's perspective is missing** -- the metaphor frames the
+  business as the castle and competitors as attackers. But most competitive
+  dynamics are more complex: businesses are simultaneously defending some
+  positions and attacking others. Google defends search while attacking cloud
+  computing. The single-castle view flattens multi-front competition.
+- **Moats can become prisons** -- a moat that keeps competitors out also
+  keeps the business in. Regulatory moats (banking licenses, spectrum
+  allocations) often come with constraints that prevent the business from
+  adapting. The metaphor hides the cost of the defense it celebrates.
+
+## Expressions
+
+- "What's the moat?" -- standard question in value investing due diligence
+- "Wide moat" / "narrow moat" -- Morningstar's classification system for
+  competitive advantage durability
+- "The moat is getting wider" -- Buffett's highest praise for a business
+- "No-moat stock" -- a commodity business without structural advantages
+- "Moat erosion" -- competitive advantage degrading over time
+- "Castle and moat architecture" -- network security borrowed the metaphor
+  to describe perimeter-based defense (and then abandoned it for zero trust)
+
+## Origin Story
+
+Warren Buffett introduced the moat metaphor in his 1995 Berkshire Hathaway
+annual meeting, describing the ideal business as "a castle surrounded by a
+moat." Charlie Munger extended the analytical framework, identifying specific
+moat types: brand (Coca-Cola), switching costs (enterprise software), network
+effects (Visa), cost advantages (Costco), and regulatory barriers (utilities).
+Pat Dorsey's "The Little Book That Builds Wealth" (2008) and Morningstar's
+"wide moat" rating system formalized the framework for institutional
+investors. The metaphor has become so embedded in investing vocabulary that
+analysts use "moat" without conscious reference to medieval fortification.
+
+## References
+
+- Buffett, W. Berkshire Hathaway Annual Meeting (1995)
+- Munger, C. "A Lesson on Elementary Worldly Wisdom" in *Poor Charlie's
+  Almanack* (2005)
+- Dorsey, P. *The Little Book That Builds Wealth* (2008)
+- Morningstar Economic Moat Rating Methodology
+++ b/catalog/mappings/incentive-caused-bias.md
+---
+slug: incentive-caused-bias
+name: "Incentive-Caused Bias"
+kind: paradigm
+source_frame: economics
+target_frame: social-behavior
+categories:
+  - psychology
+  - systems-thinking
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - survival-of-the-fittest
+  - the-map-is-not-the-territory
+---
+
+## What It Brings
+
+Economic incentive theory mapped onto cognition: people do not merely
+respond to incentives -- incentives reshape what they sincerely believe.
+A salesman paid on commission does not just push harder; he genuinely
+comes to believe his product is superior. The structural mapping runs
+deeper than "people are greedy."
+
+Key structural parallels:
+
+- **Incentives as a gravitational field** -- in economics, incentives
+  alter behavior by changing the payoff matrix. Munger's extension is
+  that they also warp the cognitive landscape. Beliefs, perceptions,
+  and professional judgments bend toward whatever the incentive structure
+  rewards, often without the person noticing. The mapping is from
+  economic force to cognitive distortion.
+- **Rational self-interest becomes irrational self-deception** -- the
+  standard economic model assumes agents respond to incentives while
+  maintaining accurate beliefs. Munger's model says the response
+  mechanism corrupts the belief-formation mechanism. The accountant
+  who finds what the client wants found, the surgeon who recommends
+  surgery, the consultant who identifies problems requiring more
+  consulting -- none of these people are necessarily lying. They have
+  been reshaped by the incentive gradient.
+- **Systemic, not individual** -- the paradigm applies to institutions,
+  professions, and entire industries. When you see a pattern of biased
+  judgment across many individuals in the same incentive structure, the
+  explanation is structural, not characterological. The economics frame
+  provides the analytical tool: look at the payoff matrix, and you can
+  predict the bias.
+
+Munger ranked this first among his 25 causes of human misjudgment:
+"Never, ever think about something else when you should be thinking
+about the power of incentives."
+
+## Where It Breaks
+
+- **Over-cynicism** -- if every professional opinion is suspected of
+  being incentive-driven, expertise becomes impossible to trust. Your
+  doctor recommends surgery: is that incentive-caused bias or a correct
+  medical judgment? The model provides no way to distinguish, and
+  reflexive application leads to a corrosive distrust of all expert
+  advice. Munger himself trusted specific experts deeply (he revered
+  his eye surgeon) -- the model alone does not tell you when to trust.
+- **Incentives are not the only cause of bias** -- cognitive biases
+  exist independently of incentive structures. Confirmation bias,
+  anchoring, and availability heuristics distort judgment even when
+  no money is involved. Reducing all bias to incentive-caused bias
+  is itself a man-with-a-hammer error: you have one model and
+  everything looks like an incentive problem.
+- **The model is self-undermining** -- if incentive-caused bias is
+  universal, then Munger's own advocacy of this model is suspect.
+  He was incentivized to believe in rational capital allocation and
+  to distrust professionals who might drain his portfolio. The model
+  cannot exempt itself from its own critique, which makes it
+  epistemically unstable if taken as the sole analytical lens.
+- **Removing incentives is not a solution** -- the naive policy
+  response is to eliminate the problematic incentive (ban commissions,
+  make advisors fee-only). But incentive structures are load-bearing:
+  remove them and you get different problems (reduced effort, adverse
+  selection, free-riding). The economic source domain understands this;
+  casual users of the model often do not.
+
+## Expressions
+
+- "Never, ever think about something else when you should be thinking
+  about the power of incentives" -- Munger's formulation, repeated
+  across decades of talks
+- "Show me the incentive and I'll show you the outcome" -- the compact
+  version, widely attributed to Munger
+- "It is difficult to get a man to understand something when his salary


### PR DESCRIPTION
## Summary

- Adds `economic-moats` paradigm mapping: medieval castle defense (moat) mapped onto competitive advantage in business
- Source frame: war, Target frame: economics
- Part of munger-mental-models project (#642)

Closes #669

## Validator output

All content valid. (35 pre-existing dangling reference warnings, non-blocking)

## Test plan

- [x] `uv run scripts/validate.py validate` passes
- [x] All referenced frames exist in catalog

Co-Authored-By: metaphorex-miner <miner@metaphorex.org>