### PR TITLE
Add mapping: newspeak-is-thought-control

### DIFF
--- a/catalog/frames/orwellian-language.md
+++ b/catalog/frames/orwellian-language.md
@@ -1,0 +1,28 @@
+---
+slug: orwellian-language
+name: "Orwellian Language"
+related:
+  - language
+  - surveillance
+  - governance
+roles:
+  - newspeak
+  - oldspeak
+  - doublethink
+  - thoughtcrime
+  - party
+  - proles
+  - ministry
+  - memory-hole
+  - unperson
+---
+
+The linguistic apparatus of George Orwell's *Nineteen Eighty-Four* (1949),
+in which the ruling Party engineers a new language (Newspeak) designed to
+make dissident thought literally impossible by eliminating the words needed
+to express it. The frame's core insight is that language does not merely
+describe thought but constrains it -- that control over vocabulary is
+control over what can be conceived. As a source domain, Orwellian language
+provides a ready-made framework for analyzing any situation where
+institutional language appears designed to limit rather than enable
+expression.

--- a/catalog/frames/thought-control.md
+++ b/catalog/frames/thought-control.md
@@ -1,0 +1,26 @@
+---
+slug: thought-control
+name: "Thought Control"
+related:
+  - language
+  - governance
+  - social-behavior
+roles:
+  - controller
+  - subject
+  - permitted-thought
+  - forbidden-thought
+  - mechanism
+  - enforcement
+  - internalization
+  - resistance
+---
+
+The shaping, limiting, or directing of what people can think -- not merely
+what they can say or do, but what they can conceive. Thought control
+operates through language (restricting vocabulary), framing (determining
+which aspects of reality are salient), repetition (normalizing certain
+ideas), and institutional structure (making alternatives invisible). As a
+target domain, thought control is structured by metaphors from censorship,
+imprisonment, and engineering, each importing different assumptions about
+whether the control is imposed from outside or internalized from within.

