### PR TITLE
Add mapping: genetic-engineering-is-biological-programming

### DIFF
--- a/catalog/mappings/genetic-engineering-is-biological-programming.md
+++ b/catalog/mappings/genetic-engineering-is-biological-programming.md
@@ -1,0 +1,168 @@
+---
+slug: genetic-engineering-is-biological-programming
+name: "Genetic Engineering Is Biological Programming"
+kind: conceptual-metaphor
+source_frame: computing
+target_frame: biology
+categories:
+  - biology-and-ecology
+  - computer-science
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - computer-virus-is-biological-infection
+---
+
+## What It Brings
+
+The metaphor frames DNA as source code and genetic engineering as
+programming: reading, writing, debugging, and compiling biological
+software. This is not a casual analogy -- it structures how an entire
+generation of synthetic biologists thinks about their work, how funders
+evaluate it, and how the public understands it. The structural mappings
+run deep:
+
+- **DNA as source code** -- the genome is treated as a text file written
+  in a four-letter alphabet (A, T, G, C) that can be read, copied,
+  edited, and executed. Just as source code is compiled into a running
+  program, DNA is "compiled" through transcription and translation into
+  functional proteins. The metaphor makes the genome feel legible,
+  modular, and ultimately controllable -- a text that can be debugged.
+- **CRISPR as find-and-replace** -- the CRISPR-Cas9 system is routinely
+  described as "molecular scissors" or "cut and paste for DNA," but the
+  deeper metaphor is the text editor: guide RNA "searches" for a target
+  sequence the way Ctrl+F searches a document, and the Cas9 protein
+  "edits" it. Jennifer Doudna titled her popular book *A Crack in
+  Creation* (2017), but the working vocabulary of CRISPR researchers is
+  dominated by computing terms: editing, targeting, off-target effects
+  (bugs), efficiency (performance).
+- **Gene circuits as logic gates** -- synthetic biology explicitly builds
+  on the computing metaphor by designing genetic constructs that function
+  as Boolean logic gates (AND, OR, NOT). The iGEM competition
+  standardizes "BioBricks" -- modular genetic parts meant to be composed
+  like software libraries. The programming metaphor here is not just
+  descriptive; it is prescriptive, shaping how researchers design
+  biological systems.
+- **Debugging the genome** -- genetic diseases are framed as bugs in the
+  code, and gene therapy is framed as patching. This is the metaphor's
+  most powerful public-facing expression: it makes genetic disease feel
+  like a solvable engineering problem rather than a tragic feature of
+  biological complexity.
+- **Booting up synthetic life** -- Craig Venter's 2010 creation of a
+  synthetic cell was described as "booting up" a cell with synthetic DNA,
+  explicitly using the computer startup metaphor. The cell's genome was
+  "installed" like an operating system into a recipient cell body.
+
+## Where It Breaks
+
+- **Code is deterministic; biology is not** -- the same source code run
+  on the same hardware produces the same output every time. The same DNA
+  sequence in different cellular contexts produces different proteins,
+  different expression levels, and different phenotypes. Epigenetics,
+  post-translational modification, stochastic gene expression, and
+  environmental interaction mean that the "code" metaphor systematically
+  understates biological variability. DNA is not source code; it is more
+  like a recipe interpreted by a chef who improvises.
+- **There is no compiler** -- the central metaphor assumes that DNA is
+  "compiled" into proteins the way source code is compiled into machine
+  code. But transcription and translation involve a web of regulatory
+  feedback, alternative splicing, RNA interference, and context-dependent
+  folding that has no analogue in compilation. A compiler transforms
+  input to output through defined rules. Biological "compilation" is
+  more like interpretation by committee.
+- **Modularity is an aspiration, not a fact** -- the BioBricks model
+  assumes that genetic parts can be composed like software modules:
+  insert part A and part B and get function A+B. In practice, genetic
+  parts interact in context-dependent ways that violate modularity.
+  Promoters behave differently depending on their genomic neighborhood.
+  The programming metaphor makes composability seem natural when it is
+  actually the hardest unsolved problem in synthetic biology.
+- **No version control in nature** -- software development assumes you
+  can roll back to a previous version if an edit fails. Genetic edits
+  to living organisms are irreversible in practice. Off-target CRISPR
+  edits cannot be "undone" the way a git revert undoes a commit. The
+  metaphor imports an assumption of reversibility that biology does not
+  support.
+- **The metaphor obscures the organism** -- framing a genome as "code"
+  foregrounds the information and backgrounds the organism. A gene-edited
+  mouse is not a program running on hardware; it is a living being with
+  experiences, suffering, and a relationship to its environment that the
+  programming metaphor renders invisible. The ethical weight of genetic
+  engineering is reduced when the object of engineering is described as
+  a text file.
+- **Intellectual property implications** -- if DNA is "code," then it
+  can be "authored" and "owned" like software. The programming metaphor
+  has directly influenced patent law around genetic sequences. The
+  Supreme Court's *Association for Molecular Pathology v. Myriad
+  Genetics* (2013) had to grapple with whether isolated DNA sequences
+  were more like discovered natural phenomena or authored code. The
+  metaphor is not neutral; it shapes legal and economic outcomes.
+
+## Expressions
+
+- "Genetic code" -- so thoroughly naturalized that most speakers do not
+  recognize it as a metaphor; it simply means the relationship between
+  DNA triplets and amino acids
+- "Gene editing" -- the dominant term for CRISPR-based modification,
+  framing the process as text editing rather than biological
+  intervention
+- "Programming cells" -- synthetic biology's self-description, used in
+  grant applications, TED talks, and undergraduate textbooks
+- "Debugging the genome" -- finding and fixing genetic errors, used
+  both in research contexts and in popular science journalism
+- "Biological software" -- used to distinguish DNA (the "software") from
+  the cell (the "hardware"), importing the hardware/software distinction
+  wholesale
+- "Booting up a cell" -- Venter's description of synthetic cell creation,
+  now used for any cell with a transplanted or synthetic genome
+- "BioBricks" -- standardized genetic parts, named to evoke Lego and
+  software libraries simultaneously
+- "Wetware" -- biological systems described by analogy to hardware and
+  software, implying that biology is simply another computing substrate
+- "Biohacking" -- amateur genetic engineering, framing biology as a
+  system to be hacked the way software can be hacked
+
+## Origin Story
+
+The information metaphor for genetics has deep roots. Erwin Schrodinger
+described chromosomes as containing "the code-script of the individual's
+future development" in *What is Life?* (1944), a decade before Watson
+and Crick. When the structure of DNA was discovered in 1953, the
+language of information theory was immediately applied: the genetic
+"code" was "read" by the cell's machinery to produce proteins. George
+Gamow proposed the "coding problem" -- how a four-letter alphabet
+encodes twenty amino acids -- in 1954, and the metaphor was established
+before computing was widespread.
+
+The programming-specific layer came later. As molecular biology matured
+in the 1970s-90s and recombinant DNA technology made genetic manipulation
+practical, computing metaphors replaced the earlier information-theory
+metaphors. By the 2000s, with the Human Genome Project complete and
+synthetic biology emerging as a field, the programming metaphor became
+dominant. Drew Endy at MIT explicitly framed synthetic biology as
+"programming living organisms" and designed the BioBricks standard to
+make the metaphor operational. CRISPR's arrival in 2012 completed the
+shift: gene editing was described in computing terms from the first
+press coverage.
+
+The metaphor is now so embedded in biology's self-understanding that it
+shapes research programs, funding priorities, and public expectations.
+When George Church says "we're learning to program life," the metaphor
+is not decorative -- it is the frame through which the research is
+conceived, funded, and evaluated.
+
+## References
+
+- Schrodinger, E. *What is Life?* (1944) -- the "code-script" metaphor
+  that preceded computing
+- Kay, L. E. *Who Wrote the Book of Life?* (2000) -- the definitive
+  history of the information metaphor in genetics
+- Endy, D. "Foundations for Engineering Biology," *Nature* 438 (2005) --
+  the manifesto for programming-as-biology
+- Doudna, J. & Sternberg, S. *A Crack in Creation* (2017) -- CRISPR
+  explained through editing/programming metaphors
+- Keller, E. F. *Refiguring Life* (1995) -- critique of the
+  gene-as-program metaphor and its conceptual costs
+- Nicholson, D. J. "Is the Cell Really a Machine?" *Journal of
+  Theoretical Biology* 477 (2019) -- systematic critique of the
+  computational metaphor in biology


### PR DESCRIPTION
## Summary

- Adds mapping `genetic-engineering-is-biological-programming`: computing/programming as the dominant conceptual frame for understanding genetic engineering, from "genetic code" to CRISPR-as-text-editing to BioBricks-as-software-libraries
- Kind: `conceptual-metaphor` -- the computing source domain is actively and visibly deployed in synthetic biology discourse, grant applications, and public communication
- No new frames needed (uses existing `computing` and `biology` frames)
- Traces the metaphor from Schrodinger's "code-script" (1944) through information theory, recombinant DNA, and CRISPR

Closes #1043

## Validator output

All content valid. Zero errors, zero new warnings.

## Test plan

- [x] `uv run scripts/validate.py validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)