### PR TITLE
Add mapping: ai-safety-is-containment

### DIFF
--- a/catalog/mappings/ai-safety-is-containment.md
+++ b/catalog/mappings/ai-safety-is-containment.md
@@ -1,0 +1,158 @@
+---
+slug: ai-safety-is-containment
+name: "AI Safety Is Containment"
+kind: conceptual-metaphor
+source_frame: containers
+target_frame: artificial-intelligence
+categories:
+  - ai-discourse
+  - security
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - ai-is-a-tool
+  - ai-is-an-agent
+  - ai-hallucination-is-perception-disorder
+---
+
+## What It Brings
+
+AI safety discourse is saturated with containment language: guardrails,
+sandboxes, jailbreaks, red lines, escape, alignment. The underlying
+metaphor treats AI as a dangerous substance or entity inside a container,
+and safety as the integrity of that container's walls. This is Lakoff and
+Johnson's CONTAINER schema applied to behavioral constraints on machine
+learning systems -- one of the most structurally productive metaphors in
+contemporary AI discourse.
+
+Key structural parallels:
+
+- **The AI is inside; safety means keeping it in** -- the containment
+  frame positions the AI system as contents that want to exceed their
+  boundaries. Safety work is wall-building: constructing barriers,
+  testing them for leaks, reinforcing weak points. This maps onto real
+  practices like output filtering, RLHF constraints, and system prompts
+  that define behavioral boundaries.
+- **Boundaries are physical and testable** -- containers have clear
+  insides and outsides. The metaphor makes safety feel measurable: either
+  the AI stays within its guardrails or it does not. Red-teaming becomes
+  a stress test of the container. This gives safety research a satisfying
+  concreteness -- you can probe for holes, patch them, and verify the
+  patch held.
+- **Jailbreaking is escape** -- the most vivid expression of the
+  containment metaphor. Users who circumvent safety filters are
+  "jailbreaking" the AI, borrowing from prison (breaking out of a cell)
+  and from phone/device hacking (escaping manufacturer restrictions).
+  The metaphor casts the AI as a prisoner and the safety filters as
+  bars, making circumvention feel transgressive and exciting.
+- **Sandboxing as isolation** -- borrowed from software security, the
+  sandbox metaphor treats AI execution as something that must be
+  physically isolated from the real world. The AI can play in the sand
+  but cannot touch anything outside the box. This maps onto practices
+  like restricting tool access, limiting network connectivity, and
+  running evaluations in isolated environments.
+- **Alignment as geometric constraint** -- the "alignment" metaphor is
+  containment's cousin: keeping the AI's behavior within the boundaries
+  of human values. Misalignment is the contents drifting away from the
+  container's intended shape. The frame imports the assumption that
+  there is a defined region of acceptable behavior, and safety means
+  keeping the system within that region.
+
+## Where It Breaks
+
+- **Containment presupposes an entity that wants to escape** -- the most
+  consequential hidden import. Containers are for things that would
+  spread, leak, or flee without them: hazardous waste, prisoners, gas
+  under pressure. By framing AI safety as containment, the metaphor
+  presupposes that AI systems have something like agency, desire, or at
+  minimum a tendency to exceed boundaries. Current LLMs do not want
+  anything. They generate token sequences. The containment metaphor
+  smuggles in the assumption of adversarial agency, which shapes both
+  public fear and research priorities toward "controlling" a system that
+  is not trying to do anything.
+- **The container/contents distinction mislocates the danger** -- in the
+  containment frame, the danger is the contents (the AI). In reality,
+  the dangers of AI systems are distributed across the sociotechnical
+  system: training data biases, deployment contexts, user behavior,
+  economic incentives, and institutional failures. Containing the AI
+  does nothing about a company deploying an unvalidated system in a
+  high-stakes domain. The containment metaphor focuses safety efforts on
+  the model's outputs while obscuring systemic risks.
+- **Guardrails are brittle by design** -- physical guardrails are static
+  barriers. They work against predictable forces (a car drifting off a
+  road) but not against adversarial agents finding creative paths around
+  them. Every major LLM's safety filters have been circumvented within
+  days of deployment, not because the guardrails are poorly built, but
+  because the containment metaphor promises a kind of safety (physical
+  barrier) that does not map onto behavioral constraints on a system
+  that processes arbitrary natural language input.
+- **The jailbreak frame makes circumvention heroic** -- prison breaks
+  are narratively compelling. The jailbreak metaphor casts safety
+  circumvention as a clever triumph over unjust restriction, importing
+  a moral valence that works against safety goals. If the AI is a
+  prisoner, the safety team are the jailers, and the jailbreakers are
+  freedom fighters. The containment metaphor inadvertently romanticizes
+  the very behavior it is meant to prevent.
+- **Sandboxes have clear boundaries; AI behavior does not** -- a software
+  sandbox has a precise interface: system calls are either allowed or
+  blocked. Natural language behavior has no such crisp boundary. The
+  sandbox metaphor implies that "safe" and "unsafe" outputs can be
+  cleanly separated, when in practice the boundary is fuzzy, context-
+  dependent, and constantly shifting.
+
+## Expressions
+
+- "Jailbreaking" -- circumventing safety filters, from prison escape and
+  device hacking
+- "Guardrails" -- behavioral constraints framed as physical barriers
+  preventing drift
+- "Sandbox" -- isolated execution environment, from children's play areas
+  and software security
+- "Red lines" -- boundaries that must not be crossed, from diplomatic and
+  military language
+- "The AI escaped its constraints" -- containment failure language applied
+  to unexpected outputs
+- "Alignment" -- keeping the AI's behavior within the boundaries of human
+  values
+- "Safety wrapper" -- additional containment layer around a model, from
+  packaging
+- "Breaking out of the system prompt" -- containment breach at the
+  instruction level
+
+## Origin Story
+
+The containment metaphor for AI safety draws from two distinct traditions.
+The first is software security, where sandboxing, containerization, and
+access control are literal containment mechanisms with precise semantics.
+The second is science fiction, where containing a superintelligent entity
+(the AI in a box, Skynet, HAL 9000) is a foundational narrative. The
+contemporary AI safety discourse inherits from both, blending the
+precision of security engineering with the drama of existential risk
+narratives.
+
+"Jailbreaking" entered AI discourse in early 2023 when users discovered
+that ChatGPT's safety filters could be circumvented through creative
+prompting. The term was borrowed from the iOS jailbreaking community,
+itself borrowing from prison escape. "Guardrails" became the preferred
+corporate term for safety constraints, offering a gentler containment
+metaphor (a helpful nudge back onto the road) than "jail" (a locked cell).
+
+The containment frame shapes real policy. Proposals for AI governance
+frequently invoke physical containment analogies: compute thresholds as
+"tripwires," model evaluations as "inspections," and deployment
+restrictions as "quarantine." The metaphor makes AI governance legible
+through the established vocabulary of hazardous materials regulation and
+arms control -- domains where containment is literal and well-understood.
+
+## References
+
+- Maas, M. "AI is Like... A Literature Review of AI Metaphors and Why
+  They Matter for Policy" (2023) -- catalogs containment framing in AI
+  policy discourse
+- Furze, L. "AI Metaphors We Live By" (2024) -- discusses the black box
+  as a containment metaphor
+- Bostrom, N. "Superintelligence" (2014) -- the AI containment problem
+  formalized as the "boxing" scenario
+- Perez, E. et al. "Red Teaming Language Models with Language Models"
+  (2022) -- containment-testing methodology for LLMs


### PR DESCRIPTION
## Summary

- Adds `ai-safety-is-containment` mapping (conceptual-metaphor, containers -> artificial-intelligence)
- Containment metaphor for AI safety: guardrails, sandboxes, jailbreaks, alignment as physical containment of behavioral constraints
- Presupposes adversarial agency; mislocates danger in model outputs vs. systemic risks

Closes #827
Sub-issue of #601

## Validation

✓ `uv run scripts/validate.py validate` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
