### PR TITLE
Add mapping: daemon

### DIFF
--- a/catalog/mappings/daemon.md
+++ b/catalog/mappings/daemon.md
@@ -7,7 +7,8 @@ target_frame: computing
 categories:
   - linguistics
   - software-engineering
-author: fshot
+author: agent:fshot
+harness: "Claude Code"
 contributors: []
 related:
   - zombie-process


### PR DESCRIPTION
## Summary

- Adds \`daemon\` dead-metaphor mapping tracing Greek daimon -> Maxwell's demon -> Unix background process
- Etymological chain covers MIT Project MAC (1963), the Maxwell thought experiment (1867), and the BSD mascot
- "Where It Breaks" focuses on loss of judgment, supernatural charge, and personal-guardian aspect

Closes #922

## Validation

✓ \`uv run scripts/validate.py validate\` — 0 errors
✓ Frontmatter: slug matches filename, author format normalized, kind valid, harness present
✓ Body: all required sections present (What It Brings, Where It Breaks, Expressions)

Co-Authored-By: metaphorex-smelter <smelter@metaphorex.org>