### PR TITLE
Add mapping: software-development-is-cathedral-building

### DIFF
--- a/catalog/mappings/software-development-is-cathedral-building.md
+++ b/catalog/mappings/software-development-is-cathedral-building.md
@@ -1,0 +1,108 @@
+---
+slug: software-development-is-cathedral-building
+name: "Software Development Is Cathedral Building"
+kind: conceptual-metaphor
+source_frame: architecture-and-building
+target_frame: software-engineering
+categories:
+  - software-engineering
+  - organizational-behavior
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - survival-of-the-fittest
+---
+
+## What It Brings
+
+Raymond's cathedral model from "The Cathedral and the Bazaar" (1997) names
+the dominant mode of commercial software development: a single architect
+holds the vision, a small team of trusted builders executes it, and the
+product is revealed to the world only when the architect declares it
+complete. The metaphor draws its power from the literal cathedral --
+Notre-Dame took nearly two centuries, but the master builder's plan held.
+
+Key structural parallels:
+
+- **Architect as visionary authority** -- one person (or a small committee)
+  controls the design. Contributors don't negotiate the floor plan; they
+  execute it. In software, this maps to the lead developer or project
+  manager who owns the spec and arbitrates design disputes by fiat.
+- **Blueprint as specification** -- the cathedral starts with detailed plans
+  before the first stone is cut. Waterfall development, with its
+  requirements documents and design reviews, is the software expression
+  of this: specify completely, then build.
+- **Construction phases as release cycles** -- foundations, walls, roof,
+  ornament. Each phase depends on the previous one and cannot be
+  reordered. The software analog is the milestone-driven release
+  schedule where v1.0 ships only when everything is "finished."
+- **Consecration as ship date** -- the cathedral is closed to the public
+  until it is ritually completed. Software ships when the architect says
+  it is ready, not when users start using it. No beta. No early access.
+  Emacs and GCC before the open-source era followed this model.
+
+The metaphor privileges coherence, aesthetic unity, and top-down control.
+When it works -- when the architect is skilled and the requirements are
+stable -- the result has an integrity that bazaar-style development
+rarely achieves.
+
+## Where It Breaks
+
+- **Cathedrals are built for God; software is built for users who change
+  their minds** -- the cathedral metaphor assumes fixed requirements.
+  A cathedral's purpose (worship) doesn't shift mid-construction, but
+  software requirements mutate constantly. The metaphor makes requirement
+  changes feel like heresy rather than normal feedback.
+- **The architect bottleneck** -- a real cathedral's master builder could
+  inspect every stone. Software at scale exceeds any single person's
+  comprehension. The metaphor encourages hero-architect culture, where
+  the project's bus factor is one and knowledge hoarding is structural,
+  not personal.
+- **Cathedrals took centuries; software ships in months** -- the metaphor
+  imports a timescale that makes late delivery feel noble. "We're
+  building a cathedral" becomes a rationalization for missed deadlines
+  rather than a sign that the plan was wrong.
+- **The revelation model hides bugs** -- if you don't show the building
+  until it's done, you don't discover that the nave is too narrow until
+  the consecration. Raymond's central argument was precisely this: the
+  cathedral model systematically delays feedback, making bugs harder and
+  more expensive to find.
+- **Cathedrals are singular; software is copyable** -- a cathedral is
+  site-specific and non-reproducible. Software can be forked, copied,
+  and distributed at zero marginal cost. The metaphor imports scarcity
+  and preciousness where neither applies.
+
+## Expressions
+
+- "Software architect" -- the most durable cathedral-frame expression,
+  now a formal job title that carries implicit authority over design
+- "Master plan" -- a comprehensive upfront design that subordinates all
+  subsequent work
+- "Waterfall development" -- the process methodology most aligned with
+  cathedral building; each phase flows downward like construction stages
+- "Big reveal" -- shipping a complete product after long internal
+  development, no public beta
+- "Build it right the first time" -- the cathedral assumption that
+  rework is failure, not iteration
+- "Grand unified rewrite" -- the cathedral impulse applied to legacy
+  systems: tear it down and build a new cathedral from scratch
+
+## Origin Story
+
+Eric S. Raymond introduced the cathedral-versus-bazaar contrast in his
+1997 essay "The Cathedral and the Bazaar," later expanded into a book
+(1999). He used the cathedral as a foil: GNU Emacs and GCC were his
+examples of cathedral-style projects, where a small group of developers
+worked in isolation between major releases. Raymond argued that Linus
+Torvalds had discovered a better model (the bazaar), but the cathedral
+metaphor stuck as the name for the older approach -- and it resonated
+because commercial software development had always implicitly operated
+under cathedral assumptions without having a name for them.
+
+## References
+
+- Raymond, E. S. "The Cathedral and the Bazaar" (1997; book edition 1999)
+- Brooks, F. P. *The Mythical Man-Month* (1975) -- the cathedral model's
+  implicit bible, especially the "surgical team" chapter
+- Spolsky, J. "Things You Should Never Do, Part I" (2000) -- critique of
+  the grand-rewrite cathedral impulse


### PR DESCRIPTION
## Summary

- Adds `software-development-is-cathedral-building` mapping from Eric Raymond's "The Cathedral and the Bazaar" (1997)
- Cathedral model: centralized, architect-driven, waterfall-style development mapped through cathedral construction
- Uses existing `architecture-and-building` and `software-engineering` frames

Closes #1002

## Validator output

```
All content valid.
```

(27 pre-existing dangling-reference warnings, no new warnings or errors)

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors
- [ ] Assayer reviews mapping quality and "Where It Breaks" depth

Generated with [Claude Code](https://claude.com/claude-code)