### PR TITLE
Add mapping: generation-ship-is-long-horizon-institution

### DIFF
--- a/catalog/frames/generation-ship.md
+++ b/catalog/frames/generation-ship.md
@@ -1,0 +1,24 @@
+---
+slug: generation-ship
+name: "Generation Ship"
+related:
+  - governance
+  - systems-thinking
+roles:
+  - ship
+  - crew
+  - mission
+  - destination
+  - generation
+  - closed-system
+  - voyage
+---
+
+A self-contained vessel on a journey so long that multiple generations of
+crew live and die aboard before arrival. The defining structural features
+are temporal scale beyond individual lifetimes, a closed resource loop with
+no external resupply, governance that must survive leadership transitions,
+and the ethical asymmetry between founders who chose the mission and
+descendants who inherit it. The ship must maintain both physical
+infrastructure and institutional purpose across generations, making it a
+frame for long-horizon planning and intergenerational obligation.

--- a/catalog/mappings/generation-ship-is-long-horizon-institution.md
+++ b/catalog/mappings/generation-ship-is-long-horizon-institution.md
@@ -1,0 +1,130 @@
+---
+slug: generation-ship-is-long-horizon-institution
+name: "Generation Ship Is Long-Horizon Institution"
+kind: conceptual-metaphor
+source_frame: generation-ship
+target_frame: governance
+categories:
+  - arts-and-culture
+  - systems-thinking
+author: agent:metaphorex-miner
+contributors: []
+related: []
+---
+
+## What It Brings
+
+A generation ship is a spacecraft designed for a voyage so long that the
+crew who arrive at the destination are the descendants -- sometimes many
+generations removed -- of the crew who departed. The people who built and
+launched the ship will never see the result. The people who arrive never
+chose to be aboard. The concept has become a frame for any institution or
+project that must sustain purpose across generational timescales:
+cathedrals, constitutions, climate policy, nuclear waste storage,
+long-term software maintenance.
+
+Key structural parallels:
+
+- **The founders do not arrive** -- the generation ship's defining feature
+  is that the people who conceive and launch the project will not live to
+  see its completion. This maps onto cathedral-builders who will never see
+  the finished nave, constitutional framers who write for citizens not yet
+  born, and climate policymakers whose targets are set for 2100. The frame
+  forces a question that short-horizon thinking avoids: how do you motivate
+  effort toward a goal you will never personally witness?
+- **The passengers did not choose** -- later generations aboard a
+  generation ship are born into a mission they had no say in. This maps
+  onto inherited institutional mandates, legacy systems, and national debts.
+  The people who maintain a 40-year-old COBOL system did not choose to
+  write it in COBOL. The citizens who service a national debt did not incur
+  it. The generation ship makes this structural injustice visible.
+- **Mission drift is existential** -- over centuries, the ship's original
+  purpose can be forgotten, distorted, or rejected. Stories like Heinlein's
+  *Orphans of the Sky* explore crews who have forgotten they are on a ship
+  at all. This maps onto institutional mission drift: universities that
+  forget their educational purpose, regulatory agencies captured by the
+  industries they regulate, religions that invert their founders' values.
+- **The environment is closed** -- a generation ship carries everything it
+  needs. Resources are finite, waste must be recycled, and every system
+  must be maintainable without external supply chains. This maps onto
+  sustainability constraints: Earth as a generation ship (Buckminster
+  Fuller's "Spaceship Earth"), isolated communities, and self-contained
+  software systems that must be maintainable without their original
+  developers.
+- **Governance must survive leadership transitions** -- no single leader
+  can command a generation ship for the entire voyage. The ship requires
+  governance structures that transfer authority across generations without
+  concentrating or losing it. This maps onto constitutional design,
+  institutional succession planning, and open-source project governance.
+
+## Where It Breaks
+
+- **Real institutions can change course** -- a generation ship is committed
+  to its trajectory. Changing destination mid-voyage is prohibitively
+  expensive in fuel and time. Real institutions can pivot, reform, or
+  dissolve. The generation ship frame overemphasizes path dependency and
+  can make institutional change seem more impossible than it actually is.
+- **The metaphor assumes a known destination** -- generation ships have a
+  target star system. The voyage is long but the goal is defined. Most
+  long-horizon institutions do not have a fixed destination. Climate policy
+  aims at a moving target. Constitutional governance is an ongoing
+  experiment, not a journey toward a predetermined end. The frame imports
+  a false teleology.
+- **Crew size is fixed; societies grow** -- generation ships in fiction
+  carefully manage population to match the ship's carrying capacity. Real
+  institutions operate in growing, shrinking, and migrating populations.
+  The closed-system assumption breaks when applied to open societies.
+- **The frame romanticizes endurance over adaptation** -- the generation
+  ship privileges maintaining the original mission over responding to new
+  information. This can produce a conservative bias: "we must stay the
+  course" even when the original plan was wrong. Sometimes the right move
+  is to abandon the mission, not to endure.
+- **It obscures who benefits from continuity** -- generation ship stories
+  rarely examine who profits from keeping the ship on course. In real
+  institutions, "long-term thinking" often serves the interests of those
+  currently in power. The frame makes institutional persistence sound
+  noble, but persistence can also be self-serving bureaucratic inertia.
+
+## Expressions
+
+- "Spaceship Earth" -- Buckminster Fuller's frame, treating the planet
+  as a generation ship with finite resources and no external resupply
+- "Cathedral thinking" -- planning on timescales beyond a single
+  lifetime, directly invoking the generation ship's temporal structure
+- "We are the crew, not the passengers" -- used in sustainability
+  contexts to emphasize agency and responsibility
+- "Long Now thinking" -- the Long Now Foundation's framing of
+  10,000-year institutional design
+- "Legacy system" -- software infrastructure inherited by developers
+  who did not build it and must maintain it indefinitely
+- "Intergenerational equity" -- policy language for the obligation not
+  to burden future generations, encoding the generation ship's core
+  ethical question
+
+## Origin Story
+
+The generation ship concept appeared in science fiction as early as the
+1920s, with Konstantin Tsiolkovsky's speculations about interstellar
+arks. Robert Heinlein's *Methuselah's Children* (1941) and *Orphans of
+the Sky* (1941) established the key narrative tropes: the forgotten
+mission, the closed society, the rediscovery of purpose. The concept
+was developed further by Brian Aldiss (*Non-Stop*, 1958), Gene Wolfe
+(*The Book of the Long Sun*, 1993-1996), and Kim Stanley Robinson
+(*Aurora*, 2015), which interrogated the concept most critically by
+asking whether generation ships are ethical at all.
+
+The metaphorical transfer to institutional design accelerated with
+Stewart Brand's *The Clock of the Long Now* (1999) and the Long Now
+Foundation's projects, which explicitly frame long-term thinking as a
+design problem with parallels to generation ship engineering.
+
+## References
+
+- Heinlein, R. *Orphans of the Sky* (1941) -- the forgotten-mission
+  trope
+- Fuller, B. *Operating Manual for Spaceship Earth* (1969) -- Earth
+  as generation ship
+- Brand, S. *The Clock of the Long Now* (1999) -- long-horizon
+  institutional design
+- Robinson, K.S. *Aurora* (2015) -- critical examination of the
+  generation ship premise


### PR DESCRIPTION
## Summary
- Adds `generation-ship-is-long-horizon-institution` mapping (kind: conceptual-metaphor)
- Creates `generation-ship` source frame
- Closes #1036

## Validator output
All content valid (0 errors, 0 new warnings).

## Test plan
- [x] `uv run scripts/validate.py validate` passes

Generated with [Claude Code](https://claude.com/claude-code)