### PR TITLE
Add mapping: three-laws-is-ethical-programming

### DIFF
--- a/catalog/frames/science-fiction.md
+++ b/catalog/frames/science-fiction.md
@@ -1,0 +1,23 @@
+---
+slug: science-fiction
+name: "Science Fiction"
+related:
+  - artificial-intelligence
+  - computing
+  - ethics-and-morality
+roles:
+  - author
+  - fictional-technology
+  - fictional-society
+  - speculative-concept
+  - narrative
+  - warning
+---
+
+The genre of speculative fiction organized around scientific and
+technological premises. As a source domain for metaphor, science fiction
+is unusually productive: its concepts (robots, cyberspace, the singularity,
+viruses, the metaverse) routinely escape their narrative origins to become
+load-bearing frames for understanding real technology and policy. The genre
+functions as a cultural laboratory where societies beta-test metaphors
+before deploying them in earnest.

--- a/catalog/mappings/three-laws-is-ethical-programming.md
+++ b/catalog/mappings/three-laws-is-ethical-programming.md
@@ -1,0 +1,135 @@
+---
+slug: three-laws-is-ethical-programming
+name: "Three Laws Is Ethical Programming"
+kind: conceptual-metaphor
+source_frame: science-fiction
+target_frame: ethics-and-morality
+categories:
+  - ai-discourse
+  - ethics-and-morality
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - daemon
+---
+
+## What It Brings
+
+Asimov's Three Laws of Robotics -- first stated in the 1942 short story
+"Runaround" -- propose that machine behavior can be governed by a small
+set of hierarchical rules hardcoded into the machine's deepest layer:
+
+1. A robot may not injure a human being or, through inaction, allow a
+   human being to come to harm.
+2. A robot must obey orders given by human beings, except where such
+   orders would conflict with the First Law.
+3. A robot must protect its own existence, except where such would
+   conflict with the First or Second Law.
+
+The metaphor maps a fictional governance mechanism onto real AI ethics
+and alignment discourse. Its structural contributions:
+
+- **Ethics as code** -- the Three Laws treat moral behavior as something
+  that can be specified in advance, written down in a formal language,
+  and compiled into a system that executes them without ambiguity. This
+  is the deepest assumption the metaphor carries: that ethics is a
+  programming problem, not a judgment problem. When policymakers say
+  "we need Asimov's laws for AI," they are importing this assumption
+  wholesale.
+- **Hierarchy as conflict resolution** -- the Laws are numbered, and
+  number beats number. When Law 1 and Law 2 conflict, Law 1 wins. This
+  maps onto real ethical frameworks (deontological priority rules, lexical
+  ordering in Rawlsian justice) and gives AI safety discussions a clean
+  mental model: stack your values, and the stack resolves all conflicts.
+- **Hardcoding as safety guarantee** -- the Laws are not suggestions; they
+  are described as being woven into the "positronic brain" at a level
+  below conscious override. This maps onto the alignment community's
+  interest in "corrigibility" and value-lock-in: if we could build values
+  into the substrate, they could not be reasoned away or self-modified out.
+- **Completeness as aspiration** -- three rules to govern all possible
+  robot behavior. The metaphor implies that ethical coverage can be
+  achieved with a small, elegant set of principles -- a constitution for
+  machines.
+
+## Where It Breaks
+
+- **Asimov wrote the Laws to fail** -- this is the most important thing
+  the metaphor's popular usage gets wrong. Asimov did not propose the
+  Three Laws as a solution; he spent his entire Robot series demonstrating
+  how they produce paradoxes, loopholes, and pathological behavior. "Liar!"
+  shows a robot driven to psychosis by conflicting Law 1 imperatives.
+  "The Evitable Conflict" shows the Laws scaling into paternalistic global
+  control. Asimov's point was that formal rules are insufficient for
+  ethics. The popular metaphor inverts the author's thesis.
+- **Natural language is not code** -- "harm" is not a computable predicate.
+  The Laws are written in English, not in a formal specification language.
+  Every word ("injure," "human being," "inaction," "allow") requires
+  interpretation that depends on context, culture, and contested values.
+  The metaphor smuggles in an illusion of precision that the actual text
+  cannot deliver. Decades of AI safety research have confirmed that
+  specifying "harm" formally is the hard problem, not the solution.
+- **Three rules cannot cover ethics** -- real moral reasoning involves
+  weighing incommensurable values, handling novel situations by analogy,
+  and accepting irreducible moral tragedy (cases where every option causes
+  harm). The Three Laws metaphor makes ethics look like a coverage problem
+  -- just add more rules -- when it is actually a judgment problem that
+  resists formalization.
+- **The hardcoding assumption ignores learning** -- modern AI systems learn
+  their behavior from data and reward signals; they are not programmed
+  with explicit rules. The Three Laws metaphor assumes a 1950s model of
+  computing (explicit instruction) and applies it to systems that operate
+  by statistical pattern matching. You cannot "hardcode" a value into a
+  neural network the way Asimov hardcoded Laws into a positronic brain.
+- **The metaphor flatters human agency** -- the Laws assume humans are the
+  correct authority and that human orders should be obeyed (Law 2). This
+  sidesteps the harder question: what happens when human orders are
+  themselves harmful? Asimov explored this too ("The Evitable Conflict"),
+  but the popular metaphor retains the comforting hierarchy.
+
+## Expressions
+
+- "We need Asimov's Laws for AI" -- the most common policy-discourse usage,
+  treating the Laws as a model rather than a cautionary tale
+- "First Law violation" -- describing an AI system that causes or permits
+  harm, borrowing Asimov's numbering as a severity scale
+- "Zeroth Law" -- Asimov's own extension (a robot may not harm humanity or,
+  by inaction, allow humanity to come to harm), now used in alignment
+  discussions to describe the move from individual to collective welfare
+- "Hardcoded ethics" -- the assumption that values can be built into a
+  system's substrate, directly descended from the Three Laws model
+- "The robot did what it was told, not what we meant" -- the specification
+  gaming problem that Asimov dramatized and that modern alignment
+  researchers call "reward hacking" or "Goodhart's Law for AI"
+
+## Origin Story
+
+Isaac Asimov and his editor John W. Campbell Jr. formulated the Three Laws
+in 1941-1942, though Asimov later credited Campbell with crystallizing
+them. They first appeared explicitly in "Runaround" (Astounding Science
+Fiction, March 1942), though the first two stories in the Robot series
+("Robbie" and "Reason") implicitly followed them. Asimov wrote the Laws
+in deliberate reaction against the "Frankenstein complex" -- the
+science-fiction cliche that robots inevitably turn on their creators. He
+wanted to explore what would happen if robots were designed with safety
+constraints, and then spent forty years showing how those constraints
+produced unexpected, often worse outcomes.
+
+The Laws entered mainstream AI discourse in the 2010s as machine learning
+systems became powerful enough to raise genuine safety concerns. By then,
+most people citing the Laws had not read Asimov's stories and did not know
+that the Laws were intended as a demonstration of failure, not a blueprint
+for success.
+
+## References
+
+- Asimov, I. "Runaround," *Astounding Science Fiction* (1942) -- first
+  explicit statement of the Three Laws
+- Asimov, I. *I, Robot* (1950) -- the collection that established the
+  Laws as a narrative framework
+- Asimov, I. *Robots and Empire* (1985) -- introduces the Zeroth Law
+- Murphy, R. & Woods, D. D. "Beyond Asimov: The Three Laws of Responsible
+  Robotics," *IEEE Intelligent Systems* 24(4) (2009) -- the robotics
+  community's formal response to the Laws-as-policy metaphor
+- Gabriel, I. "Artificial Intelligence, Values, and Alignment," *Minds
+  and Machines* 30 (2020) -- surveys why rule-based approaches to
+  alignment are insufficient


### PR DESCRIPTION
## Summary

- Adds mapping `three-laws-is-ethical-programming`: Asimov's Three Laws of Robotics as a conceptual frame for AI ethics and alignment discourse
- Creates new `science-fiction` frame (reusable for other SF metaphor mappings)
- Kind: `conceptual-metaphor` -- the source domain (Asimov's fiction) remains visible and actively referenced in policy discussions

Closes #1039

## Validator output

All content valid. Zero errors, zero new warnings.

## Test plan

- [x] `uv run scripts/validate.py validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)