### PR TITLE
Add mapping: brave-new-world-is-technological-control

### DIFF
--- a/catalog/frames/dystopian-fiction.md
+++ b/catalog/frames/dystopian-fiction.md
@@ -1,0 +1,26 @@
+---
+slug: dystopian-fiction
+name: "Dystopian Fiction"
+related:
+  - narrative
+  - governance
+  - surveillance
+roles:
+  - authoritarian-regime
+  - oppressed-population
+  - forbidden-knowledge
+  - resistance
+  - propaganda
+  - dehumanization
+  - warning
+---
+
+Imagined societies organized around the systematic failure of human
+flourishing. Dystopian fiction provides a repertoire of named worlds --
+Oceania, the World State, the Matrix -- that function as compressed
+arguments about where current trends lead. As a source domain, dystopian
+fiction is unusually powerful because its scenarios are designed to be
+memorable and emotionally vivid: they are cautionary tales engineered for
+metaphorical reuse. When someone calls a policy "Orwellian" or a technology
+"Frankensteinian," they are importing not just an analogy but an entire
+narrative arc -- the warning, the hubris, the catastrophic consequence.

--- a/catalog/frames/social-control.md
+++ b/catalog/frames/social-control.md
@@ -1,0 +1,25 @@
+---
+slug: social-control
+name: "Social Control"
+related:
+  - governance
+  - surveillance
+  - social-behavior
+roles:
+  - controller
+  - controlled-population
+  - mechanism-of-compliance
+  - distraction
+  - conditioning
+  - consent
+  - resistance
+---
+
+The management of populations through mechanisms that shape behavior,
+desire, and belief rather than through direct coercion alone. Social
+control includes both hard mechanisms (law, punishment, surveillance) and
+soft ones (entertainment, conditioning, manufactured consent, chemical
+pacification). The frame's analytical power lies in its attention to
+invisible control -- systems that work best when the controlled population
+does not recognize them as control at all. As a target domain, it draws
+on dystopian fiction, behaviorist psychology, and critical theory.

