### PR TITLE
Add mapping: pod-people-are-conformist-replacement

### DIFF
--- a/catalog/frames/alien-replacement.md
+++ b/catalog/frames/alien-replacement.md
@@ -1,0 +1,25 @@
+---
+slug: alien-replacement
+name: "Alien Replacement"
+related:
+  - social-behavior
+  - collective-assimilation
+roles:
+  - original
+  - duplicate
+  - replacement
+  - detection
+  - conformity
+  - authenticity
+  - paranoia
+---
+
+The covert substitution of an individual with an externally identical but
+internally different copy. The replacement preserves all outward markers of
+identity -- appearance, speech patterns, social role -- while erasing the
+inner life: genuine emotion, independent thought, idiosyncrasy. Key
+structural features include the uncanny resemblance that makes detection
+difficult, the pathologizing of those who notice the change, and the
+irreversibility of the process. The frame centers the anxiety that
+authenticity can be perfectly simulated from the outside while being
+completely absent on the inside.

--- a/catalog/mappings/pod-people-are-conformist-replacement.md
+++ b/catalog/mappings/pod-people-are-conformist-replacement.md
@@ -1,0 +1,135 @@
+---
+slug: pod-people-are-conformist-replacement
+name: "Pod People Are Conformist Replacement"
+kind: archetype
+source_frame: alien-replacement
+target_frame: social-behavior
+categories:
+  - arts-and-culture
+  - social-dynamics
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - the-borg-is-assimilation
+---
+
+## What It Brings
+
+In *Invasion of the Body Snatchers* (1955 novel, 1956 and 1978 films),
+alien plant pods grow perfect physical duplicates of human beings. The
+duplicates look identical but lack genuine emotion, individuality, and
+will. They function normally -- they go to work, maintain relationships,
+follow routines -- but something essential is missing. The people who
+notice the change are told they are paranoid.
+
+The "pod person" has become shorthand for anyone who appears to have been
+replaced by a conformist, emotionally flattened version of themselves. The
+frame is applied to corporate culture, political conversion, social media
+behavior, and AI-generated content. Its power lies in naming a specific
+uncanny experience: the person looks right but feels wrong.
+
+Key structural parallels:
+
+- **External identity preserved, internal self erased** -- the pod person
+  looks, speaks, and acts like the original, but the inner life is gone.
+  This maps onto the experience of watching someone adopt a corporate
+  persona, join a cult, undergo political radicalization, or optimize
+  themselves for social media. The person is still recognizable, but the
+  idiosyncrasies, doubts, and rough edges that made them themselves have
+  been smoothed away.
+- **The replacement is voluntary-seeming** -- pod people do not resist
+  their transformation. They accept it peacefully, even enthusiastically.
+  This is what makes the frame different from the Borg (which is coercive).
+  The pod-person metaphor captures conformity that looks like choice: the
+  employee who genuinely seems to believe in the corporate values, the
+  convert who is not performing belief but has actually been replaced by
+  someone who believes.
+- **Those who notice are pathologized** -- in the original story, the
+  protagonist's warnings are dismissed as paranoia. This maps directly
+  onto the experience of anyone who points out institutional conformity
+  and is told they are the problem: the whistleblower, the cultural
+  critic, the employee who asks why everyone suddenly agrees.
+- **Sleep is the mechanism** -- in the film, replacement happens during
+  sleep. You go to bed as yourself and wake up as a copy. This maps onto
+  the gradualism of conformity: you do not notice the moment of
+  replacement because it happens below the threshold of awareness.
+  One day you realize you have been saying the corporate talking points
+  without irony, and you cannot remember when you started.
+
+## Where It Breaks
+
+- **The frame assumes a fixed authentic self** -- pod people presuppose
+  an original that has been replaced. But people genuinely change. Someone
+  who adopts new values after a transformative experience is not a pod
+  person; they are a person who changed. The frame makes all change
+  suspicious by treating the earlier version of someone as more "real"
+  than the current one. This is conservative in the deepest sense: it
+  privileges the prior self over the current one.
+- **It pathologizes belonging** -- not all conformity is replacement.
+  People who find genuine community, adopt shared values, and feel
+  at home in an institution are not pod people. The frame cannot
+  distinguish between coerced conformity and authentic belonging
+  because it treats all alignment with a group as evidence of
+  replacement.
+- **The binary is too clean** -- you are either yourself or a pod
+  person. Real conformity is partial, contextual, and negotiated.
+  People code-switch between authentic and performative modes dozens
+  of times per day. The pod-person frame erases this complexity by
+  insisting on a total replacement that rarely describes reality.
+- **The frame flatters the accuser** -- calling someone a pod person
+  implicitly claims that the accuser has retained their own
+  authenticity. It is a frame that always positions the speaker as the
+  last real person in the room. This makes it useful for self-righteous
+  critics and useless for genuine self-examination. Nobody ever
+  identifies themselves as the pod person.
+- **It has no theory of recovery** -- in the films, pod people cannot be
+  restored. Once replaced, the original is gone. This makes the metaphor
+  fatalistic when applied to real conformity, which is often reversible.
+  People leave cults, quit soul-crushing jobs, and recover their
+  individuality. The pod-person frame offers no model for this because
+  its source material does not include it.
+
+## Expressions
+
+- "Who are you and what have you done with the real [name]?" --
+  the pod-person observation delivered as humor
+- "Pod person" -- used directly as a noun: "He's become a total pod
+  person since he joined that company"
+- "Body snatchers" -- applied to organizational cultures that produce
+  uniform behavior: "That consulting firm is full of body snatchers"
+- "Drinking the Kool-Aid" -- a related but distinct metaphor (Jonestown,
+  not *Body Snatchers*) that captures the same conformity anxiety
+- "NPC" -- internet slang for "non-player character," a contemporary
+  variant of the pod-person frame applied to people perceived as
+  running on social scripts rather than independent thought
+- "They got to him" -- implying conversion or replacement by an
+  institution
+- "Stepford wife" -- from *The Stepford Wives* (1972), a closely
+  related frame specifically applied to gender conformity
+
+## Origin Story
+
+Jack Finney published *The Body Snatchers* as a serial in Collier's
+Magazine in 1954 (novel, 1955). Don Siegel's 1956 film adaptation
+became a Cold War classic, read alternately as an allegory for
+Communist infiltration or for McCarthyist conformity -- the ambiguity
+itself revealing how the frame works. Philip Kaufman's 1978 remake
+shifted the anxiety to post-Watergate institutional distrust.
+
+The "pod person" entered common English by the 1980s, applied to
+anyone perceived as having undergone a suspicious personality change.
+The concept has been reinvented independently: *The Stepford Wives*
+(1972) applied the replacement frame to suburban gender roles, and
+internet culture's "NPC" meme (2018) is essentially the pod-person
+concept stripped of its science-fiction packaging.
+
+## References
+
+- Finney, J. *The Body Snatchers* (1955) -- the source novel
+- Siegel, D. *Invasion of the Body Snatchers* (1956) -- the film that
+  established the cultural frame
+- Kaufman, P. *Invasion of the Body Snatchers* (1978) -- the remake
+  that updated the anxiety for a new era
+- Levin, I. *The Stepford Wives* (1972) -- the gender-specific variant
+- Halberstam, D. *The Fifties* (1993) -- cultural context for
+  conformity anxiety in postwar America


### PR DESCRIPTION
## Summary
- Adds `pod-people-are-conformist-replacement` mapping (kind: archetype)
- Creates `alien-replacement` source frame
- Closes #1038

## Validator output
All content valid (0 errors, 0 new warnings).

## Test plan
- [x] `uv run scripts/validate.py validate` passes

Generated with [Claude Code](https://claude.com/claude-code)