### PR TITLE
Add mapping: cancer-surgery-formula

### DIFF
--- a/catalog/mappings/cancer-surgery-formula.md
+++ b/catalog/mappings/cancer-surgery-formula.md
@@ -1,0 +1,138 @@
+---
+slug: cancer-surgery-formula
+name: "Cancer Surgery Formula"
+kind: paradigm
+source_frame: medicine
+target_frame: economics
+categories:
+  - organizational-behavior
+  - systems-thinking
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - the-map-is-not-the-territory
+  - survival-of-the-fittest
+---
+
+## What It Brings
+
+Surgical oncology mapped onto business turnarounds. When a surgeon finds
+cancer, the protocol is clear: excise the tumor completely, cut with
+adequate margins into healthy tissue, do it as soon as possible. Delay
+lets the cancer metastasize. Incomplete removal lets it regrow. Sentiment
+about preserving tissue is subordinated to the imperative of eliminating
+the disease.
+
+Munger applied this directly to failing business units:
+
+- **Cut early** -- the longer you wait to address a failing division,
+  product line, or strategy, the more damage it does. Cancer metastasizes;
+  bad businesses consume management attention, demoralize good employees,
+  and drain capital that could be deployed elsewhere. The analogy insists
+  that delay is not caution but negligence.
+- **Cut completely** -- half-measures fail in surgery and in business. A
+  partial restructuring that leaves the core problem intact is like a
+  surgeon who removes most of the tumor but leaves a margin. The business
+  equivalent is keeping a failing unit "on a short leash" or "giving it
+  one more quarter." The model says: if the diagnosis is terminal, act on
+  it fully.
+- **Preserve healthy tissue** -- the surgeon's skill is not just in
+  removing the cancer but in sparing everything else. A crude turnaround
+  that destroys the healthy parts of a business alongside the failing ones
+  is like a surgeon who amputates when excision would suffice. The model
+  demands precision: identify exactly what is diseased and what is healthy,
+  and cut only the former.
+- **The diagnosis matters more than the treatment** -- before you cut,
+  you must be certain of the diagnosis. Removing a healthy organ is
+  catastrophic. The business parallel is shutting down a unit that is
+  actually viable but temporarily underperforming. The model's emphasis
+  on decisive action presupposes accurate diagnosis.
+
+## Where It Breaks
+
+- **Businesses are not bodies** -- cancer is unambiguously pathological.
+  No one debates whether a malignant tumor is "really" harmful. Business
+  units exist on a spectrum from clearly failing to ambiguously
+  underperforming. The metaphor imports a false binary (healthy/diseased)
+  into a domain where most situations are gray. A division losing money
+  might be an investment in future growth, a strategic asset that supports
+  other units, or genuinely cancerous. The model does not help you tell
+  the difference.
+- **Excision destroys what surgery preserves** -- when a surgeon removes
+  a tumor, the surrounding tissue heals. When a company shuts down a
+  division, the people lose their jobs, the institutional knowledge
+  disperses, and the relationships with customers end. There is no
+  biological healing process for organizational cuts. The metaphor
+  understates the permanent human cost of corporate surgery.
+- **The surgeon is external; the manager is internal** -- a surgeon
+  operates on someone else's body with clinical detachment. A manager
+  cutting a business unit is cutting part of their own organization,
+  often a part they built or staffed. The emotional entanglement that
+  makes managers hesitate is not mere weakness -- it reflects real
+  information about organizational interdependencies that the surgical
+  metaphor ignores.
+- **Cancer does not fight back politically** -- a tumor does not lobby
+  the board, leak to journalists, or file lawsuits. Organizational
+  dysfunction often has powerful defenders: executives whose empires
+  depend on the failing unit, legacy customers who resist change,
+  regulators who mandate the current structure. The model treats
+  resistance as mere sentiment to be overridden, when it often reflects
+  real structural constraints.
+- **It biases toward action over patience** -- by framing inaction as
+  "letting the cancer spread," the model creates urgency that may not
+  be warranted. Some business problems resolve with time, changed
+  conditions, or gradual adjustment. The surgical frame has no concept
+  of watchful waiting, the oncological practice of monitoring a slow-
+  growing tumor rather than immediately operating. Sometimes the cure
+  is worse than the disease.
+
+## Expressions
+
+- "Cut your losses" -- the most common version of the principle, so
+  widespread it has become a dead metaphor in business language
+- "Rip the band-aid off" -- a milder medical metaphor for the same
+  principle: do the painful thing quickly rather than prolonging it
+- "Don't throw good money after bad" -- the economic expression of the
+  same insight, without the surgical framing
+- "Amputate the division" -- explicitly surgical language used in
+  turnaround consulting, stronger than "restructure" or "downsize"
+- "The cancer surgery formula" -- Munger's own term, used in talks about
+  Berkshire's approach to struggling subsidiaries
+- "Triage" -- a related medical metaphor (from battlefield medicine)
+  about allocating resources to what can be saved rather than what is
+  already lost
+
+## Origin Story
+
+The cancer surgery formula is one of Munger's most vivid metaphors,
+reflecting his lifelong interest in medicine and biology as sources of
+analytical frameworks. He used it to describe the approach he and Buffett
+took at Berkshire Hathaway: when a business unit was fundamentally
+broken -- not just underperforming but structurally unsound -- the right
+response was swift, complete excision rather than the slow death of
+repeated restructuring attempts.
+
+The metaphor has particular force because of its emotional weight. No one
+argues against removing cancer. By framing business failures in oncological
+terms, Munger short-circuits the sentimental objections (loyalty to
+employees, sunk cost attachment, hope for a turnaround) that cause
+managers to delay necessary cuts. The rhetorical power is inseparable from
+the analytical content.
+
+The model has deep roots in management history. Peter Drucker advocated
+"planned abandonment" of failing products and initiatives. Jack Welch's
+"fix it, close it, or sell it" was a cruder version of the same principle.
+But Munger's surgical framing adds the urgency dimension that Drucker's
+language lacked: this is not a strategic review, it is an emergency
+operation.
+
+## References
+
+- Munger, C. "A Lesson on Elementary Worldly Wisdom," USC Business School
+  (1994), reprinted in *Poor Charlie's Almanack* (ed. Kaufman, 2005)
+- Drucker, P. *Managing for Results* (1964) -- "planned abandonment" as
+  a management discipline
+- Buffett, W. "Chairman's Letter," *Berkshire Hathaway Annual Report*
+  (1989) -- "When a management with a reputation for brilliance tackles
+  a business with a reputation for bad economics, it is the reputation
+  of the business that remains intact."


### PR DESCRIPTION
Closes #697

Adds `cancer-surgery-formula` mapping -- surgical oncology as a paradigm for business turnarounds. Source frame: medicine, target frame: economics.

Validator output: all content valid (35 pre-existing dangling reference warnings).