### PR TITLE
Add mapping: the-internet-is-a-mine

### DIFF
--- a/catalog/mappings/the-internet-is-a-mine.md
+++ b/catalog/mappings/the-internet-is-a-mine.md
@@ -1,0 +1,154 @@
+---
+slug: the-internet-is-a-mine
+name: "The Internet Is a Mine"
+kind: conceptual-metaphor
+source_frame: natural-resources
+target_frame: artificial-intelligence
+categories:
+  - ai-discourse
+  - philosophy
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - data-is-fuel
+  - compute-is-a-resource
+---
+
+## What It Brings
+
+Web scraping for AI training is described through the vocabulary of
+resource extraction: data mining, web crawling, Common Crawl, scraping.
+The metaphor maps the internet onto a mine -- a natural deposit of
+valuable material waiting to be extracted by those with the right
+equipment and the will to dig. Content created by millions of human
+beings is reframed as ore: raw, undifferentiated, and ownerless until
+someone extracts value from it.
+
+Key structural parallels:
+
+- **The internet as natural deposit** -- mines contain resources that
+  exist prior to human intervention. The mining metaphor frames the
+  internet the same way: all that text, all those images, all that code
+  was just sitting there, a natural resource that happened to accumulate.
+  This erases the labor of the people who created the content. Blog posts,
+  forum answers, photographs, and open-source code become geological
+  strata rather than human artifacts.
+- **Extraction requires capital and expertise** -- not everyone can mine.
+  You need heavy equipment, specialized knowledge, and capital investment.
+  The metaphor maps this onto web scraping at scale: only organizations
+  with sufficient compute, engineering talent, and legal resources can
+  extract training data from the internet. The mining frame naturalizes
+  the concentration of data access among a few large AI labs.
+- **The extracted material must be refined** -- raw ore is not useful;
+  it must be processed, smelted, and shaped. Similarly, raw web data
+  must be cleaned, deduplicated, filtered for quality, and formatted
+  before it becomes useful training data. The metaphor provides vocabulary
+  for the entire data pipeline: collection, cleaning, and curation map
+  onto extraction, processing, and refining.
+- **Mining claims and rights** -- mines have owners who hold extraction
+  rights. The metaphor imports property-rights logic onto internet data:
+  who has the right to scrape, who can restrict access (robots.txt as
+  mineral rights), and whether the commons can be enclosed. The "data
+  rights" discourse borrows directly from resource-rights frameworks.
+- **Depletion and exhaustion** -- mines run out. The metaphor creates
+  anxiety about "running out of data" for training, which has become a
+  genuine concern as AI labs exhaust high-quality internet text. The
+  phrase "data wall" borrows from mining's concept of hitting rock that
+  yields diminishing returns.
+
+## Where It Breaks
+
+- **Internet content is not a natural resource** -- ore exists
+  independent of human intention. Blog posts, photographs, and code
+  are created by people with purposes, rights, and expectations about
+  how their work will be used. The mining metaphor systematically erases
+  authorship and consent. When a company "mines" the internet for
+  training data, it is not extracting a natural resource; it is
+  appropriating human creative output. The metaphor's greatest rhetorical
+  power is in making this appropriation feel as natural and inevitable
+  as digging up coal.
+- **The "resource" regenerates -- but only if the creators keep
+  creating** -- mines are finite; the internet is continuously produced.
+  But the mining metaphor ignores the feedback loop: if creators learn
+  their work is being extracted to train AI that competes with them, they
+  may stop creating. The metaphor treats the supply as geological (fixed,
+  extractable) when it is actually social (dependent on ongoing human
+  motivation). Killing the goose that lays the golden eggs has no
+  analogue in mining.
+- **Extraction without compensation is the default** -- in physical
+  mining, you pay for extraction rights, mineral royalties, and land
+  access. The internet mining metaphor imports the extraction vocabulary
+  but not the compensation framework. This is the most politically
+  charged break: the metaphor normalizes taking without paying by framing
+  it as natural resource extraction, while conveniently omitting the
+  part where miners pay for what they extract.
+- **Environmental damage maps poorly** -- physical mining causes
+  ecological destruction: polluted waterways, deforested land, toxic
+  waste. Internet data extraction does not destroy the source material
+  (the blog post still exists after scraping). But there are second-order
+  harms: AI-generated content flooding the internet degrades the quality
+  of the commons, which does map loosely onto environmental degradation.
+  The metaphor captures downstream pollution better than direct extraction
+  damage.
+- **The commons was already enclosed** -- the mining metaphor implies
+  open access to an unowned resource. But much internet content is
+  already governed by copyright, terms of service, and Creative Commons
+  licenses. The metaphor reframes an enclosure of the digital commons
+  as exploitation of a natural one, which is a politically convenient
+  category error.
+
+## Expressions
+
+- "Data mining" -- the oldest and most entrenched extractive metaphor
+  for information processing, predating AI by decades
+- "Web crawling" -- automated traversal of the internet framed as
+  physical exploration of underground passages
+- "Common Crawl" -- the name of the largest open web archive, directly
+  invoking the commons-as-natural-resource frame
+- "Scraping" -- physically removing material from a surface, importing
+  abrasion and material transfer
+- "Data is the new oil" -- the explicit resource equivalence, widely
+  attributed to Clive Humby (2006)
+- "We're running out of data" -- depletion anxiety imported from
+  finite-resource economics
+- "Training data pipeline" -- processing infrastructure framed as
+  industrial extraction and refining
+- "Synthetic data" -- when the mine runs dry, you manufacture the
+  resource, borrowing from synthetic fuel and synthetic materials
+
+## Origin Story
+
+"Data mining" entered computing vocabulary in the 1990s, originally
+referring to statistical pattern extraction from databases. The metaphor
+was already extractive: you "mined" data the way you mined ore, looking
+for valuable patterns buried in large undifferentiated masses. Web
+scraping extended the metaphor to the internet, and "web crawling"
+added the image of moving through underground tunnels.
+
+The metaphor intensified dramatically with large language models. When
+OpenAI, Google, and other labs began training on effectively the entire
+internet, the mining frame became literal: these organizations were
+extracting value from a commons that others had created. The backlash
+from content creators -- artists, writers, programmers, journalists --
+is in part a rejection of the mining metaphor itself. To call it
+"mining" is to accept that the internet is a resource to be extracted
+rather than a community to be respected.
+
+"Data is the new oil," attributed to British mathematician Clive Humby
+in 2006 and popularized by The Economist in 2017, is the explicit
+form of this metaphor. It maps the entire apparatus of petroleum
+economics onto data: extraction, refining, pricing, geopolitics,
+and environmental externalities. The phrase has been both celebrated
+(by data brokers and AI companies) and criticized (by privacy advocates
+and labor organizers) for precisely the implications the metaphor carries.
+
+## References
+
+- Maas, M. "AI is Like... A Literature Review of AI Metaphors and Why
+  They Matter for Policy" (2023) -- catalogs extractive metaphors in AI
+- Furze, L. "AI Metaphors We Live By" (2024) -- documents mining and
+  extraction language in AI discourse
+- The Economist, "The World's Most Valuable Resource Is No Longer Oil,
+  but Data" (2017) -- popularized the "data is the new oil" framing
+- Humby, C. (2006) -- originator of "data is the new oil"


### PR DESCRIPTION
## Summary

- Adds `the-internet-is-a-mine` mapping for the extractive metaphor framing web scraping as resource mining
- Covers structural parallels (natural deposit, capital requirements, refining pipeline, depletion) and substantive breaks (erasure of authorship, missing compensation, commons enclosure)
- Uses existing frames (`natural-resources`, `artificial-intelligence`) and categories (`ai-discourse`, `philosophy`)

Closes #842

## Validator output

```
All content valid.
```

## Validation
✓ `uv run scripts/validate.py` — 0 errors

Generated with [Claude Code](https://claude.com/claude-code)