### PR TITLE
Add mapping: cyberspace-is-a-place

### DIFF
--- a/catalog/mappings/cyberspace-is-a-place.md
+++ b/catalog/mappings/cyberspace-is-a-place.md
@@ -1,0 +1,143 @@
+---
+slug: cyberspace-is-a-place
+name: "Cyberspace Is a Place"
+kind: dead-metaphor
+source_frame: spatial-location
+target_frame: network-communication
+categories:
+  - social-dynamics
+  - computer-science
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - the-internet-is-a-mine
+---
+
+## What It Brings
+
+William Gibson coined "cyberspace" in his 1984 novel *Neuromancer*,
+describing it as "a consensual hallucination experienced daily by billions."
+Within a decade the word had migrated from science fiction to law, policy,
+and everyday speech. The metaphor is now so deeply dead that we navigate
+websites, visit pages, enter chat rooms, and go to addresses without
+noticing that every one of these verbs implies physical movement through
+physical space. The internet is not a place. But we cannot talk about it
+without pretending it is.
+
+Key structural parallels:
+
+- **Navigation as movement** -- we "go to" websites, "visit" pages,
+  "browse" the web, "surf" the net. The spatial metaphor maps physical
+  locomotion onto the act of requesting data from servers. This is not
+  merely decorative language: it shapes interface design (back buttons,
+  breadcrumb trails, site maps) and user cognition (people report feeling
+  "lost" on complex websites).
+- **Sites as locations** -- a "website" is a site, a place where something
+  is situated. A "home page" is where you live online. An "address" (URL)
+  tells you where to find something. The metaphor maps the postal/geographic
+  system of locations and addresses onto the technical system of servers
+  and resource identifiers, making the abstract infrastructure feel as
+  concrete as a street grid.
+- **Boundaries and territories** -- "firewalls" create perimeters.
+  "Domains" stake out territory. "Gateways" control entry. The spatial
+  metaphor imports the entire apparatus of territorial sovereignty --
+  borders, jurisdictions, trespass -- onto network architecture. This has
+  real legal consequences: courts debate whether "entering" a computer
+  system constitutes trespass, importing property law into a domain where
+  nothing physical is entered.
+- **Depth and surface** -- we speak of the "surface web" and the "deep
+  web," the "dark web" as a hidden underground. The spatial metaphor maps
+  vertical depth onto accessibility: what is easy to find is on the
+  surface; what requires special tools is deep or dark. This vertical
+  axis imports moral connotations (darkness as danger, depth as secrecy)
+  that shape public perception of non-indexed internet content.
+
+## Where It Breaks
+
+- **There is no space** -- the fundamental break. Data does not exist in
+  a place. When you "visit" a website, your browser sends an HTTP request
+  to a server that may be anywhere on earth, receives a response, and
+  renders it locally. Nothing moves through space except electromagnetic
+  signals. The spatial metaphor conceals the actual mechanics of
+  networking -- packet switching, DNS resolution, TCP handshakes -- behind
+  a comfortable fiction of travel and arrival.
+- **The metaphor implies distance, but the internet has almost none** --
+  a server in Tokyo and a server in the next room are equally "far" in
+  network terms (latency differences are milliseconds). The spatial
+  metaphor imports the idea that remote things are harder to reach, which
+  was true of physical libraries but is false of networked information.
+  This import occasionally causes real confusion: people assume that
+  "local" data is more accessible than "remote" data, when accessibility
+  depends on permissions, not proximity.
+- **"Cyberspace" suggests a single unified space** -- Gibson's cyberspace
+  was a shared virtual environment. The real internet is radically
+  fragmented: walled gardens, paywalls, national firewalls, incompatible
+  platforms, and proprietary protocols create a patchwork, not a commons.
+  The spatial metaphor's implication of a single navigable territory
+  obscures this fragmentation and the power structures that produce it.
+- **The metaphor struggles with copies and simultaneity** -- in physical
+  space, an object is in one place at a time. On the internet, the "same"
+  content can exist on thousands of servers simultaneously, be cached at
+  every node, and be modified independently at each copy. The spatial
+  metaphor has no vocabulary for this: you cannot "visit" something that
+  is everywhere at once. This breaks the postal-address model at its
+  foundation.
+- **Jurisdiction becomes incoherent** -- the spatial metaphor imports
+  territorial law (if it is "in" a country, that country's laws apply).
+  But data on the internet crosses jurisdictions constantly, exists in
+  multiple jurisdictions simultaneously, and can be accessed from anywhere.
+  The legal fiction that cyberspace is a place with borders has produced
+  decades of jurisdictional confusion that the metaphor itself cannot
+  resolve.
+
+## Expressions
+
+- "Go to this website" -- the most common spatial expression, treating
+  data retrieval as physical travel
+- "Visit a page" -- the tourism metaphor applied to information access
+- "Chat room" -- a spatial container for conversation, now largely
+  replaced by "channel" (still spatial, but linear rather than enclosed)
+- "The information superhighway" -- the 1990s spatial metaphor that
+  preceded "cyberspace" in popular discourse, mapping the internet onto
+  road infrastructure
+- "Deep web" and "dark web" -- depth and darkness as spatial properties
+  of internet content that is not indexed by search engines
+- "Digital footprint" -- traces left behind as you move through
+  cyberspace, importing the tracking metaphor from physical space
+- "Surf the web" -- recreation and movement combined, treating internet
+  use as riding waves across a surface
+- "Online" and "offline" -- being in or out of cyberspace, as if it were
+  a location one enters and exits
+
+## Origin Story
+
+William Gibson coined "cyberspace" in his 1982 short story "Burning
+Chrome" and developed it fully in *Neuromancer* (1984), where it
+described a three-dimensional virtual reality that users experienced as
+a navigable space. The word combined "cybernetics" (Wiener's term for
+control and communication systems) with "space" to create a neologism
+that felt both technical and experiential. The term was adopted by
+internet culture in the early 1990s, well before the technology
+resembled Gibson's vision, because it provided exactly the cognitive
+scaffold people needed: a way to think about networked information as
+a place they could go. John Perry Barlow's "A Declaration of the
+Independence of Cyberspace" (1996) took the spatial metaphor to its
+political extreme, treating the internet as a sovereign territory.
+The metaphor's power is demonstrated by the fact that even its critics
+cannot escape it -- the entire vocabulary of internet regulation
+(domain, site, address, gateway, firewall, traffic) is spatial.
+
+## References
+
+- Gibson, W. *Neuromancer* (1984) -- the source text that defined
+  cyberspace as a spatial concept
+- Barlow, J.P. "A Declaration of the Independence of Cyberspace" (1996)
+  -- the political apotheosis of the spatial metaphor
+- Lakoff, G. "The Contemporary Theory of Metaphor" (1993) -- theoretical
+  framework for understanding spatial metaphors as conceptual structures
+- Johnson, D. & Post, D. "Law and Borders: The Rise of Law in
+  Cyberspace" (1996) -- analysis of how the spatial metaphor shapes
+  internet law
+- Adams, P. "Cyberspace and Virtual Places" (1997) -- geographic analysis
+  of the spatial metaphor's implications


### PR DESCRIPTION
## Summary

- Adds dead-metaphor mapping for cyberspace as a place, tracing Gibson's 1984 neologism through the spatial vocabulary of internet discourse
- Uses existing `spatial-location` and `network-communication` frames
- Resolves #1026

## Validation

✓ `uv run scripts/validate.py validate` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
