### PR TITLE
Add mapping: ai-is-a-magnifying-glass

### DIFF
--- a/catalog/mappings/ai-is-a-magnifying-glass.md
+++ b/catalog/mappings/ai-is-a-magnifying-glass.md
@@ -1,0 +1,131 @@
+---
+slug: ai-is-a-magnifying-glass
+name: "AI Is a Magnifying Glass"
+kind: conceptual-metaphor
+source_frame: vision
+target_frame: artificial-intelligence
+categories:
+  - ai-discourse
+  - philosophy
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - ai-is-a-mirror
+  - ai-is-a-tool
+---
+
+## What It Brings
+
+A magnifying glass does not create what it shows; it enlarges what is
+already there. The metaphor frames AI as an amplifier of existing patterns,
+biases, and capabilities -- not as an independent creator. Where the mirror
+metaphor (its close relative) emphasizes faithful reflection, the magnifying
+glass emphasizes selective enlargement: AI does not just show us our biases,
+it makes them bigger and harder to ignore.
+
+Key structural parallels:
+
+- **Amplification without creation** -- a magnifying glass reveals detail
+  that was always present but too small to see. The metaphor positions AI
+  outputs as amplifications of training data patterns, not as novel
+  creations. When a hiring algorithm discriminates, the magnifying glass
+  says: that discrimination was always in the data; the algorithm just
+  made it larger and more consequential.
+- **Selective focus** -- you point a magnifying glass at something specific.
+  It enlarges what you aim it at and ignores everything else. The metaphor
+  captures how AI systems amplify particular patterns depending on what
+  they are trained on and how they are deployed. The choice of where to
+  point the glass is a human decision, and the metaphor makes that
+  decision visible.
+- **The observer directs the instrument** -- a magnifying glass is passive
+  in the hand. It requires someone to hold it, aim it, and interpret what
+  they see. The metaphor preserves human agency in a way that more
+  autonomous framings (agent, copilot) do not. AI is an optical instrument,
+  not a colleague.
+- **Distortion at the edges** -- magnifying glasses produce chromatic
+  aberration and barrel distortion, especially at high magnification.
+  The metaphor imports the idea that AI amplification is not perfectly
+  faithful: it introduces artifacts. Statistical patterns in training data
+  become exaggerated, minority signals get lost, and the enlarged picture
+  may be subtly warped even as the center appears sharp.
+- **Making the invisible visible** -- magnifying glasses let you see things
+  the naked eye cannot: fine print, hairline cracks, microorganisms. The
+  metaphor frames AI as a tool for surfacing patterns in data that humans
+  could never detect at scale: disease markers in medical images, fraud
+  signals in transaction data, structural patterns in protein sequences.
+
+## Where It Breaks
+
+- **Magnifying glasses do not generate** -- a magnifying glass shows you
+  what exists. A language model generates text that never existed before.
+  An image generator creates pictures of things that have never been
+  photographed. The amplification metaphor cannot account for AI's
+  generative capabilities. When GPT writes a poem, it is not magnifying
+  an existing poem; it is producing something new from statistical
+  patterns. The metaphor fits analytical AI (classification, detection)
+  far better than generative AI.
+- **The metaphor understates the transformation** -- a magnifying glass
+  preserves the structure of what it enlarges. AI systems do not merely
+  scale up input patterns; they recombine, interpolate, and extrapolate
+  in ways that fundamentally transform the source material. A magnifying
+  glass over a newspaper shows you the same newspaper larger. An AI
+  trained on newspapers produces something qualitatively different from
+  any individual newspaper.
+- **Amplification implies a fixed subject** -- you magnify what is there.
+  But AI systems are trained on curated datasets that represent editorial
+  choices about what to include and exclude. The "subject" being magnified
+  is itself constructed. The magnifying glass metaphor hides this curation
+  step by implying that the AI is simply enlarging the world as it is.
+- **The frame deflects design responsibility** -- if AI merely magnifies
+  what exists, then the problem is always upstream: in the data, in
+  society, in human nature. The metaphor makes it difficult to hold AI
+  developers responsible for design choices -- objective function
+  selection, training data filtering, output post-processing -- that
+  shape what gets amplified and by how much. The magnifying glass is
+  blameless; the thing it magnifies is not.
+- **Scale changes the nature of the thing** -- a magnifying glass over
+  an ant shows you a larger ant. But when AI amplifies a pattern from
+  a dataset of millions into a deployed system affecting billions, the
+  change in scale changes the nature of the impact. A bias that was
+  statistically minor in a dataset becomes a systematic discrimination
+  machine at deployment scale. The magnifying glass metaphor cannot
+  express how amplification at scale creates qualitatively new harms.
+
+## Expressions
+
+- "AI is a magnifying glass for bias" -- the most common formulation,
+  used in fairness and ethics discussions
+- "It just amplifies what's already there" -- the deflection version,
+  redirecting blame from the system to the data
+- "AI magnifies both the good and the bad" -- the balanced version,
+  acknowledging amplification as morally neutral
+- "Putting a magnifying glass on the data" -- describing AI-powered
+  analytics and pattern detection
+- "The lens we use to look at the problem" -- extending the optical
+  metaphor from magnification to framing
+
+## Origin Story
+
+The magnifying glass metaphor for AI emerged alongside the mirror metaphor
+in discussions of algorithmic bias in the mid-2010s. While the mirror says
+"AI reflects us," the magnifying glass says "AI makes our patterns bigger."
+The distinction matters: reflection implies fidelity, while magnification
+implies selective enlargement and possible distortion. Leon Furze (2024)
+identifies the magnifying glass as a companion to the mirror in his
+Lakoff-inspired analysis of AI metaphors, noting that both belong to the
+vision/optics family of AI framings. The magnifying glass has been
+particularly productive in discussions of AI fairness, where it provides
+a frame for arguing that debiasing AI requires debiasing society -- a
+position that can be either a genuine call to action or a convenient
+excuse for inaction, depending on who wields it.
+
+## References
+
+- Furze, L. "AI Metaphors We Live By" (2024) -- identifies the magnifying
+  glass as a companion to the mirror metaphor in AI discourse
+- O'Neil, C. *Weapons of Math Destruction* (2016) -- documents how
+  algorithmic amplification of existing inequalities creates feedback
+  loops, the book-length case for the magnifying glass frame
+- Barocas, S. and Selbst, A. "Big Data's Disparate Impact" (2016) --
+  early academic articulation of how ML amplifies existing discrimination


### PR DESCRIPTION
## Summary

- Adds `ai-is-a-magnifying-glass` mapping (conceptual-metaphor)
- Source frame: vision -> Target frame: artificial-intelligence
- AI as selective amplifier of existing patterns, biases, and capabilities

Closes #844 (sub-issue of #601)

## Validator output

All content valid. Zero errors.

## Test plan

- [x] `uv run scripts/validate.py validate` passes
- [ ] Review mapping content for accuracy and tone

Generated with [Claude Code](https://claude.com/claude-code)