### PR TITLE
Add mapping: ansible-is-instant-communication

### DIFF
--- a/catalog/frames/science-fiction.md
+++ b/catalog/frames/science-fiction.md
@@ -1,0 +1,23 @@
+---
+slug: science-fiction
+name: "Science Fiction"
+related:
+  - artificial-intelligence
+  - computing
+  - ethics-and-morality
+roles:
+  - author
+  - fictional-technology
+  - fictional-society
+  - speculative-concept
+  - narrative
+  - warning
+---
+
+The genre of speculative fiction organized around scientific and
+technological premises. As a source domain for metaphor, science fiction
+is unusually productive: its concepts (robots, cyberspace, the singularity,
+viruses, the metaverse) routinely escape their narrative origins to become
+load-bearing frames for understanding real technology and policy. The genre
+functions as a cultural laboratory where societies beta-test metaphors
+before deploying them in earnest.

--- a/catalog/mappings/ansible-is-instant-communication.md
+++ b/catalog/mappings/ansible-is-instant-communication.md
@@ -1,0 +1,132 @@
+---
+slug: ansible-is-instant-communication
+name: "Ansible Is Instant Communication"
+kind: dead-metaphor
+source_frame: science-fiction
+target_frame: computing
+categories:
+  - software-engineering
+  - arts-and-culture
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - daemon
+---
+
+## What It Brings
+
+Ursula K. Le Guin invented the ansible in *Rocannon's World* (1966) as a
+device for instantaneous communication across any distance -- a plot
+necessity for coordinating civilizations separated by light-years. The word
+may derive from "answerable," as in a device that makes the universe
+answerable to human communication. The ansible appeared across Le Guin's
+Hainish Cycle and was borrowed by Orson Scott Card (*Ender's Game*, 1985),
+Vernor Vinge, and others, becoming a shared science-fiction trope for
+communication without latency.
+
+In 2012, Michael DeHaan named his IT automation tool "Ansible" after Le
+Guin's device. The metaphor's structural contributions:
+
+- **Action at a distance without delay** -- Le Guin's ansible communicates
+  instantly across light-years. The DevOps tool Ansible pushes
+  configuration to hundreds or thousands of remote servers simultaneously
+  over SSH, making them respond as if they were local. The metaphor
+  captures the felt experience of the tool: you type a command once and
+  every machine in your fleet executes it, as though distance between
+  data centers were irrelevant.
+- **Agentless architecture as fictional elegance** -- Le Guin's ansible
+  required no relay stations, no infrastructure between sender and
+  receiver. Ansible the tool is agentless: it requires no daemon or
+  client software on the target machines, just SSH access. The fictional
+  device's architectural simplicity maps onto the tool's selling point:
+  nothing to install, nothing to maintain on the other end.
+- **Orchestration as communication** -- the deeper parallel is that
+  configuration management is reframed as a communication act rather than
+  a mechanical one. You are not "programming" servers; you are "telling"
+  them what state to be in. Ansible's YAML playbooks read more like
+  messages than like code, and the tool's vocabulary (playbooks, roles,
+  tasks) reinforces the communication metaphor.
+
+## Where It Breaks
+
+- **The ansible was peer-to-peer; the tool is command-and-control** -- Le
+  Guin's ansible enabled dialogue between equals across interstellar
+  distances. Ansible the tool is unidirectional: a control node pushes
+  configuration to managed nodes. The managed nodes do not initiate
+  communication. The fictional device's most important quality --
+  bidirectional conversation -- is absent from its namesake.
+- **Instant means instant** -- Le Guin's ansible was genuinely
+  instantaneous, violating relativity. The DevOps tool operates over SSH,
+  which is subject to network latency, packet loss, timeouts, and
+  connection limits. Running Ansible against 500 servers takes real,
+  sometimes painful, time. The "instant" part of the metaphor is
+  aspirational, not literal.
+- **The fictional ansible was rare and precious** -- in Le Guin's
+  universe, ansibles were expensive, politically significant devices
+  controlled by governments. The DevOps tool is open-source software
+  that anyone can install with `pip install ansible`. The metaphor
+  imports a sense of wonder and significance that the technology has
+  deliberately democratized away.
+- **The source is vanishing** -- most Ansible users and contributors have
+  never read Le Guin. The name has become an arbitrary brand, like
+  "Apache" or "Python," where the original metaphorical content has
+  evaporated. This is the defining characteristic of a dead metaphor:
+  the word functions as a label, not as a frame for understanding.
+- **Communication implies understanding** -- Le Guin's ansible carried
+  meaning between sentient beings. Ansible the tool pushes declarative
+  state descriptions to machines that execute them literally. There is
+  no understanding, no negotiation, no possibility of the receiver
+  saying "I think you mean something else." The metaphor flatters the
+  tool by implying a meeting of minds where there is only instruction
+  execution.
+
+## Expressions
+
+- "Ansible playbook" -- a YAML file describing desired server state,
+  borrowing dramatic terminology (playbook, role, act) that reinforces
+  the communication-as-performance metaphor
+- "Run the playbook" -- execute a configuration push, spoken as though
+  directing a theatrical performance rather than deploying code
+- "Ansible Galaxy" -- the community repository of shared roles, extending
+  the science-fiction naming convention (galaxy) without most users
+  recognizing the Le Guin connection
+- "Ansible Tower" / "Ansible Automation Platform" -- Red Hat's commercial
+  products, where the Le Guin reference has been diluted into pure
+  enterprise branding
+- "Idempotent" -- Ansible's core technical property (running a playbook
+  twice produces the same state), which has no connection to Le Guin's
+  ansible but has become inseparable from the tool's identity
+
+## Origin Story
+
+Le Guin coined "ansible" in *Rocannon's World* (1966), her first Hainish
+novel. The device solved a narrative problem: how do you tell stories
+about an interstellar civilization when radio signals take years to cross
+between star systems? The ansible made coordination possible, and Le Guin
+used it across six subsequent Hainish novels without ever explaining how
+it worked -- it was a social technology, not a physics puzzle.
+
+The word escaped Le Guin's fiction entirely. Orson Scott Card used it in
+*Ender's Game* (1985) with her blessing. By the 2000s, "ansible" had
+become a generic SF term for FTL communication, appearing in dozens of
+novels, games, and TV shows.
+
+Michael DeHaan chose the name for his 2012 automation tool because he
+wanted to evoke the idea of reaching any machine instantly. In a 2013
+interview, he confirmed the Le Guin reference. When Red Hat acquired
+Ansible in 2015 for $150 million, the Le Guin connection was mentioned
+in exactly zero press releases. The metaphor had done its work and been
+discarded -- the name was now a brand, not a literary allusion.
+
+## References
+
+- Le Guin, U. K. *Rocannon's World* (1966) -- first appearance of the
+  ansible
+- Le Guin, U. K. *The Dispossessed* (1974) -- the ansible's invention as
+  a plot point, the most famous depiction
+- Card, O. S. *Ender's Game* (1985) -- the ansible as military
+  communication device, extending Le Guin's concept
+- DeHaan, M. "AnsibleFest 2013" keynote -- confirms the Le Guin naming
+  inspiration
+- Ansible Documentation, docs.ansible.com -- the tool's own documentation,
+  which makes no mention of Le Guin


### PR DESCRIPTION
## Summary

- Adds mapping `ansible-is-instant-communication`: Le Guin's faster-than-light communicator as the naming source for the DevOps automation tool
- Creates new `science-fiction` frame
- Kind: `dead-metaphor` -- most Ansible users have no awareness of the Le Guin origin; the name functions as an arbitrary brand

Closes #1040

## Validator output

All content valid. Zero errors, zero new warnings.

## Test plan

- [x] `uv run scripts/validate.py validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)