--- a/catalog/mappings/newspeak-is-thought-control.md
+++ b/catalog/mappings/newspeak-is-thought-control.md
@@ -1,0 +1,149 @@
+---
+slug: newspeak-is-thought-control
+name: "Newspeak Is Thought Control"
+kind: conceptual-metaphor
+source_frame: orwellian-language
+target_frame: thought-control
+categories:
+  - arts-and-culture
+  - law-and-governance
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related: []
+---
+
+## What It Brings
+
+In George Orwell's *Nineteen Eighty-Four* (1949), the Party is
+systematically replacing English ("Oldspeak") with Newspeak, a simplified
+language designed to make heretical thought impossible. If there is no
+word for freedom, you cannot think about freedom. The concept has become
+one of the most widely deployed metaphors in political discourse: whenever
+someone accuses an institution of manipulating language to constrain
+thought -- "that's Newspeak" -- they are invoking Orwell's fictional
+apparatus to frame a real-world linguistic practice.
+
+Key structural parallels:
+
+- **Vocabulary reduction as thought elimination** -- Newspeak works by
+  shrinking the language. Words are deleted each year; synonyms and
+  antonyms are collapsed (bad becomes "ungood"). The metaphor frames
+  any reduction or simplification of language as potentially sinister:
+  corporate jargon that replaces specific terms with vague ones,
+  bureaucratic language that eliminates distinctions, platform content
+  policies that remove words from permissible discourse. Each becomes
+  legible as a Newspeak operation.
+- **The institution as language engineer** -- in the novel, the Party
+  deliberately designs Newspeak. The metaphor imports intentionality:
+  when someone calls corporate language "Newspeak," they are claiming
+  that the language was engineered to serve power, not that it evolved
+  accidentally. This is the metaphor's most consequential import --
+  it transforms linguistic observation into conspiracy claim.
+- **The Sapir-Whorf hypothesis as political weapon** -- Newspeak
+  operationalizes the strong version of linguistic relativity: language
+  determines thought, so controlling language controls thought. The
+  metaphor gives political force to a contested linguistic theory,
+  making the claim that vocabulary limits cognition feel like common
+  sense rather than an empirical question.
+- **Euphemism as the mechanism** -- Orwell's Ministry of Peace makes
+  war, the Ministry of Truth produces lies. The metaphor trains
+  attention on institutional euphemism: "enhanced interrogation" for
+  torture, "rightsizing" for layoffs, "content moderation" for
+  censorship (or, depending on your politics, for safety). Every
+  euphemism becomes a potential Newspeak operation.
+- **The binary of authentic vs. engineered language** -- the Newspeak
+  metaphor implies that there exists a natural, uncorrupted language
+  (Oldspeak) that the institution is replacing with an artificial one.
+  This frames all institutional language reform as inherently
+  suspicious and all "plain speaking" as inherently authentic.
+
+## Where It Breaks
+
+- **Language does not determine thought as strongly as Newspeak requires**
+  -- the novel's premise depends on the strong Sapir-Whorf hypothesis:
+  eliminate the word, eliminate the thought. Decades of linguistic
+  research suggest this is false. People can think concepts for which
+  they lack words; they coin new terms, repurpose existing ones, and
+  use circumlocution. Real thought control requires more than vocabulary
+  management. The metaphor overstates language's power over cognition.
+- **Newspeak is deliberate; most linguistic simplification is not** --
+  the metaphor imports intentionality where none may exist. Corporate
+  jargon usually emerges from institutional incentives (legal risk
+  avoidance, status signaling, interdepartmental negotiation), not from
+  a deliberate plan to constrain employee thought. Calling it "Newspeak"
+  attributes to conspiracy what is adequately explained by bureaucratic
+  drift.
+- **The metaphor is politically omnidirectional** -- both left and right
+  invoke Newspeak against each other. Conservatives call inclusive
+  language (they/them pronouns, "person of color") Newspeak; progressives
+  call corporate euphemisms ("right to work," "pro-life") Newspeak. The
+  metaphor provides no criteria for distinguishing genuine linguistic
+  manipulation from legitimate language evolution. Everything the
+  speaker dislikes becomes Newspeak.
+- **Orwell's novel is about state power; the metaphor is applied to all
+  institutions** -- Newspeak is imposed by a totalitarian government with
+  absolute coercive power. When the metaphor is applied to a university's
+  style guide or a social media platform's terms of service, it equates
+  institutional recommendations with totalitarian coercion. The metaphor
+  has no vocabulary for degrees of power or voluntariness.
+- **The authentic-language assumption is false** -- all language is
+  socially constructed and institutionally shaped. There is no pristine
+  "Oldspeak" that precedes institutional influence. Standard English
+  itself was an institutional project (dictionaries, grammar books,
+  national education systems). The Newspeak metaphor treats a particular
+  moment's linguistic conventions as natural and all changes as artificial,
+  which is historically naive.
+- **The metaphor can suppress legitimate language reform** -- some changes
+  to language are genuine improvements: replacing exclusionary terms,
+  adding precision, removing ambiguity. The Newspeak frame treats all
+  institutional language change as suspicious by default, which can be
+  used to resist changes that serve equity, clarity, or accuracy.
+
+## Expressions
+
+- "That's Newspeak" -- the canonical accusation, applied to any language
+  perceived as deliberately obscuring or constraining
+- "Orwellian" -- the broader adjective, covering not just language but
+  surveillance, propaganda, and totalitarian control
+- "War is peace, freedom is slavery" -- Orwell's example slogans, quoted
+  to illustrate perceived doublethink in political messaging
+- "Memory hole" -- the destruction of inconvenient records, applied to
+  corporate rebranding, historical revisionism, and content deletion
+- "Thoughtcrime" -- the concept of forbidden thought, invoked against
+  any perceived punishment for expressing unpopular opinions
+- "Doublethink" -- holding contradictory beliefs simultaneously, applied
+  to institutional hypocrisy
+
+## Origin Story
+
+George Orwell developed the concept of Newspeak in the appendix to
+*Nineteen Eighty-Four* (1949), drawing on his earlier essay "Politics
+and the English Language" (1946), which argued that political language is
+designed to "make lies sound truthful and murder respectable." Orwell
+was influenced by the propaganda techniques he observed in the Spanish
+Civil War, by totalitarian uses of language in Nazi Germany and the
+Soviet Union, and by Basic English -- C.K. Ogden's real proposal to
+reduce English to 850 words for international communication. Orwell
+initially supported Basic English before recognizing its potential for
+abuse. The Newspeak concept entered political discourse almost
+immediately upon publication and has been continuously deployed since:
+against McCarthyism in the 1950s, against Pentagon language in the
+Vietnam era ("pacification," "strategic hamlet"), against corporate
+euphemism since the 1980s, and against social media content policies
+since the 2010s. The term's political versatility -- its equal
+applicability to left and right, to state and corporate power -- is
+both its strength as a metaphor and its weakness as an analytical tool.
+
+## References
+
+- Orwell, G. *Nineteen Eighty-Four* (1949) -- the source text, especially
+  the appendix "The Principles of Newspeak"
+- Orwell, G. "Politics and the English Language" (1946) -- the essay that
+  laid the groundwork for Newspeak
+- Lutz, W. *Doublespeak: From "Revenue Enhancement" to "Terminal Living"*
+  (1989) -- the most thorough application of Orwellian analysis to
+  contemporary institutional language
+- Rodden, J. *The Politics of Literary Reputation: The Making and Claiming
+  of "St. George" Orwell* (1989) -- traces how Orwell's concepts have
+  been appropriated across the political spectrum


### PR DESCRIPTION
## Summary
- Analyzes how Orwell's Newspeak has become the default frame for critiquing institutional language
- Source frame: `orwellian-language` (new), target frame: `thought-control` (new)
- Kind: `conceptual-metaphor` -- source is still consciously invoked as "Orwellian"
- Examines the metaphor's political omnidirectionality and the false Sapir-Whorf import

Closes #1033

## Validator output
All content valid (27 pre-existing warnings, 0 errors).

## Test plan
- [ ] Frontmatter schema passes validation
- [ ] Both new frames have required fields
- [ ] "Where It Breaks" section is substantive (6 points)

Generated with [Claude Code](https://claude.com/claude-code)