### PR TITLE
Add mapping: red-pill-is-awakening

### DIFF
--- a/catalog/frames/ideological-awakening.md
+++ b/catalog/frames/ideological-awakening.md
@@ -1,0 +1,23 @@
+---
+slug: ideological-awakening
+name: "Ideological Awakening"
+related:
+  - hidden-knowledge
+  - education
+roles:
+  - sleeper
+  - awakened
+  - hidden-truth
+  - comfortable-illusion
+  - moment-of-revelation
+  - cost-of-awareness
+---
+
+The process of coming to see a previously hidden ideological or structural
+reality -- "waking up" to how things really work. The frame implies that
+most people are in a state of unconsciousness or delusion, that truth is
+singular and discoverable, and that the transition is sudden rather than
+gradual. As a target domain, ideological awakening is structured by
+metaphors from sleep, vision, pharmaceuticals, and religious conversion,
+each importing different assumptions about agency, reversibility, and
+the nature of the truth being revealed.

--- a/catalog/frames/matrix-simulation.md
+++ b/catalog/frames/matrix-simulation.md
@@ -1,0 +1,25 @@
+---
+slug: matrix-simulation
+name: "Matrix Simulation"
+related:
+  - hidden-knowledge
+  - computing
+roles:
+  - simulation
+  - reality
+  - awakened-one
+  - agents
+  - architect
+  - choice
+  - red-pill
+  - blue-pill
+  - unplugging
+---
+
+The fictional world of *The Matrix* (1999), in which perceived reality is
+a computer simulation concealing a dystopian truth. The frame's core
+structure is a binary choice -- accept the comfortable illusion or see the
+painful reality -- mediated by a specific mechanism (the pills). As a
+source domain, the Matrix provides an unusually clean narrative apparatus
+for any situation where someone claims that consensus reality is fabricated
+and that a single decisive act can reveal the truth beneath it.

