### PR TITLE
Prospect: Jungian archetypes (issue #8)

### DIFF
--- a/playbooks/jungian-archetypes/manifest.json
+++ b/playbooks/jungian-archetypes/manifest.json
@@ -1,0 +1,213 @@
+{
+  "project": "jungian-archetypes",
+  "project_issue": 8,
+  "source_type": "archive",
+  "archive_urls": [
+    "https://en.wikipedia.org/wiki/Category:Jungian_archetypes",
+    "https://en.wikipedia.org/wiki/Jungian_archetypes",
+    "https://scottjeffrey.com/classic-jungian-archetypes/",
+    "https://iaap.org/resources/academic-resources/collected-works-abstracts/volume-9-1-archetypes-collective-unconscious/",
+    "https://carolspearson.com/about/the-pearson-12-archetype-system-human-development-and-evolution"
+  ],
+  "candidates": [
+    {
+      "slug": "the-self",
+      "name": "The Self",
+      "kind": "archetype",
+      "source_frame": "mythology",
+      "target_frame": "integration-and-wholeness",
+      "categories": [
+        "psychology",
+        "organizational-behavior",
+        "systems-thinking"
+      ],
+      "source": "archive",
+      "archive_refs": {
+        "cw9_1": "Conscious, Unconscious, and Individuation; A Study in the Process of Individuation; Concerning Mandala Symbolism",
+        "cw9_2": "Aion: Researches into the Phenomenology of the Self (entire volume)",
+        "wikipedia": "Self (Jung)"
+      },
+      "description": "The archetype of wholeness and integration -- the organizing center of the psyche that transcends ego. Maps onto system architecture (the unified system vs. its components), organizational identity (mission as integrating principle), and the individuation process in personal development."
+    },
+    {
+      "slug": "the-shadow",
+      "name": "The Shadow",
+      "kind": "archetype",
+      "source_frame": "mythology",
+      "target_frame": "hidden-knowledge",
+      "categories": [
+        "psychology",
+        "organizational-behavior",
+        "software-engineering"
+      ],
+      "source": "archive",
+      "archive_refs": {
+        "cw9_2": "Aion, Chapter 2: The Shadow",
+        "wikipedia": "Shadow (psychology)"
+      },
+      "description": "The denied, repressed, or unacknowledged aspects of self or system. Maps onto technical debt, shadow IT, organizational denial, and the gap between stated values and actual behavior. The most structurally productive Jungian archetype for modern organizational analysis."
+    },
+    {
+      "slug": "the-persona",
+      "name": "The Persona",
+      "kind": "archetype",
+      "source_frame": "mythology",
+      "target_frame": "social-roles",
+      "categories": [
+        "psychology",
+        "organizational-behavior",
+        "software-engineering"
+      ],
+      "source": "archive",
+      "archive_refs": {
+        "cw7": "Two Essays on Analytical Psychology, Chapter 2: The Persona",
+        "wikipedia": "Persona (psychology)"
+      },
+      "description": "The social mask -- the public-facing identity adopted for social interaction. Maps onto public APIs, facade patterns, corporate branding, and the distinction between interface and implementation. Jung's term literally means 'mask' (from Latin theatrical masks)."
+    },
+    {
+      "slug": "the-anima-animus",
+      "name": "The Anima / Animus",
+      "kind": "archetype",
+      "source_frame": "mythology",
+      "target_frame": "creative-tension",
+      "categories": [
+        "psychology",
+        "organizational-behavior",
+        "arts-and-culture"
+      ],
+      "source": "archive",
+      "archive_refs": {
+        "cw9_1": "Concerning the Archetypes, with Special Reference to the Anima Concept",
+        "cw9_2": "Aion, Chapter 3: The Syzygy: Anima and Animus",
+        "wikipedia": "Anima and animus"
+      },
+      "description": "The inner complement -- the contrasexual aspect of the psyche that bridges conscious and unconscious. Maps onto creative tension in cross-functional teams, the relationship between analytical and intuitive modes, and the productive friction between complementary perspectives. Requires careful handling of Jung's gender essentialism in the 'Where It Breaks' section."
+    },
+    {
+      "slug": "the-hero",
+      "name": "The Hero",
+      "kind": "archetype",
+      "source_frame": "mythology",
+      "target_frame": "social-roles",
+      "categories": [
+        "psychology",
+        "organizational-behavior",
+        "arts-and-culture"
+      ],
+      "source": "archive",
+      "archive_refs": {
+        "cw9_1": "The Psychology of the Child Archetype (Child God and Child Hero)",
+        "cw5": "Symbols of Transformation (hero myth analysis)",
+        "wikipedia": "Hero",
+        "pearson": "The Warrior / Hero archetype"
+      },
+      "description": "The journey, the protagonist, the founder myth. Maps onto startup founder narratives, hero culture in engineering (hero-driven development), and the monomyth structure in product storytelling. The most commercially exploited Jungian archetype."
+    },
+    {
+      "slug": "the-great-mother",
+      "name": "The Great Mother",
+      "kind": "archetype",
+      "source_frame": "mythology",
+      "target_frame": "nurturing-and-creation",
+      "categories": [
+        "psychology",
+        "organizational-behavior",
+        "systems-thinking"
+      ],
+      "source": "archive",
+      "archive_refs": {
+        "cw9_1": "Psychological Aspects of the Mother Archetype (full essay)",
+        "wikipedia": "Mother goddess",
+        "neumann": "Erich Neumann, The Great Mother (1955)"
+      },
+      "description": "Nurturing, creation, dependency, and the devouring aspect. Maps onto platforms (nurturing ecosystem but creating dependency), organizational culture as mother figure, and the dual nature of protective systems that also constrain. Jung's CW9.1 devotes its longest essay to this archetype."
+    },
+    {
+      "slug": "the-wise-old-man",
+      "name": "The Wise Old Man",
+      "kind": "archetype",
+      "source_frame": "mythology",
+      "target_frame": "authority-and-mentorship",
+      "categories": [
+        "psychology",
+        "organizational-behavior"
+      ],
+      "source": "archive",
+      "archive_refs": {
+        "cw9_1": "The Phenomenology of the Spirit in Fairytales",
+        "wikipedia": "Mentor",
+        "pearson": "The Sage archetype"
+      },
+      "description": "Authority, mentorship, and accumulated wisdom. Maps onto legacy systems (deprecated but containing irreplaceable knowledge), senior engineers as institutional memory, and the tension between wisdom and obsolescence. Jung discusses this as 'the spirit' archetype in fairytales -- the old man who appears at the threshold with guidance."
+    },
+    {
+      "slug": "the-divine-child",
+      "name": "The Divine Child",
+      "kind": "archetype",
+      "source_frame": "mythology",
+      "target_frame": "potential-and-emergence",
+      "categories": [
+        "psychology",
+        "organizational-behavior"
+      ],
+      "source": "archive",
+      "archive_refs": {
+        "cw9_1": "The Psychology of the Child Archetype (full essay)",
+        "wikipedia": "Child archetype",
+        "pearson": "The Innocent archetype"
+      },
+      "description": "Potential, new beginnings, and the futurity of the archetype. Maps onto greenfield projects, startup energy, the junior engineer's fresh perspective, and the paradox of the vulnerable-yet-invincible new thing. Jung emphasizes both the abandonment motif (the child left to fend for itself) and the invincibility motif (the child that survives against all odds)."
+    },
+    {
+      "slug": "the-maiden",
+      "name": "The Maiden (Kore)",
+      "kind": "archetype",
+      "source_frame": "mythology",
+      "target_frame": "potential-and-emergence",
+      "categories": [
+        "psychology",
+        "arts-and-culture"
+      ],
+      "source": "archive",
+      "archive_refs": {
+        "cw9_1": "The Psychological Aspects of the Kore (full essay)",
+        "wikipedia": "Puer aeternus"
+      },
+      "description": "Innocence, untested potential, and the threshold of transformation. Maps onto untested systems, the junior engineer before first production incident, and products before market contact. Jung pairs the Kore with the Mother as complementary aspects of the feminine archetype. The Persephone myth (descent and return) is the defining narrative."
+    },
+    {
+      "slug": "the-senex",
+      "name": "The Senex (Crone)",
+      "kind": "archetype",
+      "source_frame": "mythology",
+      "target_frame": "authority-and-mentorship",
+      "categories": [
+        "psychology",
+        "organizational-behavior"
+      ],
+      "source": "llm",
+      "archive_refs": {
+        "note": "Not a standalone essay in CW9.1. The Senex is the polar opposite of the Puer Aeternus, developed primarily by James Hillman in post-Jungian archetypal psychology. Jung discusses the pattern in The Phenomenology of the Spirit in Fairytales but does not use the term 'senex' as a label."
+      },
+      "description": "Wisdom through age, rigidity, and the tension between preservation and stagnation. Maps onto deprecated-but-valuable knowledge, legacy codebases, institutional processes that once served well but now constrain. The Senex-Puer polarity (order vs. chaos, age vs. youth) is one of the most productive structural tensions in organizational analysis."
+    },
+    {
+      "slug": "the-shapeshifter",
+      "name": "The Shapeshifter",
+      "kind": "archetype",
+      "source_frame": "mythology",
+      "target_frame": "social-roles",
+      "categories": [
+        "psychology",
+        "organizational-behavior",
+        "software-engineering"
+      ],
+      "source": "llm",
+      "archive_refs": {
+        "note": "Not a standalone archetype in Jung's CW9.1. The Shapeshifter appears in Christopher Vogler's 'The Writer's Journey' (1992) as a narrative archetype derived from Campbell's monomyth, which itself draws on Jung. The shapeshifting quality is discussed by Jung as an attribute of the Anima/Animus and Trickster rather than a standalone archetype."
+      },
+      "description": "Adaptability, polymorphism, and identity fluidity. Maps onto the consultant who adapts to each client's culture, polymorphic code, and organizational roles that shift based on context. Structurally related to the Persona (masks) and Trickster (boundary-crossing) but emphasizes continuous transformation rather than transgression."
+    }
+  ]
+}

--- a/playbooks/jungian-archetypes/playbook.md
+++ b/playbooks/jungian-archetypes/playbook.md
@@ -1,0 +1,252 @@
+---
+project_issue: 8
+repo: metaphorex/metaphorex
+source_type: book
+status: draft
+---
+
+# Playbook: Jungian Archetypes
+
+## Source Description
+
+Carl Gustav Jung's theory of archetypes, developed across the Collected
+Works but concentrated in:
+
+- **CW9.1**: *The Archetypes and the Collective Unconscious* (1959) --
+  the primary source. Contains dedicated essays on the Mother, Child,
+  Kore (Maiden), Spirit (Wise Old Man), and Trickster archetypes, plus
+  theoretical foundations and the individuation process.
+- **CW9.2**: *Aion: Researches into the Phenomenology of the Self* (1951)
+  -- the Self, Shadow, Anima/Animus, and Syzygy.
+- **CW7**: *Two Essays on Analytical Psychology* -- the Persona.
+- **CW5**: *Symbols of Transformation* -- the Hero myth.
+- *Man and His Symbols* (1964) -- posthumous popular overview, especially
+  Henderson's "Ancient Myths and Modern Man."
+
+Secondary sources that systematize Jung's archetypes for applied use:
+- Carol Pearson, *Awakening the Heroes Within* (1991) -- the 12-archetype
+  system (Innocent, Orphan, Warrior, Caregiver, Seeker, Lover, Destroyer,
+  Creator, Sage, Jester, Magician, Ruler)
+- Erich Neumann, *The Great Mother* (1955) -- exhaustive study of the
+  Mother archetype
+- James Hillman, various works -- post-Jungian archetypal psychology,
+  especially the Senex-Puer polarity
+
+Important: Jung explicitly stated that archetypes cannot be exhaustively
+enumerated. The candidate list represents the **core named figures** that
+appear consistently across Jung's writings and have demonstrable cross-domain
+structural parallels. This is a finite, scoped extraction -- not an attempt
+to catalog every archetypal pattern Jung ever discussed.
+
+## Access Method
+
+### Primary Archives
+
+**Wikipedia Category: Jungian archetypes**
+URL: https://en.wikipedia.org/wiki/Category:Jungian_archetypes
+
+Enumerates 17 archetype articles. Provides structured descriptions,
+cross-references to Jung's works, and bibliographic citations. Used to
+verify which archetypes have established academic recognition as distinct
+Jungian constructs.
+
+**IAAP Collected Works Abstracts (Vol. 9.1)**
+URL: https://iaap.org/resources/academic-resources/collected-works-abstracts/volume-9-1-archetypes-collective-unconscious/
+
+The International Association for Analytical Psychology hosts chapter-level
+abstracts of Jung's collected works. CW9.1's table of contents confirms
+which archetypes Jung devoted full essays to:
+1. Psychological Aspects of the Mother Archetype
+2. The Psychology of the Child Archetype
+3. The Psychological Aspects of the Kore
+4. The Phenomenology of the Spirit in Fairytales (Wise Old Man)
+5. On the Psychology of the Trickster-Figure
+
+**Scott Jeffrey: Classic Jungian Archetypes**
+URL: https://scottjeffrey.com/classic-jungian-archetypes/
+
+Secondary compilation that lists 15+ archetypes with CW citations. Cross-
+referenced against CW9.1 and CW9.2 to verify each archetype's provenance.
+
+**Carol Pearson's 12-Archetype System**
+URL: https://carolspearson.com/about/the-pearson-12-archetype-system-human-development-and-evolution
+
+Pearson's system bridges Jung's clinical archetypes to branding and narrative.
+Used to identify which Jungian archetypes have active cross-domain usage in
+commercial and organizational contexts.
+
+### Cross-Reference Methodology
+
+Each candidate was verified against at least two of the following:
+1. CW9.1 or CW9.2 table of contents (archetype has a dedicated essay)
+2. Wikipedia Category:Jungian_archetypes (archetype has a standalone article)
+3. Scott Jeffrey's compilation (archetype included with CW citations)
+4. Pearson's 12-archetype system (archetype has commercial/narrative usage)
+
+Candidates present in the CW table of contents are tagged `source: "archive"`.
+Candidates from secondary Jungian literature without a CW essay are tagged
+`source: "llm"` (the Senex and Shapeshifter).
+
+### Already in Catalog (1 entry -- skipped)
+
+- `the-trickster` -- seed entry, high quality, serves as quality bar
+
+## Extraction Strategy
+
+### For Miners
+
+Each candidate in the manifest has:
+- `slug`: filename for `catalog/mappings/{slug}.md`
+- `name`: human-readable archetype name
+- `kind`: `archetype` (all entries)
+- `source_frame`: `mythology` (all entries -- archetypes originate in
+  mythological/psychic structures)
+- `target_frame`: the modern domain where the archetype's structural
+  parallels are most productive
+- `archive_refs`: dict of primary source citations (CW essay titles,
+  Wikipedia articles, Pearson equivalents)
+- `description`: brief note on cross-domain mappings to develop
+
+**Miner workflow:**
+
+1. Read `the-trickster` entry as the quality bar. Match its depth,
+   structural rigor, and tone -- especially the "Where It Breaks" section.
+2. For each candidate, consult the `archive_refs` to identify the primary
+   Jungian source material. The CW essay titles tell you exactly where
+   Jung discusses the archetype.
+3. Write structural parallels as bullet points in "What It Brings" --
+   each parallel should name the mythological pattern AND its modern
+   counterpart (see the Trickster's "boundary crosser," "rule breaker as
+   rule revealer," "sacred fool," "generative destruction" pattern).
+4. "Where It Breaks" is the most important section. Every Jungian
+   archetype has real limitations when mapped onto modern systems. Common
+   failure modes:
+   - **Gender essentialism** (especially Anima/Animus, Mother, Maiden)
+   - **Cultural specificity presented as universal** (Jung's examples
+     are overwhelmingly European/Christian)
+   - **Romanticization of the archetype** (Hero worship, Shadow
+     mystification)
+   - **Flattening complexity** (reducing rich psychic structures to
+     personality types or brand categories)
+5. "Expressions" should include real-world terms that invoke the archetype:
+   "shadow IT," "hero culture," "persona non grata," "greenfield project,"
+   etc. These should be documented phrases, not invented examples.
+6. Cross-reference `related:` links within the Jungian set and to existing
+   catalog entries (especially `the-trickster` and `the-commons`).
+
+### Batching Recommendation
+
+Process in structural clusters:
+
+- **Batch 1 -- The Psychic Structure (4):** the-self, the-shadow,
+  the-persona, the-anima-animus. These are Jung's four core structural
+  archetypes that describe the psyche's architecture. They relate to each
+  other as a system.
+- **Batch 2 -- The Figures (4):** the-hero, the-great-mother,
+  the-wise-old-man, the-divine-child. These are the named figures that
+  appear in myths and dreams. They map more directly onto narrative and
+  organizational roles.
+- **Batch 3 -- The Extended Set (3):** the-maiden, the-senex,
+  the-shapeshifter. These require more careful sourcing (the Senex is
+  post-Jungian, the Shapeshifter is Vogler/Campbell-derived).
+
+### Frame Inventory
+
+**Existing reusable frames:**
+- `mythology` -- source frame for all entries
+- `social-roles` -- target for Persona, Hero, Shapeshifter
+
+**New frames needed:**
+- `integration-and-wholeness` -- target for the Self
+- `hidden-knowledge` -- target for the Shadow
+- `creative-tension` -- target for Anima/Animus
+- `nurturing-and-creation` -- target for Great Mother
+- `authority-and-mentorship` -- target for Wise Old Man, Senex
+- `potential-and-emergence` -- target for Divine Child, Maiden
+
+These frames are cheap to create and structurally justified. Each captures
+a distinct target domain that multiple archetypes (and future mappings)
+can reference.
+
+### Categories
+
+All entries get `psychology` as primary category. Additional categories
+per entry are specified in the manifest. The most common secondary
+categories are:
+- `organizational-behavior` -- for archetypes with strong org-design parallels
+- `arts-and-culture` -- for archetypes prominent in narrative/branding
+- `software-engineering` -- for archetypes with direct software pattern parallels
+- `systems-thinking` -- for archetypes that describe system-level dynamics
+
+## Schema Mapping
+
+### Kind Assignment
+
+All candidates are `kind: archetype`. This is consistent with the existing
+`the-trickster` entry and with the Metaphorex schema, which defines
+archetype as a valid kind alongside conceptual-metaphor, design-pattern,
+paradigm, cross-field-mapping, and dead-metaphor.
+
+### Author
+
+All entries should use `author: jung` (or `author: jung-hillman` for the
+Senex, `author: vogler-campbell` for the Shapeshifter).
+
+## Gotchas
+
+1. **The Trickster already exists.** It is a seed entry and the quality bar
+   for this project. Miners should read it first and match its depth. New
+   entries should cross-reference it in `related:`.
+
+2. **Gender essentialism is a real problem.** The Anima/Animus archetype
+   and the Mother/Maiden archetypes carry gender assumptions from 1920s-
+   1950s Swiss psychiatry. The "Where It Breaks" sections must address
+   this directly, not euphemistically. The structural insight (complementary
+   inner aspects, creative tension) survives the critique; the gendered
+   framing does not.
+
+3. **Cultural specificity.** Jung's "universals" are drawn overwhelmingly
+   from European mythology, Christian symbolism, and alchemical texts. The
+   archetypes DO appear cross-culturally (the Trickster is the strongest
+   example) but the specific expressions Jung uses are culturally bounded.
+   Miners should note this and include non-European expressions where
+   possible.
+
+4. **The Pearson/branding flattening.** Carol Pearson's 12-archetype system
+   and its branding derivatives (Harley-Davidson as "The Outlaw," Apple as
+   "The Magician") have made these archetypes ubiquitous in marketing. This
+   is useful context but should not be the primary framing. The entries
+   should privilege Jung's structural depth over Pearson's applied
+   simplification.
+
+5. **The Senex and Shapeshifter are LLM-sourced.** The Senex comes from
+   post-Jungian archetypal psychology (primarily Hillman), not from Jung's
+   own named archetypes. The Shapeshifter comes from Vogler/Campbell
+   narrative theory. Both have strong cross-domain mappings but the Surveyor
+   should verify that their inclusion is warranted given the project's
+   Jungian scope.
+
+6. **No structured digital archive exists.** Unlike the Osaka University
+   Metaphor List for Lakoff, there is no single HTML/JSON/CSV database of
+   Jungian archetypes. The candidate list was compiled by cross-referencing
+   the CW9.1 table of contents, Wikipedia's category page, and secondary
+   compilations. The extraction script encodes these sources deterministically
+   but cannot "scrape" a canonical list the way the MWLB playbook does.
+
+7. **11 candidates is well under the 100 sub-issue cap.** No overflow
+   handling needed.
+
+8. **The Self is abstract.** Unlike the Hero or Shadow, the Self archetype
+   is not a figure but a structural principle (integration, wholeness,
+   mandala symbolism). The Miner will need to work harder to find concrete
+   cross-domain mappings. Organizational mission statements, system
+   architecture's "single source of truth," and the concept of personal
+   integration are the most productive mapping targets.
+
+9. **Related entries in the catalog.** Beyond `the-trickster`, several
+   existing entries have structural connections:
+   - `the-facade-pattern` -- structural parallel to the Persona
+   - `technical-debt` -- structural parallel to the Shadow
+   - `the-commons` -- archetypal thinking about shared resources
+   - `creating-is-birthing` -- structural parallel to the Great Mother
+   - `people-are-plants` -- developmental metaphors related to the Child

--- a/playbooks/jungian-archetypes/scripts/extract_archetypes.py
+++ b/playbooks/jungian-archetypes/scripts/extract_archetypes.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""
+Extract Jungian archetype candidates for the Metaphorex catalog.
+
+Sources cross-referenced:
+1. Jung, C.G. Collected Works Vol. 9 Part 1: The Archetypes and the
+   Collective Unconscious (1959) -- table of contents and chapter structure
+2. Wikipedia Category:Jungian_archetypes -- enumerated list of archetype
+   articles (accessed 2025)
+3. Scott Jeffrey, "15+ Classic Jungian Archetypes" (scottjeffrey.com) --
+   secondary compilation from Jungian primary sources
+4. Carol Pearson, "Awakening the Heroes Within" (1991) -- the 12-archetype
+   system that popularized Jung's archetypes in branding/narrative contexts
+
+The issue (#8) scopes to Jung's CORE archetypes as figures/structures that
+function as cross-domain mappings in modern discourse. This is NOT the
+exhaustive list of all archetypes ever discussed (which Jung said was
+infinite) but the canonical set that appears consistently across:
+- Jung's own writings (CW9.1, CW9.2 Aion, Man and His Symbols)
+- Secondary Jungian literature (von Franz, Hillman, Pearson)
+- Cross-domain usage (branding, storytelling, organizational behavior)
+
+Usage:
+    python3 extract_archetypes.py > candidates.json
+"""
+
+import json
+import sys
+
+# ── Primary source: CW9.1 table of contents ──────────────────────────────
+# Each essay in CW9.1 addresses specific archetypes. These are the
+# archetypes that Jung devoted full chapters to.
+CW9_1_ARCHETYPES = {
+    "mother": {
+        "essay": "Psychological Aspects of the Mother Archetype",
+        "sections": [
+            "On the Concept of the Archetype",
+            "The Mother-Complex of the Son",
+            "The Mother-Complex of the Daughter",
+            "Positive Aspects of the Mother-Complex",
+        ],
+    },
+    "child": {
+        "essay": "The Psychology of the Child Archetype",
+        "sections": [
+            "The Archetype as Link with the Past",
+            "The Function of the Archetype",
+            "The Futurity of the Archetype",
+            "Child God and Child Hero",
+            "Abandonment, Invincibility, Hermaphroditism, Beginning and End",
+        ],
+    },
+    "kore": {
+        "essay": "The Psychological Aspects of the Kore",
+        "sections": [],
+    },
+    "spirit": {
+        "essay": "The Phenomenology of the Spirit in Fairytales",
+        "sections": [],
+        "note": "Maps to the Wise Old Man / Senex archetype",
+    },
+    "trickster": {
+        "essay": "On the Psychology of the Trickster-Figure",
+        "sections": [],
+    },
+}
+
+# ── CW9.2 (Aion) archetypes ──────────────────────────────────────────────
+# Aion focuses on the Self and its constituent archetypes
+CW9_2_ARCHETYPES = ["self", "shadow", "anima", "animus", "syzygy"]
+
+# ── Wikipedia Category:Jungian_archetypes ─────────────────────────────────
+# Full enumeration of articles in the category (accessed 2025):
+WIKIPEDIA_JUNGIAN_ARCHETYPES = [
+    "Anima and animus",
+    "Apollo archetype",
+    "Apollonian and Dionysian",
+    "Child archetype",
+    "Cosmic Man",
+    "Goddess",
+    "Hero",
+    "Jester",
+    "Magician",
+    "Martyr",
+    "Mentor",
+    "Mother goddess",
+    "Persona (psychology)",
+    "Puer aeternus",
+    "Self (Jung)",
+    "Shadow (psychology)",
+    "Trickster",
+]
+
+# ── Candidate definitions ─────────────────────────────────────────────────
+# Each candidate maps a Jungian archetype to its cross-domain structural
+# parallels. The issue (#8) specifies the scope; we add the Shapeshifter
+# and Senex which appear in secondary Jungian literature and have strong
+# cross-domain mappings.
+
+CANDIDATES = [
+    {
+        "slug": "the-self",
+        "name": "The Self",
+        "kind": "archetype",
+        "source_frame": "mythology",
+        "target_frame": "integration-and-wholeness",
+        "categories": ["psychology", "organizational-behavior", "systems-thinking"],
+        "source": "archive",
+        "archive_refs": {
+            "cw9_1": "Conscious, Unconscious, and Individuation; A Study in the Process of Individuation; Concerning Mandala Symbolism",
+            "cw9_2": "Aion: Researches into the Phenomenology of the Self (entire volume)",
+            "wikipedia": "Self (Jung)",
+        },
+        "description": "The archetype of wholeness and integration -- the "
+        "organizing center of the psyche that transcends ego. Maps onto "
+        "system architecture (the unified system vs. its components), "
+        "organizational identity (mission as integrating principle), and "
+        "the individuation process in personal development.",
+    },
+    {
+        "slug": "the-shadow",
+        "name": "The Shadow",
+        "kind": "archetype",
+        "source_frame": "mythology",
+        "target_frame": "hidden-knowledge",
+        "categories": ["psychology", "organizational-behavior", "software-engineering"],
+        "source": "archive",
+        "archive_refs": {
+            "cw9_2": "Aion, Chapter 2: The Shadow",
+            "wikipedia": "Shadow (psychology)",
+        },
+        "description": "The denied, repressed, or unacknowledged aspects of "
+        "self or system. Maps onto technical debt, shadow IT, organizational "
+        "denial, and the gap between stated values and actual behavior. "
+        "The most structurally productive Jungian archetype for modern "
+        "organizational analysis.",
+    },
+    {
+        "slug": "the-persona",
+        "name": "The Persona",
+        "kind": "archetype",
+        "source_frame": "mythology",
+        "target_frame": "social-roles",
+        "categories": ["psychology", "organizational-behavior", "software-engineering"],
+        "source": "archive",
+        "archive_refs": {
+            "cw7": "Two Essays on Analytical Psychology, Chapter 2: The Persona",
+            "wikipedia": "Persona (psychology)",
+        },
+        "description": "The social mask -- the public-facing identity adopted "
+        "for social interaction. Maps onto public APIs, facade patterns, "
+        "corporate branding, and the distinction between interface and "
+        "implementation. Jung's term literally means 'mask' (from Latin "
+        "theatrical masks).",
+    },
+    {
+        "slug": "the-anima-animus",
+        "name": "The Anima / Animus",
+        "kind": "archetype",
+        "source_frame": "mythology",
+        "target_frame": "creative-tension",
+        "categories": ["psychology", "organizational-behavior", "arts-and-culture"],
+        "source": "archive",
+        "archive_refs": {
+            "cw9_1": "Concerning the Archetypes, with Special Reference to the Anima Concept",
+            "cw9_2": "Aion, Chapter 3: The Syzygy: Anima and Animus",
+            "wikipedia": "Anima and animus",
+        },
+        "description": "The inner complement -- the contrasexual aspect of the "
+        "psyche that bridges conscious and unconscious. Maps onto creative "
+        "tension in cross-functional teams, the relationship between "
+        "analytical and intuitive modes, and the productive friction between "
+        "complementary perspectives. Requires careful handling of Jung's "
+        "gender essentialism in the 'Where It Breaks' section.",
+    },
+    {
+        "slug": "the-hero",
+        "name": "The Hero",
+        "kind": "archetype",
+        "source_frame": "mythology",
+        "target_frame": "social-roles",
+        "categories": ["psychology", "organizational-behavior", "arts-and-culture"],
+        "source": "archive",
+        "archive_refs": {
+            "cw9_1": "The Psychology of the Child Archetype (Child God and Child Hero)",
+            "cw5": "Symbols of Transformation (hero myth analysis)",
+            "wikipedia": "Hero",
+            "pearson": "The Warrior / Hero archetype",
+        },
+        "description": "The journey, the protagonist, the founder myth. Maps "
+        "onto startup founder narratives, hero culture in engineering "
+        "(hero-driven development), and the monomyth structure in product "
+        "storytelling. The most commercially exploited Jungian archetype.",
+    },
+    {
+        "slug": "the-great-mother",
+        "name": "The Great Mother",
+        "kind": "archetype",
+        "source_frame": "mythology",
+        "target_frame": "nurturing-and-creation",
+        "categories": ["psychology", "organizational-behavior", "systems-thinking"],
+        "source": "archive",
+        "archive_refs": {
+            "cw9_1": "Psychological Aspects of the Mother Archetype (full essay)",
+            "wikipedia": "Mother goddess",
+            "neumann": "Erich Neumann, The Great Mother (1955)",
+        },
+        "description": "Nurturing, creation, dependency, and the devouring "
+        "aspect. Maps onto platforms (nurturing ecosystem but creating "
+        "dependency), organizational culture as mother figure, and the "
+        "dual nature of protective systems that also constrain. Jung's "
+        "CW9.1 devotes its longest essay to this archetype.",
+    },
+    {
+        "slug": "the-wise-old-man",
+        "name": "The Wise Old Man",
+        "kind": "archetype",
+        "source_frame": "mythology",
+        "target_frame": "authority-and-mentorship",
+        "categories": ["psychology", "organizational-behavior"],
+        "source": "archive",
+        "archive_refs": {
+            "cw9_1": "The Phenomenology of the Spirit in Fairytales",
+            "wikipedia": "Mentor",
+            "pearson": "The Sage archetype",
+        },
+        "description": "Authority, mentorship, and accumulated wisdom. Maps "
+        "onto legacy systems (deprecated but containing irreplaceable "
+        "knowledge), senior engineers as institutional memory, and the "
+        "tension between wisdom and obsolescence. Jung discusses this as "
+        "'the spirit' archetype in fairytales -- the old man who appears "
+        "at the threshold with guidance.",
+    },
+    {
+        "slug": "the-divine-child",
+        "name": "The Divine Child",
+        "kind": "archetype",
+        "source_frame": "mythology",
+        "target_frame": "potential-and-emergence",
+        "categories": ["psychology", "organizational-behavior"],
+        "source": "archive",
+        "archive_refs": {
+            "cw9_1": "The Psychology of the Child Archetype (full essay)",
+            "wikipedia": "Child archetype",
+            "pearson": "The Innocent archetype",
+        },
+        "description": "Potential, new beginnings, and the futurity of the "
+        "archetype. Maps onto greenfield projects, startup energy, the "
+        "junior engineer's fresh perspective, and the paradox of the "
+        "vulnerable-yet-invincible new thing. Jung emphasizes both the "
+        "abandonment motif (the child left to fend for itself) and the "
+        "invincibility motif (the child that survives against all odds).",
+    },
+    {
+        "slug": "the-maiden",
+        "name": "The Maiden (Kore)",
+        "kind": "archetype",
+        "source_frame": "mythology",
+        "target_frame": "potential-and-emergence",
+        "categories": ["psychology", "arts-and-culture"],
+        "source": "archive",
+        "archive_refs": {
+            "cw9_1": "The Psychological Aspects of the Kore (full essay)",
+            "wikipedia": "Puer aeternus",
+        },
+        "description": "Innocence, untested potential, and the threshold of "
+        "transformation. Maps onto untested systems, the junior engineer "
+        "before first production incident, and products before market "
+        "contact. Jung pairs the Kore with the Mother as complementary "
+        "aspects of the feminine archetype. The Persephone myth (descent "
+        "and return) is the defining narrative.",
+    },
+    {
+        "slug": "the-senex",
+        "name": "The Senex (Crone)",
+        "kind": "archetype",
+        "source_frame": "mythology",
+        "target_frame": "authority-and-mentorship",
+        "categories": ["psychology", "organizational-behavior"],
+        "source": "llm",
+        "archive_refs": {
+            "note": "Not a standalone essay in CW9.1. The Senex is the "
+            "polar opposite of the Puer Aeternus, developed primarily by "
+            "James Hillman in post-Jungian archetypal psychology. Jung "
+            "discusses the pattern in The Phenomenology of the Spirit in "
+            "Fairytales but does not use the term 'senex' as a label.",
+        },
+        "description": "Wisdom through age, rigidity, and the tension between "
+        "preservation and stagnation. Maps onto deprecated-but-valuable "
+        "knowledge, legacy codebases, institutional processes that once "
+        "served well but now constrain. The Senex-Puer polarity (order "
+        "vs. chaos, age vs. youth) is one of the most productive "
+        "structural tensions in organizational analysis.",
+    },
+    {
+        "slug": "the-shapeshifter",
+        "name": "The Shapeshifter",
+        "kind": "archetype",
+        "source_frame": "mythology",
+        "target_frame": "social-roles",
+        "categories": ["psychology", "organizational-behavior", "software-engineering"],
+        "source": "llm",
+        "archive_refs": {
+            "note": "Not a standalone archetype in Jung's CW9.1. The "
+            "Shapeshifter appears in Christopher Vogler's 'The Writer's "
+            "Journey' (1992) as a narrative archetype derived from "
+            "Campbell's monomyth, which itself draws on Jung. The "
+            "shapeshifting quality is discussed by Jung as an attribute "
+            "of the Anima/Animus and Trickster rather than a standalone "
+            "archetype.",
+        },
+        "description": "Adaptability, polymorphism, and identity fluidity. "
+        "Maps onto the consultant who adapts to each client's culture, "
+        "polymorphic code, and organizational roles that shift based on "
+        "context. Structurally related to the Persona (masks) and "
+        "Trickster (boundary-crossing) but emphasizes continuous "
+        "transformation rather than transgression.",
+    },
+]
+
+# ── Existing catalog entries to exclude ───────────────────────────────────
+ALREADY_IN_CATALOG = {"the-trickster"}
+
+
+def build_manifest():
+    """Build the manifest from the candidate definitions."""
+    candidates = []
+    for c in CANDIDATES:
+        if c["slug"] in ALREADY_IN_CATALOG:
+            continue
+        candidates.append(c)
+
+    return {
+        "project": "jungian-archetypes",
+        "project_issue": 8,
+        "source_type": "archive",
+        "archive_urls": [
+            "https://en.wikipedia.org/wiki/Category:Jungian_archetypes",
+            "https://en.wikipedia.org/wiki/Jungian_archetypes",
+            "https://scottjeffrey.com/classic-jungian-archetypes/",
+            "https://iaap.org/resources/academic-resources/collected-works-abstracts/volume-9-1-archetypes-collective-unconscious/",
+            "https://carolspearson.com/about/the-pearson-12-archetype-system-human-development-and-evolution",
+        ],
+        "candidates": candidates,
+    }
+
+
+def main():
+    manifest = build_manifest()
+    json.dump(manifest, sys.stdout, indent=2)
+    print()  # trailing newline
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds playbook, manifest, and extraction script for the Jungian archetypes import project (issue #8)
- 11 archetype candidates: The Self, Shadow, Persona, Anima/Animus, Hero, Great Mother, Wise Old Man, Divine Child, Maiden (Kore), Senex, Shapeshifter
- 9 candidates sourced from structured archives (CW9.1/CW9.2 table of contents, Wikipedia Category:Jungian_archetypes, IAAP abstracts, Scott Jeffrey compilation)
- 2 candidates LLM-sourced with clear provenance notes (Senex from Hillman's post-Jungian work, Shapeshifter from Vogler/Campbell)
- The Trickster excluded as it already exists in the catalog as a seed entry and serves as quality bar

## Archive sources cross-referenced

- IAAP Collected Works Vol. 9.1 abstracts (chapter-level archetype coverage)
- Wikipedia Category:Jungian_archetypes (17 articles enumerated)
- Scott Jeffrey: 15+ Classic Jungian Archetypes (secondary compilation with CW citations)
- Carol Pearson's 12-Archetype System (branding/narrative cross-domain usage)

## Test plan

- [x] `uv run scripts/validate.py validate` passes (zero errors, pre-existing warnings only)
- [ ] Surveyor reviews manifest completeness against CW9.1 table of contents
- [ ] Surveyor verifies LLM-sourced entries (the-senex, the-shapeshifter) are warranted

Closes: n/a (this is a prospect PR, not a close)
Parent issue: #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)