### PR TITLE
Add mapping: patch

### DIFF
--- a/catalog/mappings/patch.md
+++ b/catalog/mappings/patch.md
@@ -1,0 +1,121 @@
+---
+slug: patch
+name: "Patch"
+kind: dead-metaphor
+source_frame: textiles
+target_frame: software-programs
+categories:
+  - software-engineering
+  - linguistics
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - spaghetti-code
+  - technical-debt
+---
+
+## What It Brings
+
+A software patch is a piece of cloth sewn over a hole in fabric. The
+metaphor maps textile repair onto code repair with surprising structural
+fidelity: something tore, you cut a piece to fit the gap, you stitch it
+in place. The result is functional but visibly mended -- you can always
+tell where the patch was applied.
+
+- **Repair over replacement** -- the core import is that you fix what
+  exists rather than reweaving the whole garment. Patching assumes the
+  original is worth preserving and that local repair is more practical
+  than starting over. This is the fundamental economic logic of software
+  maintenance: the cost of a targeted fix is orders of magnitude less
+  than a rewrite.
+- **Materiality of code** -- the metaphor treats software as a physical
+  substance that can tear and be mended. This was literally true in the
+  punched-card era: programmers placed adhesive tape over incorrect holes
+  and punched new ones -- actual patches on actual cards. The physical
+  practice preceded the metaphor; the word followed the hands.
+- **Accumulation as degradation** -- "patchwork" carries a connotation
+  of declining quality. A quilt of patches is serviceable but not
+  elegant. The metaphor imports this judgment directly: heavily patched
+  software is understood to be fragile, inconsistent, and due for
+  replacement. "It's just patch on patch" is a condemnation.
+
+## Where It Breaks
+
+- **Patches don't change the fabric's behavior** -- a textile patch
+  restores the original function of the garment. A software patch often
+  changes behavior: adding features, modifying logic, altering
+  interfaces. The metaphor frames all code changes as repair, even when
+  they are evolution. "Feature patch" is almost oxymoronic in the
+  textile domain but routine in software. This conflation of repair and
+  enhancement has practical consequences: teams that think of all changes
+  as patches may underinvest in design, treating every modification as
+  a quick mend rather than a deliberate alteration.
+- **Textile patches are local; software patches propagate** -- sewing a
+  patch onto a sleeve does not affect the collar. But a software patch
+  can have cascading effects throughout a codebase. The spatial locality
+  that makes textile patching safe does not hold for code. The metaphor
+  encourages a false sense of containment: this change is "just a patch,"
+  implying bounded impact. Regression bugs are the reality the metaphor
+  hides.
+- **The original was designed; the patch is expedient** -- in textiles,
+  the garment was crafted with intent and the patch is a concession to
+  damage. The metaphor smuggles in the assumption that the original code
+  was good and the patch is a lesser substitute. In practice, patches
+  sometimes improve on the original, fixing not just the immediate
+  defect but correcting design flaws the original author missed. The
+  textile metaphor cannot encode improvement -- only restoration.
+- **Digital patches are invisible when applied** -- a cloth patch is
+  always visible. A well-applied software patch leaves no seam. The
+  metaphor's core image -- the visible mend, the patchwork quilt of
+  fixes -- does not match how modern version control works. After merge,
+  the patch disappears into the codebase. You need `git blame` to find
+  the stitch marks.
+
+## Expressions
+
+- "Apply a patch" -- the standard verb, inherited directly from textile
+  work (you apply a patch to fabric with adhesive or stitching)
+- "Patch Tuesday" -- Microsoft's monthly security update cycle, where the
+  regularity of the schedule has made patching feel like routine
+  maintenance rather than emergency repair
+- "Hotfix" -- an emergency patch applied to a live system, where the heat
+  metaphor (hot = in production) layers onto the textile metaphor
+- "Patchwork" -- accumulated fixes that create an inconsistent whole,
+  carrying the textile connotation of visible, mismatched repairs
+- "Patch it up" -- colloquial for a quick, imperfect fix, used
+  interchangeably for software, relationships, and physical objects
+- "Unpatched vulnerability" -- a known hole in the fabric that has not
+  yet been covered, where the defensive urgency maps directly from
+  exposed skin to exposed system
+
+## Origin Story
+
+The textile origin is ancient: Old English *plaece*, Old French *pieche*,
+a piece of cloth used to mend a garment. The word carried connotations of
+poverty (patched clothing meant you could not afford new) and pragmatism
+(patching extended useful life).
+
+In computing, the literal-to-metaphorical transition was unusually
+physical. Programmers working with punched cards and paper tape in the
+1940s and 1950s literally patched their programs: placing adhesive tape
+over incorrectly punched holes and punching correct ones nearby. The word
+"patch" described the physical act before it described the conceptual one.
+When programs moved to magnetic storage and then to networked code
+repositories, the word followed -- but the physical referent vanished.
+
+By the 1970s, "patch" was standard computing vocabulary. The Unix `patch`
+utility, written by Larry Wall in 1985, formalized the metaphor into a
+tool: it reads a diff file and applies changes to source code. The tool's
+name completed the abstraction. Nobody using `patch -p1 < fix.diff` is
+thinking about cloth, tape, or punched cards. The metaphor is thoroughly
+dead.
+
+## References
+
+- Wall, L. "patch -- apply a diff file to an original" (1985) -- the
+  Unix utility that cemented the term in software practice
+- Raymond, E. S. *The New Hacker's Dictionary* (1996) -- documents the
+  punched-card origin of the term
+- Etymonline, "patch (n.)" -- traces the textile word to Old English and
+  Old French sources


### PR DESCRIPTION
## Summary

- Adds dead-metaphor entry for **patch** (textiles -> software-programs)
- Traces the metaphor from textile repair through punched-card tape to modern version control
- All frames and categories already exist in catalog

Closes #914

## Validator output

```
All content valid.
```

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors

Generated with [Claude Code](https://claude.com/claude-code)