### PR TITLE
Add mapping: the-matrix-is-hidden-reality

### DIFF
--- a/catalog/frames/dystopian-fiction.md
+++ b/catalog/frames/dystopian-fiction.md
@@ -1,0 +1,26 @@
+---
+slug: dystopian-fiction
+name: "Dystopian Fiction"
+related:
+  - narrative
+  - governance
+  - surveillance
+roles:
+  - authoritarian-regime
+  - oppressed-population
+  - forbidden-knowledge
+  - resistance
+  - propaganda
+  - dehumanization
+  - warning
+---
+
+Imagined societies organized around the systematic failure of human
+flourishing. Dystopian fiction provides a repertoire of named worlds --
+Oceania, the World State, the Matrix -- that function as compressed
+arguments about where current trends lead. As a source domain, dystopian
+fiction is unusually powerful because its scenarios are designed to be
+memorable and emotionally vivid: they are cautionary tales engineered for
+metaphorical reuse. When someone calls a policy "Orwellian" or a technology
+"Frankensteinian," they are importing not just an analogy but an entire
+narrative arc -- the warning, the hubris, the catastrophic consequence.

--- a/catalog/mappings/the-matrix-is-hidden-reality.md
+++ b/catalog/mappings/the-matrix-is-hidden-reality.md
@@ -1,0 +1,141 @@
+---
+slug: the-matrix-is-hidden-reality
+name: "The Matrix Is Hidden Reality"
+kind: conceptual-metaphor
+source_frame: dystopian-fiction
+target_frame: hidden-knowledge
+categories:
+  - philosophy
+  - arts-and-culture
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - culture-as-a-control-system
+---
+
+## What It Brings
+
+The Wachowskis released *The Matrix* in 1999, and within a year "taking
+the red pill" had become a metaphor for seeing through comfortable
+illusions to the uncomfortable truth beneath. The film dramatizes an
+ancient philosophical structure -- Plato's cave, Descartes's evil demon,
+the Gnostic demiurge -- but gives it a modern technological wrapper that
+has proved extraordinarily productive as a source domain. People now
+"take the red pill" about economics, politics, diet, religion, and
+virtually any domain where they believe consensus reality conceals a
+deeper truth.
+
+Key structural parallels:
+
+- **Consensus reality as constructed illusion** -- the Matrix is a
+  computer simulation designed to keep humans docile while their bodies
+  are harvested for energy. The metaphor maps this onto any situation
+  where the official account of reality is believed to be a deliberate
+  fabrication: mainstream media as manufactured narrative, consumer
+  culture as engineered distraction, institutional authority as
+  performance concealing power. The structural import is that what
+  everyone accepts as real is precisely what should be questioned.
+- **The red pill as irreversible enlightenment** -- Morpheus offers Neo
+  a choice: the blue pill returns him to comfortable ignorance, the red
+  pill reveals the truth. The metaphor maps this onto any moment of
+  disillusionment that cannot be undone. Once you see the hidden reality,
+  you cannot unsee it. This structure has been adopted across the
+  political spectrum, from radical left critiques of capitalism to
+  far-right conspiracy theories, precisely because its form is
+  content-independent.
+- **The architect behind the simulation** -- the Matrix has designers who
+  deliberately construct the illusion. The metaphor imports intentionality:
+  someone is behind the curtain, maintaining the false reality for their
+  benefit. This maps onto conspiracy thinking generally, but also onto
+  legitimate structural critiques -- the idea that social systems are
+  designed to serve specific interests while appearing neutral.
+- **The small band of awakened resisters** -- Neo, Morpheus, and Trinity
+  see what the masses cannot. The metaphor maps this onto any group that
+  considers itself enlightened while the majority sleeps: activists,
+  whistleblowers, contrarians, conspiracy theorists. The structural
+  flattery of the metaphor -- you are Neo, everyone else is a battery --
+  is a major part of its appeal and its danger.
+
+## Where It Breaks
+
+- **The Matrix has a binary structure; real hidden knowledge rarely
+  does** -- in the film, you are either in the Matrix or out of it,
+  asleep or awake, blue pill or red pill. Real epistemological situations
+  are almost never this clean. Knowledge is partial, perspectives are
+  multiple, and "waking up" from one illusion often means walking into
+  another. The binary frame makes the metaphor satisfying but
+  epistemologically dangerous -- it encourages the belief that once you
+  have found the hidden truth, your work is done.
+- **The metaphor flatters the user** -- the Matrix frame positions the
+  speaker as Neo: special, chosen, able to see what the masses cannot.
+  This narcissistic structure makes it a favorite of conspiracy theories,
+  cult leaders, and anyone who wants to claim epistemic superiority
+  without doing the work of evidence and argument. The metaphor provides
+  a ready-made framework for dismissing disagreement ("they're still in
+  the Matrix") that is structurally unfalsifiable.
+- **The film's hidden reality is unambiguously real; real "hidden truths"
+  are contested** -- in the Matrix, the desert of the real is objectively
+  there. In actual epistemology, competing claims about hidden reality
+  are themselves subject to error, bias, and manipulation. The metaphor
+  imports a naive realism (there is one true reality behind the veil)
+  that most serious philosophy has abandoned.
+- **"Red pill" has been politically captured** -- the term has been
+  adopted by specific political movements (men's rights activists,
+  far-right communities) to describe their particular ideological
+  conversion. This political capture has narrowed the metaphor's
+  usability. For many audiences, "red-pilled" now connotes a specific
+  political orientation rather than a general structure of
+  disillusionment, limiting the metaphor's analytical utility.
+- **The metaphor cannot distinguish legitimate critique from
+  paranoia** -- the Matrix structure works equally well for a
+  whistleblower exposing genuine corruption and for a conspiracy theorist
+  inventing patterns in noise. The metaphor provides no internal
+  mechanism for evaluating whether the "hidden reality" is actually real.
+  This is its deepest structural flaw: it is a form without epistemology.
+
+## Expressions
+
+- "Take the red pill" -- choosing to see uncomfortable truth rather than
+  remain in comfortable ignorance
+- "Still in the Matrix" -- describing someone who has not yet recognized
+  the hidden reality, used dismissively
+- "Red-pilled" -- having undergone the conversion from mainstream belief
+  to an alternative understanding, now politically charged
+- "Glitch in the Matrix" -- a moment where consensus reality breaks down
+  and the constructed nature of the system becomes briefly visible
+- "Wake up" -- the imperative form, urging someone to see through the
+  illusion, drawing on the sleep/waking binary that the Matrix inherits
+  from older enlightenment metaphors
+- "We live in a simulation" -- the literal version of the Matrix metaphor,
+  now a semi-serious philosophical and scientific hypothesis (Bostrom)
+- "Blue pill" -- choosing comfortable ignorance, used to describe
+  deliberate avoidance of inconvenient truths
+
+## Origin Story
+
+*The Matrix* (1999) was written and directed by the Wachowskis, drawing
+explicitly on Jean Baudrillard's *Simulacra and Simulation* (a copy
+appears in the film), Plato's Allegory of the Cave, Descartes's
+skeptical hypotheses, Gnostic theology, and Philip K. Dick's fiction
+about simulated realities. The film's genius as a metaphor source was
+packaging these philosophical traditions into a single, visually
+memorable narrative: a choice between two pills. The red-pill/blue-pill
+structure entered internet culture almost immediately and has since
+proliferated across virtually every domain of discourse. Notably, the
+metaphor has been adopted by communities whose values differ sharply
+from the filmmakers' intentions -- the Wachowskis, both transgender
+women, have expressed discomfort with the red-pill metaphor's adoption
+by far-right and men's rights communities.
+
+## References
+
+- Wachowski, L. & Wachowski, L. *The Matrix* (1999) -- the source text
+- Baudrillard, J. *Simulacra and Simulation* (1981) -- the philosophical
+  text the film explicitly references
+- Bostrom, N. "Are You Living in a Computer Simulation?" (2003) -- the
+  philosophical argument that takes the Matrix premise seriously
+- Irwin, W., ed. *The Matrix and Philosophy* (2002) -- academic analysis
+  of the film's philosophical sources and implications
+- Plato, *Republic*, Book VII -- the Allegory of the Cave, the
+  metaphor's deepest ancestor


### PR DESCRIPTION
## Summary

- Adds conceptual-metaphor mapping for The Matrix as hidden reality, tracing the Wachowskis' 1999 film into red-pill epistemology and hidden-truth discourse
- Creates `dystopian-fiction` frame; uses existing `hidden-knowledge` frame
- Resolves #1028

## Validation

✓ `uv run scripts/validate.py validate` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
