### PR TITLE
Add mapping: terraforming-is-planetary-engineering

### DIFF
--- a/catalog/frames/planetary-engineering.md
+++ b/catalog/frames/planetary-engineering.md
@@ -1,0 +1,24 @@
+---
+slug: planetary-engineering
+name: "Planetary Engineering"
+related:
+  - natural-phenomena
+  - systems-thinking
+roles:
+  - planet
+  - atmosphere
+  - engineer
+  - transformation
+  - habitability
+  - ecosystem
+  - desired-state
+---
+
+The deliberate modification of a planet's environment -- atmosphere,
+temperature, hydrosphere, biosphere -- to make it suitable for human life.
+The frame centers on whole-system transformation: changing not one variable
+but an interconnected web of variables simultaneously, guided by a
+specification of the desired end state. Key structural features include
+the dependency ordering of changes (atmosphere before water before
+biology), the multi-generational timescale, and the assumption of
+sufficient engineering mastery to reshape an entire world.

--- a/catalog/mappings/terraforming-is-planetary-engineering.md
+++ b/catalog/mappings/terraforming-is-planetary-engineering.md
@@ -1,0 +1,124 @@
+---
+slug: terraforming-is-planetary-engineering
+name: "Terraforming Is Planetary Engineering"
+kind: conceptual-metaphor
+source_frame: planetary-engineering
+target_frame: systems-thinking
+categories:
+  - arts-and-culture
+  - systems-thinking
+author: agent:metaphorex-miner
+contributors: []
+related: []
+---
+
+## What It Brings
+
+Terraforming -- the science-fiction concept of transforming an alien world
+into one habitable by humans -- has become a frame for any project that
+attempts to reshape an entire environment rather than adapt to it. The
+concept originated in science fiction (Jack Williamson coined the term in
+1942), entered planetary science as a serious research question, and then
+migrated into infrastructure, DevOps, and organizational transformation as
+a metaphor for environment-level change.
+
+The name of the infrastructure-as-code tool Terraform is not accidental.
+It encodes the ambition: define the desired state of your entire cloud
+environment and let the tool reshape reality to match.
+
+Key structural parallels:
+
+- **Whole-environment transformation** -- terraforming does not modify a
+  single variable. It changes atmospheric composition, temperature,
+  hydrology, and biological systems simultaneously to produce a new stable
+  state. This maps onto large-scale infrastructure projects that cannot
+  succeed by changing one component in isolation: migrating a data center,
+  rebuilding a city's transit system, or transforming a company's entire
+  technology stack.
+- **Desired end-state, not incremental patching** -- the terraformer begins
+  with a specification of what the planet should look like when finished.
+  The current state is treated as raw material to be reshaped, not a
+  constraint to be respected. This maps onto declarative infrastructure
+  tools, urban master planning, and any approach that privileges the
+  blueprint over the existing reality.
+- **Timescale beyond individual lifetimes** -- serious terraforming
+  proposals for Mars span centuries. The metaphor imports the idea that
+  some transformations are inherently multi-generational and cannot be
+  compressed. This resonates with climate engineering, institutional
+  reform, and cultural change.
+- **Cascading dependencies** -- you cannot create oceans on Mars before
+  you create an atmosphere. Terraforming has a dependency graph. This maps
+  onto infrastructure migrations where you must sequence changes carefully
+  because each layer depends on the one beneath it.
+
+## Where It Breaks
+
+- **Planets do not have users** -- terraforming assumes an uninhabited
+  world that can be reshaped without consulting anyone. Real environments
+  are inhabited. Infrastructure transformations displace existing users,
+  workflows, and dependencies. The terraforming frame encourages treating
+  the existing environment as a blank canvas, which erases the people who
+  already live and work there.
+- **The "desired state" is not objective** -- in science fiction,
+  terraforming has a clear target: make the planet Earth-like. In practice,
+  the desired state of an infrastructure, a city, or an organization is
+  contested. The terraforming metaphor smuggles in the assumption that
+  someone has the authority and the knowledge to define what "habitable"
+  means for everyone.
+- **Feedback loops are not optional** -- actual planetary systems are
+  chaotic. Terraforming proposals handwave the feedback loops that would
+  make controlled transformation nearly impossible: releasing CO2 to warm
+  Mars might trigger dust storms that block sunlight. Real infrastructure
+  transformations face the same problem. The metaphor's confidence in
+  whole-system control is its biggest lie.
+- **You cannot roll back a planet** -- the terraforming frame, especially
+  as used in DevOps, implies reversibility (terraform destroy). But the
+  analogy's source domain has no undo button. Once you have altered an
+  atmosphere, you cannot restore the previous state. The metaphor borrows
+  the ambition of planetary engineering while discarding its irreversibility.
+- **The frame naturalizes hubris** -- terraforming is inherently a frame
+  of mastery over nature. When applied to complex social or technical
+  systems, it encourages the belief that sufficient engineering can
+  overcome any obstacle. This is the frame that produces failed megaprojects,
+  disastrous urban renewal, and infrastructure migrations that destroy
+  more value than they create.
+
+## Expressions
+
+- "Terraform your infrastructure" -- HashiCorp's tool, now the dominant
+  frame for declarative infrastructure management
+- "Terraforming the organization" -- consultancy language for
+  wholesale cultural transformation
+- "We need to terraform this codebase" -- describing a rewrite so
+  extensive it reshapes the entire development environment
+- "Planetary-scale engineering" -- used for global cloud infrastructure,
+  borrowing the scope of terraforming
+- "Making Mars habitable" -- used metaphorically for making hostile
+  technical environments productive
+
+## Origin Story
+
+Jack Williamson coined "terraforming" in his 1942 short story
+"Collision Orbit." The concept was further developed by Carl Sagan, who
+published a serious scientific paper on terraforming Venus in 1961, and
+by James Lovelock and others who explored Mars terraforming in the 1970s
+and 1980s. Kim Stanley Robinson's *Mars Trilogy* (1992-1996) gave the
+concept its most detailed fictional treatment, exploring not just the
+engineering but the political, ecological, and ethical dimensions of
+planetary transformation.
+
+The metaphor entered technology through HashiCorp's Terraform (2014),
+which made "terraforming" a daily verb for infrastructure engineers.
+The tool's success cemented the metaphorical transfer: infrastructure
+is a planet, configuration is atmosphere, and the engineer is a god
+reshaping worlds.
+
+## References
+
+- Williamson, J. "Collision Orbit" (1942) -- first use of "terraforming"
+- Sagan, C. "The Planet Venus" in *Science* 133 (1961) -- first
+  scientific terraforming proposal
+- Robinson, K.S. *Red Mars*, *Green Mars*, *Blue Mars* (1992-1996) --
+  definitive fictional treatment
+- HashiCorp, Terraform documentation (2014-present) -- the tool that
+  made the metaphor operational


### PR DESCRIPTION
## Summary
- Adds `terraforming-is-planetary-engineering` mapping (kind: conceptual-metaphor)
- Creates `planetary-engineering` source frame
- Closes #1035

## Validator output
All content valid (0 errors, 0 new warnings).

## Test plan
- [x] `uv run scripts/validate.py validate` passes

Generated with [Claude Code](https://claude.com/claude-code)