### PR TITLE
Add mapping: regression-to-the-mean

### DIFF
--- a/catalog/mappings/regression-to-the-mean.md
+++ b/catalog/mappings/regression-to-the-mean.md
@@ -1,0 +1,138 @@
+---
+slug: regression-to-the-mean
+name: "Regression to the Mean"
+kind: paradigm
+source_frame: probability
+target_frame: causal-reasoning
+categories:
+  - cognitive-science
+  - systems-thinking
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - the-map-is-not-the-territory
+  - latticework-of-mental-models
+  - power-laws
+---
+
+## What It Brings
+
+A statistical phenomenon mapped onto prediction and judgment. Regression
+to the mean is the observation that if a variable is extreme on its first
+measurement, it will tend to be closer to the average on its second
+measurement -- not because of any causal force pulling it back, but
+because extreme values are statistically unlikely to be repeated. The
+model reframes a wide range of apparent patterns as statistical artifacts
+rather than real effects.
+
+Key structural parallels:
+
+- **Extreme performance is partly luck** -- any measured outcome is a
+  combination of skill (or underlying tendency) and randomness. When
+  someone performs exceptionally well or badly, the random component was
+  probably favorable or unfavorable. On the next measurement, the random
+  component is likely closer to zero, so the measured outcome moves toward
+  the mean. This is not a force; it is arithmetic. The model teaches you
+  to decompose observed outcomes into signal and noise before attributing
+  causation.
+- **The illusion of effective intervention** -- a manager reprimands a
+  poor performer, and the next quarter their numbers improve. A doctor
+  prescribes a treatment when symptoms peak, and the patient gets better.
+  In both cases, regression to the mean would have produced improvement
+  without the intervention. The model reveals that we systematically
+  overestimate the effectiveness of actions taken at extreme moments,
+  because the natural regression provides a false confirmation.
+- **Punishment seems to work better than reward** -- Kahneman's famous
+  observation: pilots reprimanded after bad landings improve; pilots
+  praised after good landings get worse. Both are regression effects, but
+  the asymmetry creates a persistent illusion that criticism is more
+  effective than praise. The model explains a deep bias in management and
+  education toward punishment, grounded not in psychology but in
+  statistics.
+- **The sophomore slump is predictable** -- in sports, business, and the
+  arts, exceptional debut performances are reliably followed by less
+  impressive second efforts. This is not because success breeds
+  complacency (though it might); it is because the debut performance
+  was partly lucky, and the luck is unlikely to be repeated. The model
+  predicts the pattern without needing any psychological explanation.
+
+## Where It Breaks
+
+- **Not everything regresses** -- regression to the mean applies to
+  variables with a random component measured repeatedly. It does not apply
+  to deterministic processes, to first measurements of a fixed quantity,
+  or to systems undergoing genuine structural change. A company whose
+  earnings spike because it entered a new market may sustain the spike
+  indefinitely. Treating all extreme outcomes as regression candidates is
+  as much an error as ignoring regression entirely.
+- **The mean itself can shift** -- the model assumes a stable underlying
+  distribution. But in many real systems, the mean is moving. A student
+  whose test scores jump may have genuinely learned something; the new
+  mean is higher. Climate temperatures that hit new extremes are not
+  regressing to a fixed mean -- the mean is rising. Applying the
+  regression model to non-stationary processes produces false comfort.
+- **It can excuse inaction** -- if extreme outcomes are just noise that
+  will self-correct, why intervene? The model can become a rationalization
+  for doing nothing. A manager who dismisses a spike in customer
+  complaints as "regression to the mean" may be ignoring a genuine
+  systemic problem. The model tells you not to over-react, but it
+  provides no clear threshold for when a signal is real rather than noise.
+- **Psychological reality matters even if it is statistically irrelevant**
+  -- the model correctly identifies that the "sophomore slump" is partly
+  a statistical artifact. But it is also psychologically real: people
+  who experience public success do face new pressures (expectations,
+  scrutiny, loss of underdog motivation) that may independently reduce
+  performance. Dismissing the psychology because the statistics already
+  explain the pattern is reductive.
+- **The model requires knowing the distribution** -- to predict regression,
+  you need to know the mean, the variance, and that the variable is
+  at least partly random. In practice, for most interesting real-world
+  variables, you do not know any of these with confidence. The model
+  offers clear predictions in textbook examples and murky guidance in
+  real decisions.
+
+## Expressions
+
+- "Regression to the mean" -- Galton's original term, now used broadly
+  in statistics, sports, business, and everyday reasoning
+- "Reversion to the mean" -- the more common variant in financial
+  contexts, applied to stock prices, earnings, and market valuations
+- "The sophomore slump" -- the pop-culture version, applied to athletes,
+  musicians, and directors after exceptional debuts
+- "Don't confuse correlation with causation" -- not identical, but the
+  regression fallacy is one of the most common mechanisms by which
+  spurious correlations arise
+- "Things will even out" -- the folk version, which is approximately
+  correct for regression but dangerously wrong when mistaken for the
+  gambler's fallacy (confusing statistical tendency with compensating
+  force)
+
+## Origin Story
+
+Francis Galton discovered regression to the mean in the 1880s while
+studying the heights of parents and children. He noticed that
+exceptionally tall parents tended to have children shorter than
+themselves (though still above average), and exceptionally short parents
+tended to have taller children. He called it "regression toward
+mediocrity," a term that carries an unfortunately judgmental tone for a
+purely statistical phenomenon. The concept entered psychology through
+Kahneman and Tversky's work on judgment under uncertainty in the 1970s,
+where they demonstrated that failure to recognize regression effects was
+one of the most robust cognitive errors in human reasoning. Munger
+absorbed it as a core mental model, particularly for investing: apparent
+"turnarounds" in company performance are often just regression, and the
+wise investor accounts for this before attributing improvement to
+new management.
+
+## References
+
+- Galton, F. "Regression Towards Mediocrity in Hereditary Stature"
+  (1886)
+- Kahneman, D. *Thinking, Fast and Slow* (2011), ch. 17 -- the
+  definitive modern treatment of regression fallacies
+- Kahneman, D. & Tversky, A. "On the Psychology of Prediction" (1973)
+- Munger, C. "The Psychology of Human Misjudgment" (1995), collected
+  in *Poor Charlie's Almanack* (2005)
+- Secrist, H. *The Triumph of Mediocrity in Business* (1933) -- the
+  notorious case study in confusing regression with a causal process


### PR DESCRIPTION
Closes #682

Adds the **regression-to-the-mean** paradigm mapping -- statistical regression phenomenon mapped onto prediction and judgment. Extreme results tend to be followed by more moderate ones; mistaking regression for causation is one of the most common reasoning errors.

Source frame: `probability` | Target frame: `causal-reasoning`

Validator output: All content valid (0 errors, 1 new warning for dangling `power-laws` reference which will be resolved by #683).