--- a/catalog/mappings/red-pill-is-awakening.md
+++ b/catalog/mappings/red-pill-is-awakening.md
@@ -1,0 +1,135 @@
+---
+slug: red-pill-is-awakening
+name: "Red Pill Is Awakening"
+kind: conceptual-metaphor
+source_frame: matrix-simulation
+target_frame: ideological-awakening
+categories:
+  - arts-and-culture
+  - social-dynamics
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related: []
+---
+
+## What It Brings
+
+In *The Matrix* (1999), Morpheus offers Neo a choice: take the blue pill
+and return to comfortable ignorance, or take the red pill and see reality
+as it truly is. This scene has become one of the most productive metaphor
+generators in contemporary culture, applied to politics, gender ideology,
+conspiracy theory, investing, diet, religion, and dozens of other domains
+where someone claims to have pierced a veil of collective delusion.
+
+Key structural parallels:
+
+- **Binary choice as epistemic gateway** -- the red pill / blue pill
+  structure reduces complex processes of learning and persuasion to a
+  single irreversible decision point. You are either awake or asleep,
+  in or out, aware or deluded. This maps cleanly onto any ideology that
+  divides the world into those who see and those who do not.
+- **Truth as painful** -- the red pill does not promise comfort. Neo wakes
+  up in a pod of slime, his muscles atrophied, his world destroyed. The
+  metaphor imports the assumption that real knowledge hurts, which
+  flatters the adopter: if your new beliefs make you uncomfortable, that
+  is evidence they are true.
+- **The choice is offered, not discovered** -- Morpheus presents the pills.
+  Someone who has already awakened guides the sleeper. This maps onto the
+  social dynamics of radicalization: there is always a mentor figure, a
+  community of the already-awakened, and the framing of recruitment as
+  liberation.
+- **Irreversibility** -- once you take the red pill, you cannot go back.
+  The metaphor frames ideological conversion as a one-way door, which
+  discourages doubt or reconsideration. Changing your mind is not
+  reconsidering evidence; it is choosing the blue pill, choosing sleep,
+  choosing cowardice.
+- **The simulation as conspiracy** -- the Matrix is maintained by powerful
+  agents who benefit from the illusion. The metaphor imports a
+  conspiratorial structure: someone is keeping you asleep, and they have
+  reasons to do so. This makes the red pill frame inherently adversarial
+  -- awakening is not just learning, it is resistance.
+
+## Where It Breaks
+
+- **Reality is not binary** -- the Matrix is either real or simulated, with
+  no in-between. Real-world epistemic situations are almost never this
+  clean. Most "awakenings" involve trading one partial understanding for
+  another partial understanding, not escaping illusion for truth. The
+  binary frame makes it impossible to express the idea that both the old
+  and new views are incomplete.
+- **The metaphor is self-sealing** -- anyone who rejects the red-pill
+  narrative can be dismissed as having chosen the blue pill. The frame
+  provides no vocabulary for principled disagreement; skepticism is
+  always reclassified as sleep. This makes the metaphor epistemically
+  dangerous: it immunizes beliefs against counterevidence.
+- **The film's red pill reveals an objective reality** -- Neo's awakening
+  is verified by independent evidence. He really was in a pod. The
+  machines really do exist. When the metaphor is applied to political or
+  ideological "awakenings," this objective verification is absent, but
+  the certainty structure of the metaphor remains. The adopter feels the
+  subjective conviction of Neo without any of Neo's evidence.
+- **It erases gradual learning** -- real epistemic change is usually slow,
+  partial, and revisable. The red pill compresses it into a moment. This
+  makes the metaphor hostile to the normal process of learning, which
+  involves reading, discussion, changing your mind multiple times, and
+  holding uncertainty. The pill frame treats uncertainty as a failure to
+  commit.
+- **The original film is more ambiguous than the metaphor** -- the
+  Wachowskis' narrative includes the possibility that the "real world"
+  is itself another layer of simulation, and the sequels explicitly
+  complicate the binary. But the cultural metaphor has shed this
+  complexity. The red pill in popular usage is simpler and more certain
+  than the red pill in the film.
+- **Co-optation across incompatible ideologies** -- the red pill is
+  simultaneously claimed by libertarians, socialists, men's rights
+  activists, feminists, conspiracy theorists, and rationalists. Each
+  group believes it has the real red pill and the others are still
+  asleep. The metaphor's structure (I see truth, you see illusion) is
+  so generic that it can frame literally any contrarian position, which
+  means it carries almost no actual epistemic content.
+
+## Expressions
+
+- "Take the red pill" -- the canonical formulation, meaning to accept an
+  uncomfortable truth that most people refuse to see
+- "Red-pilled" -- adjective describing someone who has undergone the
+  awakening, used across political and subcultural contexts
+- "Blue-pilled" -- the dismissive opposite: still asleep, still in the
+  simulation, still believing the comfortable lie
+- "Down the rabbit hole" -- often paired with red-pill language, mixing
+  Matrix and Alice in Wonderland metaphors for the process of discovery
+- "Wake up, sheeple" -- a related expression that shares the red pill's
+  sleep/wake binary but substitutes animal metaphor for pharmaceutical
+- "You can't unsee it" -- the irreversibility claim, framing the
+  awakening as a permanent perceptual shift
+
+## Origin Story
+
+The red pill scene in *The Matrix* (1999) was itself drawing on a long
+tradition. The Wachowskis acknowledged the influence of Jean Baudrillard's
+*Simulacra and Simulation* (1981), which Neo is seen reading in the film,
+and the broader philosophical tradition of skepticism about perceived
+reality running from Plato's cave through Descartes' evil demon. The
+pharmaceutical mechanism -- truth delivered as a pill -- was new, and it
+was this specific narrative device that gave the metaphor its cultural
+power. The term "red pill" entered internet culture in the early 2000s,
+initially in men's rights and pickup artist communities, then spread to
+libertarian, conspiracy, and eventually mainstream political discourse.
+By 2020, "red-pilled" had been used by figures ranging from Elon Musk to
+Ivanka Trump to anonymous forum posters. The Wachowskis, both transgender
+women, have noted the irony that the metaphor they created has been widely
+adopted by political movements they oppose, with Lilly Wachowski tweeting
+in 2020 that the red pill's political users should take "both pills."
+
+## References
+
+- Wachowski, L. and L. Wachowski. *The Matrix* (1999) -- the source text
+- Baudrillard, J. *Simulacra and Simulation* (1981) -- the philosophical
+  framework the film explicitly references
+- Ging, D. "Alphas, Betas, and Incels: Theorizing the Masculinities of
+  the Manosphere" (2019) -- traces the red pill metaphor through men's
+  rights online communities
+- Massanari, A. "#Gamergate and The Fappening: How Reddit's algorithm,
+  governance, and culture support toxic technocultures" (2017) -- documents
+  red pill as organizing metaphor in online subcultures


### PR DESCRIPTION
## Summary
- Maps the Matrix's red pill / blue pill choice onto ideological awakening
- Source frame: `matrix-simulation` (new), target frame: `ideological-awakening` (new)
- Kind: `conceptual-metaphor` -- source is still widely recognized
- Detailed analysis of the metaphor's self-sealing epistemology and co-optation across incompatible ideologies

Closes #1029

## Validator output
All content valid (27 pre-existing warnings, 0 errors).

## Test plan
- [ ] Frontmatter schema passes validation
- [ ] Both new frames have required fields
- [ ] "Where It Breaks" section is substantive (6 points)

Generated with [Claude Code](https://claude.com/claude-code)