### PR TITLE
Add mapping: dystopia-is-social-warning

### DIFF
--- a/catalog/frames/dystopia.md
+++ b/catalog/frames/dystopia.md
@@ -1,0 +1,24 @@
+---
+slug: dystopia
+name: "Dystopia"
+related:
+  - governance
+  - social-behavior
+roles:
+  - society
+  - regime
+  - citizen
+  - control-mechanism
+  - organizing-principle
+  - resistance
+  - warning
+---
+
+A fictional society organized around a single principle -- surveillance,
+conformity, pleasure, efficiency, equality -- taken to its logical extreme
+until it becomes oppressive. The frame's defining structural features are
+the absence of counterbalancing forces, the totality of the system (no
+external alternative exists), and the function as cautionary tale: the
+dystopia exists to be recognized and avoided, not to be inhabited. The
+frame converts abstract social trends into visceral narrative, making
+policy risks feel personal and urgent.

--- a/catalog/mappings/dystopia-is-social-warning.md
+++ b/catalog/mappings/dystopia-is-social-warning.md
@@ -1,0 +1,137 @@
+---
+slug: dystopia-is-social-warning
+name: "Dystopia Is Social Warning"
+kind: archetype
+source_frame: dystopia
+target_frame: governance
+categories:
+  - arts-and-culture
+  - ethics-and-morality
+author: agent:metaphorex-miner
+contributors: []
+related: []
+---
+
+## What It Brings
+
+A dystopia is a fictional society organized around a principle taken to
+its logical extreme -- surveillance, conformity, efficiency, pleasure,
+equality -- until that principle devours everything else. The frame has
+escaped literature entirely. "Dystopian" is now a standard adjective in
+policy debate, technology criticism, and journalism, applied to any trend
+that a speaker wants to mark as heading toward a nightmarish endpoint.
+
+The archetype recurs independently across cultures and centuries: Plato's
+critique of democracy in *Republic*, Swift's satirical Houyhnhnms,
+Zamyatin's *We*, Huxley's *Brave New World*, Orwell's *1984*, Atwood's
+*The Handmaid's Tale*. Each instantiation is different, but the
+structural pattern is identical: take a real social tendency, remove all
+counterbalancing forces, and show what happens.
+
+Key structural parallels:
+
+- **Extrapolation as argument** -- the dystopian frame works by taking a
+  present-day trend and projecting it forward without the messy
+  countervailing forces that real societies produce. This is its
+  rhetorical power: it makes abstract risks visceral. "Surveillance
+  capitalism" is a policy concept; "this is literally 1984" is a felt
+  experience. The frame converts analysis into alarm.
+- **Named exemplars as shorthand** -- specific dystopias function as
+  compressed arguments. Invoking "1984" imports an entire analytical
+  framework: state surveillance, language manipulation, historical
+  revisionism, thought control. Invoking "Brave New World" imports a
+  different one: pleasurable conformity, chemical pacification, the
+  elimination of discomfort as a form of control. The named exemplars
+  save argumentative work but also constrain thought to the specific
+  failure mode each novel explored.
+- **The warning is the point** -- dystopias exist to be avoided. This
+  gives the frame a built-in call to action that descriptive analysis
+  lacks. Saying "this policy is dystopian" is not a description; it is
+  a demand to change course. The frame converts observation into
+  obligation.
+- **Total systems, not partial failures** -- dystopias are not societies
+  with problems. They are societies where the problem is the system
+  itself. This maps onto critiques of systemic rather than incidental
+  failures: the issue is not that surveillance is sometimes misused but
+  that the surveillance architecture itself is the threat.
+
+## Where It Breaks
+
+- **The frame only has one volume setting** -- dystopia is binary: either
+  a society is heading toward dystopia or it is not. There is no
+  "somewhat dystopian." This flattens the gradient of real policy
+  outcomes. A city installing traffic cameras is not on the same
+  trajectory as Oceania's telescreens, but the dystopian frame makes
+  them feel connected. The result is rhetorical inflation that erodes
+  the frame's own credibility.
+- **Dystopias require a single organizing principle; real societies do
+  not** -- *1984* is about surveillance. *Brave New World* is about
+  pleasure as control. Real societies are messy composites of many
+  organizing principles in tension. The dystopian frame encourages
+  mono-causal thinking: identify the one bad trend and fight it. This
+  misses how real social failures emerge from the interaction of
+  multiple trends, none of which is dystopian in isolation.
+- **The frame is better at opposition than construction** -- "this is
+  dystopian" tells you what to resist but not what to build. Dystopian
+  thinking produces excellent critics and poor policymakers. The frame
+  excels at identifying failure modes and is nearly useless for
+  designing alternatives.
+- **Crying dystopia desensitizes** -- when everything from vaccine
+  passports to school dress codes is called "dystopian," the word loses
+  its force. The frame suffers from the same inflation as "fascist" or
+  "Orwellian" -- overuse drains it of analytical content and turns it
+  into a generic expression of disapproval.
+- **It assumes intentional design** -- dystopias are designed by
+  malicious or misguided architects: the Party, the World State,
+  Gilead's Commanders. Real dystopian outcomes usually emerge from
+  nobody's plan. Surveillance capitalism was not designed by a
+  totalitarian regime; it evolved from advertising incentives. The
+  frame's emphasis on intentional control makes it harder to see
+  emergent systemic failures that have no architect.
+
+## Expressions
+
+- "This is literally 1984" -- the most common dystopian invocation,
+  applied to surveillance, censorship, and language policing
+- "Brave New World scenario" -- used when the threat is comfort and
+  distraction rather than coercion
+- "Dystopian" as a standalone adjective -- "That policy is dystopian"
+  requires no further explanation
+- "Big Brother" -- Orwell's surveillance figure, now a common noun
+  (see also the reality TV show that ironically normalized the concept)
+- "Handmaid's Tale vibes" -- applied to reproductive rights restrictions
+  and theocratic governance
+- "We're living in a dystopia" -- the frame applied reflexively to the
+  speaker's own society, usually to express helplessness
+- "Orwellian" -- language manipulation, doublespeak, institutional
+  dishonesty
+
+## Origin Story
+
+The word "dystopia" was coined by John Stuart Mill in 1868 as the
+opposite of Thomas More's "utopia" (1516). But the literary tradition
+predates the term. Swift's *Gulliver's Travels* (1726) contains
+dystopian societies. The modern dystopian canon begins with Zamyatin's
+*We* (1924), which directly influenced Huxley's *Brave New World* (1932)
+and Orwell's *1984* (1949).
+
+The dystopian frame entered mainstream political discourse during the
+Cold War, when *1984* was read as a warning about Soviet totalitarianism.
+It broadened in the 2000s and 2010s as surveillance technology, social
+media, and algorithmic governance made previously fictional scenarios
+feel plausible. The Snowden revelations (2013) and the rise of
+authoritarian populism triggered a measurable surge in sales of *1984*
+and *The Handmaid's Tale*, as readers reached for dystopian frames to
+make sense of current events.
+
+## References
+
+- Orwell, G. *Nineteen Eighty-Four* (1949) -- the dominant dystopian
+  exemplar in Anglophone culture
+- Huxley, A. *Brave New World* (1932) -- the alternative dystopian
+  template: control through pleasure
+- Atwood, M. *The Handmaid's Tale* (1985) -- dystopia applied to
+  gender and reproductive politics
+- Postman, N. *Amusing Ourselves to Death* (1985) -- argues that
+  Huxley's dystopia is more relevant than Orwell's
+- Zamyatin, Y. *We* (1924) -- the ur-text of modern dystopian fiction


### PR DESCRIPTION
## Summary
- Adds `dystopia-is-social-warning` mapping (kind: archetype)
- Creates `dystopia` source frame
- Closes #1037

## Validator output
All content valid (0 errors, 0 new warnings).

## Test plan
- [x] `uv run scripts/validate.py validate` passes

Generated with [Claude Code](https://claude.com/claude-code)