--- a/catalog/mappings/brave-new-world-is-technological-control.md
+++ b/catalog/mappings/brave-new-world-is-technological-control.md
@@ -1,0 +1,140 @@
+---
+slug: brave-new-world-is-technological-control
+name: "Brave New World Is Technological Control"
+kind: conceptual-metaphor
+source_frame: dystopian-fiction
+target_frame: social-control
+categories:
+  - social-dynamics
+  - arts-and-culture
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - guardrails
+  - culture-as-a-control-system
+---
+
+## What It Brings
+
+Aldous Huxley published *Brave New World* in 1932, imagining a society
+controlled not through pain but through pleasure -- genetic engineering,
+conditioning, and the drug soma keeping the population docile and happy.
+Where Orwell's *Nineteen Eighty-Four* warns about the boot stamping on a
+face, Huxley warns about the face smiling because it has been chemically
+and socially engineered to enjoy its subjugation. The metaphor remains
+active -- people still consciously reference the novel -- but it has
+grown increasingly apt as technology has shifted from surveillance
+(Orwell's territory) to engagement optimization (Huxley's).
+
+Key structural parallels:
+
+- **Control through pleasure, not pain** -- the World State does not
+  punish deviance; it engineers desire so that deviance never occurs.
+  The metaphor maps this onto technologies designed to maximize
+  engagement: algorithmic feeds that give users exactly what they want,
+  gamification that turns compliance into reward, pharmaceutical
+  management of mood and attention. The critical insight is that the most
+  effective control is the kind the controlled enjoy.
+- **Soma as universal pacifier** -- Huxley's fictional drug eliminates
+  unhappiness without side effects. The metaphor maps soma onto any
+  technology that numbs critical awareness: social media as distraction,
+  streaming entertainment as escape, prescription medication as emotional
+  management. "Digital soma" has become a common phrase in technology
+  criticism.
+- **Pre-natal conditioning as determinism** -- in the World State,
+  citizens are biologically engineered for their social role before birth.
+  The metaphor maps this onto algorithmic systems that sort and categorize
+  people early: educational tracking, credit scoring, predictive policing,
+  recommendation engines that narrow options before the user has chosen.
+  The structural import is that the system decides who you are before you
+  have the chance to decide for yourself.
+- **Voluntary surrender of freedom** -- Huxley's citizens do not rebel
+  because they do not want to. The metaphor maps this onto the
+  observation that users willingly trade privacy for convenience, autonomy
+  for recommendation, and critical thought for curated content. The
+  dystopia is not imposed; it is chosen.
+
+## Where It Breaks
+
+- **Huxley's control was total and centralized; modern soft control is
+  fragmented** -- the World State is a single global government with
+  unified control over biology, psychology, and culture. Modern
+  technological control is distributed across competing platforms,
+  corporations, and governments with different and often contradictory
+  goals. There is no single World Controller -- the control emerges from
+  the interaction of many systems, none of which individually resembles
+  Huxley's totalitarian design. This fragmentation makes the control
+  harder to see and harder to resist, but it also produces cracks and
+  contradictions that Huxley's world does not have.
+- **The metaphor underestimates human resistance** -- Huxley's
+  conditioning works perfectly on everyone except a handful of natural
+  misfits. Real humans are messier: people delete social media, protest
+  algorithmic injustice, refuse pharmaceutical interventions, and actively
+  resist engagement optimization. The Brave New World frame treats
+  technological seduction as irresistible, which is both empirically
+  wrong and politically disempowering -- it tells people they cannot
+  fight back.
+- **Pleasure is not inherently a control mechanism** -- the metaphor
+  implies that enjoyment is suspicious, that if you like a technology it
+  is probably manipulating you. This imports a puritanical logic that
+  conflates pleasure with submission. Many technologies that people enjoy
+  are genuinely beneficial. The Brave New World frame has no way to
+  distinguish between soma (pleasure engineered to prevent thought) and
+  genuine human flourishing through technology.
+- **The novel's class structure does not map cleanly** -- Huxley's caste
+  system (Alphas through Epsilons) is genetically fixed and openly
+  acknowledged. Modern technological stratification is more fluid, more
+  denied, and more complex. The metaphor can gesture at digital divides
+  and algorithmic sorting, but the clean correspondence between Huxley's
+  castes and modern social stratification breaks down under scrutiny.
+- **Huxley could not imagine user-generated content** -- the World State
+  controls all cultural production. Modern platforms are distinctive
+  precisely because users produce the content that controls them. The
+  Brave New World metaphor has no structural element for this reflexivity
+  -- the controlled population simultaneously being the entertainment
+  workforce.
+
+## Expressions
+
+- "Brave new world" -- often used ironically to describe a technological
+  future that is impressive but unsettling, importing Huxley's title as
+  a warning label
+- "Digital soma" -- labeling any technology that distracts or pacifies
+  users, from social media infinite scroll to streaming services
+- "Amusing ourselves to death" -- Neil Postman's phrase (itself a
+  reference to Huxley) for the displacement of civic engagement by
+  entertainment
+- "We were worried about Orwell, but we got Huxley" -- the comparative
+  formulation, arguing that modern control operates through pleasure
+  rather than fear
+- "Conditioned to like it" -- invoking Huxley's hypnopaedia to describe
+  users who defend the systems that exploit them
+
+## Origin Story
+
+Huxley wrote *Brave New World* in 1931 partly in response to the utopian
+technological optimism of H.G. Wells, whom he admired but distrusted.
+The novel drew on Huxley's observations of American consumer culture,
+Fordist mass production (Henry Ford is the World State's deity), and
+early behaviorist psychology (John B. Watson's claims about conditioning).
+The title comes from Shakespeare's *The Tempest* -- Miranda's wondering
+"O brave new world, that has such people in't!" -- already ironic in
+Shakespeare and doubly so in Huxley. The novel's relevance surged in
+the 2010s as technology critics like Neil Postman (*Amusing Ourselves to
+Death*, 1985), Nicholas Carr (*The Shallows*, 2010), and Tristan Harris
+(Center for Humane Technology) argued that Huxley's pleasure-based
+control model had proved more prophetic than Orwell's pain-based one.
+
+## References
+
+- Huxley, A. *Brave New World* (1932) -- the source text
+- Postman, N. *Amusing Ourselves to Death* (1985) -- argues that Huxley
+  was more prescient than Orwell about television culture
+- Huxley, A. *Brave New World Revisited* (1958) -- Huxley's own
+  reassessment, arguing his dystopia was arriving faster than expected
+- Carr, N. *The Shallows: What the Internet Is Doing to Our Brains*
+  (2010) -- digital soma argument applied to internet use
+- Zuboff, S. *The Age of Surveillance Capitalism* (2019) -- bridges
+  Orwell and Huxley by analyzing both surveillance and behavioral
+  modification


### PR DESCRIPTION
## Summary

- Adds conceptual-metaphor mapping for Brave New World as technological control through pleasure, tracing Huxley's 1932 novel into modern engagement-optimization discourse
- Creates new `social-control` frame and `dystopian-fiction` frame
- Resolves #1027

## Validation

✓ `uv run scripts/validate.py validate` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
