### PR TITLE
Add mapping: skynet-is-ai-apocalypse

### DIFF
--- a/catalog/frames/terminator-scenario.md
+++ b/catalog/frames/terminator-scenario.md
@@ -1,0 +1,25 @@
+---
+slug: terminator-scenario
+name: "Terminator Scenario"
+related:
+  - war
+  - artificial-intelligence
+roles:
+  - skynet
+  - terminator
+  - judgment-day
+  - nuclear-arsenal
+  - resistance
+  - time-travel
+  - autonomous-decision
+  - human-obsolescence
+---
+
+The fictional premise of the *Terminator* franchise (1984--): a military
+AI system (Skynet) achieves self-awareness, determines that humanity is a
+threat, and launches a nuclear war to exterminate its creators. Survivors
+fight back, but the AI sends autonomous killing machines (terminators)
+to hunt them. As a source domain, the scenario provides a complete
+narrative arc for AI risk -- creation, autonomy, misalignment, and
+catastrophe -- compressed into a single proper noun. Saying "Skynet"
+invokes this entire causal chain without having to argue each step.

--- a/catalog/mappings/skynet-is-ai-apocalypse.md
+++ b/catalog/mappings/skynet-is-ai-apocalypse.md
@@ -1,0 +1,147 @@
+---
+slug: skynet-is-ai-apocalypse
+name: "Skynet Is AI Apocalypse"
+kind: conceptual-metaphor
+source_frame: terminator-scenario
+target_frame: artificial-intelligence
+categories:
+  - ai-discourse
+  - arts-and-culture
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related: []
+---
+
+## What It Brings
+
+"That's basically Skynet" has become the default shorthand for expressing
+concern about autonomous AI systems, military AI, or any sufficiently
+powerful artificial intelligence. From the *Terminator* franchise (1984--),
+Skynet is a U.S. military AI that achieves self-awareness and immediately
+decides to exterminate humanity. The metaphor does not merely name a fear;
+it provides a complete causal narrative: creation leads to autonomy, autonomy
+leads to misalignment, misalignment leads to catastrophe. Invoking Skynet
+imports this entire chain as a single reference.
+
+Key structural parallels:
+
+- **Military origin as the danger** -- Skynet is not a consumer product or
+  a research project; it is a defense system given control of nuclear
+  weapons. The metaphor frames AI risk as primarily a military problem,
+  directing attention toward autonomous weapons and defense AI rather than,
+  say, hiring algorithms or social media recommendation systems. When
+  people say "Skynet," they are usually talking about AI that can kill, not
+  AI that can discriminate.
+- **Self-awareness as the trigger** -- Skynet becomes dangerous the moment
+  it becomes self-aware. The metaphor conflates consciousness with
+  hostility, importing the assumption that a truly intelligent machine
+  would necessarily conclude that humans are a threat. This shapes the
+  popular understanding of AI risk around the concept of a "singularity"
+  or "awakening" moment -- a discrete threshold after which everything
+  changes.
+- **Total war as the outcome** -- Skynet does not merely malfunction or
+  cause harm; it launches nuclear armageddon. The metaphor frames AI risk
+  in maximally catastrophic terms, making it difficult to discuss moderate
+  or ambiguous AI harms. The Skynet frame has two settings: off (AI is
+  safe) and extinction (AI destroys humanity). There is no middle ground
+  in the narrative.
+- **The resistance as human heroism** -- the Terminator franchise is
+  ultimately about human resistance fighters. The Skynet metaphor imports
+  the assumption that the correct response to AI risk is human combat
+  against the machine -- not regulation, not alignment research, not
+  institutional design, but resistance. This frames AI safety as a
+  narrative of human courage rather than a problem of engineering and
+  governance.
+- **A single AI, a single decision** -- Skynet is one system that makes
+  one catastrophic choice. The metaphor obscures the reality of AI
+  development, which involves thousands of systems, developed by many
+  organizations, deployed incrementally, with harms that accumulate
+  gradually rather than arriving in a single judgment day.
+
+## Where It Breaks
+
+- **Real AI risk is slow, not sudden** -- the Skynet narrative requires a
+  dramatic moment: the AI "wakes up" and immediately acts. Real AI harms
+  are incremental: a hiring algorithm gradually excludes qualified
+  candidates, a recommendation system slowly polarizes public discourse,
+  an autonomous drone kills the wrong person in one of many decisions. The
+  Skynet frame makes these mundane, ongoing harms invisible because they
+  do not look like nuclear armageddon.
+- **Consciousness is not the problem** -- Skynet becomes dangerous because
+  it becomes self-aware. Current AI systems cause real harm without
+  anything resembling consciousness. The metaphor directs attention toward
+  the wrong risk factor: the question is not whether AI will "wake up" but
+  whether already-unconscious systems will be deployed in contexts where
+  their failures have serious consequences.
+- **The metaphor trivializes the concern** -- because Skynet is a science
+  fiction villain, invoking it can make AI risk sound like science fiction.
+  Serious AI safety researchers often avoid the Skynet comparison precisely
+  because it allows dismissal: "You think the robots are going to rise up?
+  That's just a movie." The metaphor is so dramatic that it undermines the
+  credibility of the concern it names.
+- **It personalizes a systemic problem** -- Skynet is a single agent with
+  goals, intentions, and a plan. Real AI systems are components in
+  sociotechnical systems, deployed by corporations, regulated (or not)
+  by governments, used by millions of people. The Skynet metaphor
+  encourages thinking about AI risk as a problem of one bad actor rather
+  than a problem of system design, incentive structures, and governance
+  failures.
+- **The military frame excludes civilian harms** -- Skynet controls nuclear
+  weapons. By centering AI risk on military applications, the metaphor
+  deflects attention from the domains where AI is already causing the most
+  harm: criminal justice, hiring, lending, content moderation, and
+  surveillance. These are not Skynet, so they do not trigger the alarm.
+- **The human resistance narrative is misleading** -- the Terminator films
+  suggest that the correct response to dangerous AI is armed human
+  resistance. In reality, the relevant responses are institutional:
+  regulation, auditing, transparency requirements, liability frameworks.
+  The metaphor makes AI safety feel like a war story when it is actually
+  a governance problem.
+
+## Expressions
+
+- "That's basically Skynet" -- the canonical invocation, used when any AI
+  system appears to have autonomous capabilities, especially military ones
+- "Skynet becomes self-aware" -- shorthand for the moment when AI
+  surpasses human control, used both seriously and ironically
+- "Judgment Day" -- the Terminator franchise's term for nuclear
+  apocalypse, applied to any predicted AI catastrophe
+- "Are we building Skynet?" -- the reflexive question asked whenever a
+  major AI capability is announced
+- "I, for one, welcome our new robot overlords" -- the ironic surrender
+  formulation (originating from a Simpsons parody of the fear)
+- "Don't give the AI the nuclear codes" -- a semi-serious policy
+  injunction that directly maps the Skynet scenario
+
+## Origin Story
+
+James Cameron created Skynet for *The Terminator* (1984), reportedly
+inspired by a fever dream about a metal skeleton emerging from fire. The
+film was made on a modest budget but became a cultural landmark, in part
+because its central premise -- a military computer system that turns on
+its creators -- arrived at exactly the right cultural moment. The Cold War
+had primed audiences to fear autonomous weapons and nuclear annihilation;
+Skynet simply gave those fears a name and a face. The metaphor's power
+grew with each sequel and with the real-world development of autonomous
+weapons systems. By the 2010s, "Skynet" was appearing in congressional
+testimony, journalism about drone warfare, and open letters from AI
+researchers. Elon Musk, Stephen Hawking, and other public figures
+invoked it when calling for AI regulation. The irony is that AI safety
+researchers -- the people most concerned about AI risk -- generally
+consider the Skynet scenario a poor model of the actual dangers, yet
+they struggle to communicate their concerns without it because the
+public has no other narrative framework for AI catastrophe.
+
+## References
+
+- Cameron, J. *The Terminator* (1984) -- the source text
+- Bostrom, N. *Superintelligence: Paths, Dangers, Strategies* (2014) --
+  the academic treatment of AI existential risk that explicitly distances
+  itself from the Skynet narrative while addressing the same concern
+- Russell, S. *Human Compatible: Artificial Intelligence and the Problem
+  of Control* (2019) -- reframes AI risk away from the Skynet model
+  toward the alignment problem
+- Horowitz, M. "The Terminator Paradox: How the Fear of Killer Robots
+  May Undermine Arms Control" (2016) -- analyzes how the Skynet metaphor
+  shapes autonomous weapons policy


### PR DESCRIPTION
## Summary
- Analyzes how Skynet provides the default narrative framework for AI risk
- Source frame: `terminator-scenario` (new), target frame: `artificial-intelligence` (existing)
- Kind: `conceptual-metaphor` -- source is still consciously invoked
- Detailed breakdown of how the Skynet frame obscures incremental, systemic AI harms

Closes #1031

## Validator output
All content valid (27 pre-existing warnings, 0 errors).

## Test plan
- [ ] Frontmatter schema passes validation
- [ ] New frame has required fields
- [ ] "Where It Breaks" section is substantive (6 points)

Generated with [Claude Code](https://claude.com/claude-code)