### PR TITLE
Add mapping: virus

### DIFF
--- a/catalog/mappings/virus.md
+++ b/catalog/mappings/virus.md
@@ -1,0 +1,141 @@
+---
+slug: virus
+name: "Virus"
+kind: dead-metaphor
+source_frame: medicine
+target_frame: computing
+categories:
+  - software-engineering
+  - security
+  - linguistics
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - firewall
+---
+
+## What It Brings
+
+A computer virus is a self-replicating program that spreads by inserting
+copies of itself into other programs or files. The biological metaphor
+maps with unusual structural precision: biological viruses replicate by
+hijacking host cells' machinery; computer viruses replicate by hijacking
+host programs' execution. The name did not just label the phenomenon --
+it imported an entire framework for understanding and responding to it.
+
+- **Epidemiological thinking** -- the metaphor brought the full apparatus
+  of disease science into computer security. Infection vectors, patient
+  zero, quarantine, inoculation, herd immunity, mutation, epidemic
+  threshold -- the entire vocabulary of virology transferred to
+  cybersecurity because the structural parallels were strong enough to
+  support it. This was not decorative naming; it was conceptual
+  scaffolding that shaped how researchers modeled the problem.
+- **Self-replication as the defining trait** -- biological viruses are
+  defined by their inability to reproduce independently; they need a
+  host. Computer viruses are likewise defined by parasitic replication:
+  they cannot run without a host program. This structural parallel is
+  the core of the metaphor and the reason it works better than
+  alternatives like "pest" or "intruder." The replication mechanism is
+  the mapping, not just the harmfulness.
+- **The immune-system response** -- the metaphor structured the defense
+  industry. Antivirus software scans for known signatures (like
+  antibodies recognizing antigens), maintains databases of known threats
+  (like immunological memory), and quarantines suspicious files (like
+  isolating infected patients). The entire antivirus industry's
+  architecture mirrors clinical medicine because the virus metaphor
+  made that architecture thinkable.
+
+## Where It Breaks
+
+- **Viruses are not authored** -- biological viruses evolve through
+  natural selection. They have no designer, no intent, no target. Computer
+  viruses are written by humans with specific goals: espionage, ransom,
+  destruction, notoriety. The metaphor erases the attacker. "Your system
+  has a virus" sounds like a natural misfortune, like catching a cold.
+  It obscures the fact that a person deliberately created and deployed the
+  malware. This framing has real consequences: it makes cyberattacks feel
+  like weather events rather than criminal acts.
+- **Biological evolution outpaces the metaphor** -- biological viruses
+  mutate randomly and are selected by fitness. Early computer viruses
+  were static: identical copies spreading unchanged. The metaphor
+  initially overpromised by implying mutation and evolution that did not
+  exist. Then reality caught up -- polymorphic viruses that change their
+  code with each infection, metamorphic viruses that rewrite themselves
+  entirely -- and the metaphor became accidentally accurate. The
+  convergence was coincidence, not prediction.
+- **The immune model fails at scale** -- biological immune systems are
+  decentralized, adaptive, and self-organizing. Antivirus software is
+  centralized (signature databases maintained by companies), reactive
+  (new viruses must be identified before they can be detected), and
+  brittle (a novel virus evades all existing signatures). The immune
+  metaphor promised adaptive defense but delivered static pattern
+  matching. The gap between biological and computational "immunity"
+  is where most security failures live.
+- **"Virus" became a folk category** -- the precise biological mapping
+  (self-replication via host hijacking) dissolved into a general term for
+  any malicious software. Trojans, worms, ransomware, spyware -- users
+  call them all "viruses" despite fundamental structural differences. A
+  worm replicates independently (no host needed), which makes it
+  precisely *not* a virus in the biological mapping. The metaphor's
+  success killed its precision. "Malware" was coined to escape the
+  collapsing category, but "virus" persists as the folk term.
+
+## Expressions
+
+- "Infected" -- a system carrying a virus, mapping biological infection
+  directly onto computational compromise
+- "Quarantine" -- isolating a suspicious file, as hospitals isolate
+  patients to prevent spread
+- "Antivirus" -- defensive software named by direct analogy to medical
+  intervention
+- "Virus definition update" -- refreshing the signature database, like
+  updating a medical reference with newly identified pathogens
+- "Worm" -- a self-replicating program that spreads without a host, where
+  the zoological metaphor replaced the medical one because the biological
+  mapping no longer fit (worms are independent organisms, not parasites)
+- "Going viral" -- the metaphor's escape from computing back into general
+  culture, where it describes rapid, uncontrolled spread of information
+  rather than of malicious code
+
+## Origin Story
+
+Fred Cohen, a graduate student at the University of Southern California,
+coined "computer virus" in 1983 in a paper supervised by Len Adleman (the
+"A" in RSA cryptography). Cohen defined it precisely: "a program that can
+infect other programs by modifying them to include a possibly evolved copy
+of itself." The biological parallel was deliberate and structural. Adleman
+reportedly suggested the name "virus" because Cohen's programs exhibited
+the same reproductive parasitism as biological viruses.
+
+The metaphor was not entirely new. Science fiction had imagined digital
+infections (the 1972 novel *When HARLIE Was One* described a program that
+spread between computers), and the term "worm" was already in use for
+self-replicating network programs after the Xerox PARC experiments of
+1982. But Cohen's formalization gave "virus" its technical definition and
+its epidemiological framework.
+
+The Brain virus (1986), created by two Pakistani brothers as a copyright
+protection measure, is generally considered the first PC virus found in
+the wild. By the early 1990s, the antivirus industry was established, and
+the vocabulary was fixed: infection, detection, disinfection, quarantine.
+The biological metaphor was dead within a decade of its coining -- users
+said "virus" as a technical term, not a figure of speech.
+
+The metaphor's second death came when "virus" expanded to cover all
+malware. By the 2000s, actual self-replicating viruses were a minority of
+threats, but "virus" remained the public's word for any malicious
+software. The precise biological mapping that justified the original name
+had dissolved into a generic synonym for digital harm.
+
+## References
+
+- Cohen, F. "Computer Viruses" (PhD dissertation, 1986; first presented
+  1983) -- the founding formalization of the concept and the name
+- Adleman, L. "An Abstract Theory of Computer Viruses," *Advances in
+  Cryptology* (1988) -- mathematical formalization by the namer
+- Spafford, E. "The Internet Worm Program: An Analysis," *Purdue
+  Technical Report* (1988) -- the Morris Worm analysis that established
+  the virus/worm distinction
+- Szor, P. *The Art of Computer Virus Research and Defense* (2005) --
+  comprehensive reference that uses the biological framework throughout


### PR DESCRIPTION
## Summary

- Adds dead-metaphor entry for **virus** (medicine -> computing)
- Traces from biological virology through Cohen's 1983 coining to the modern malware folk category
- Documents how the metaphor imported epidemiological thinking into cybersecurity
- All frames and categories already exist in catalog

Closes #916

## Validator output

```
All content valid.
```

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors

Generated with [Claude Code](https://claude.com/claude-code)