### PR TITLE
Add mapping: mentat-is-human-computer

### DIFF
--- a/catalog/frames/human-computation.md
+++ b/catalog/frames/human-computation.md
@@ -1,0 +1,23 @@
+---
+slug: human-computation
+name: "Human Computation"
+related:
+  - computing
+  - social-roles
+roles:
+  - operator
+  - training
+  - conditioning
+  - output
+  - enhancement
+  - substitution
+---
+
+Humans performing tasks normally associated with machines: calculation,
+data processing, pattern recognition, and logical inference. The frame
+encompasses both the historical reality (human "computers" at NASA,
+Bletchley Park codebreakers) and the fictional extreme (Herbert's
+Mentats, trained from childhood to replace banned AI). As a source
+domain, human computation imports assumptions about replaceability,
+the blurring of person and function, and the costs of sustaining
+machine-like performance in biological beings.

--- a/catalog/mappings/mentat-is-human-computer.md
+++ b/catalog/mappings/mentat-is-human-computer.md
@@ -1,0 +1,141 @@
+---
+slug: mentat-is-human-computer
+name: "Mentat Is Human Computer"
+kind: conceptual-metaphor
+source_frame: human-computation
+target_frame: artificial-intelligence
+categories:
+  - ai-discourse
+  - philosophy
+author: agent:metaphorex-miner
+contributors: []
+related: []
+---
+
+## What It Brings
+
+In Herbert's *Dune* universe, the Butlerian Jihad has destroyed all
+"thinking machines." In their place, humans called Mentats are trained
+from childhood to perform computer-like feats of logic, data analysis,
+and strategic computation. A Mentat is not a mystic or a genius in the
+Romantic sense -- he is a human deliberately shaped into a processor.
+The Mentat's mantra is: "It is by will alone I set my mind in motion."
+
+When this concept escapes *Dune* into real-world discourse, it imports
+a specific set of structural parallels:
+
+- **Prohibition breeds substitution** -- the Butlerian Jihad banned AI,
+  so civilization found a human substitute. The metaphor maps onto any
+  situation where a technology is restricted and human labor fills the
+  gap: content moderation (humans reviewing what algorithms flag), AI
+  red-teaming (humans stress-testing what machines produce), and the
+  recurring pattern where "AI" products turn out to rely on concealed
+  human workers. The Mentat frame names the substitution pattern:
+  eliminate the machine, create a human who acts like one.
+- **Training as manufacturing** -- Mentats are not born; they are
+  produced through rigorous conditioning. The parallel to machine
+  learning is structural: both Mentats and neural networks are shaped
+  by their training regimen rather than by innate properties. The
+  metaphor highlights the uncomfortable symmetry between training a
+  human to think like a machine and training a machine to think like
+  a human.
+- **Sapho juice as performance enhancement** -- Mentats use a
+  substance called sapho juice to amplify their computational
+  abilities, staining their lips red. The frame maps onto cognitive
+  enhancement drugs (modafinil, Adderall) in knowledge-worker culture,
+  and onto the broader question of what it costs to sustain
+  superhuman-seeming performance. The stained lips are the visible
+  mark of the price paid.
+- **The human as tool** -- the Mentat is valued for his function, not
+  his personhood. He is "a human computer," and the noun that matters
+  is "computer." This maps onto the dehumanization of knowledge
+  workers whose value is measured in outputs per hour: data labelers,
+  annotation workers, and the human computation layer behind AI
+  systems.
+
+The metaphor's distinctive contribution is its inversion of the usual
+AI anxiety. Instead of "machines will replace humans," the Mentat frame
+asks: "what happens when humans are forced to replace machines?"
+
+## Where It Breaks
+
+- **Mentats are elite; real human computation workers are exploited** --
+  in *Dune*, Mentats hold positions of power as advisors to noble
+  houses. They are rare, respected, and politically influential. The
+  real-world humans who perform computation that AI cannot (or is not
+  trusted to) -- content moderators in Manila, data labelers in
+  Nairobi -- occupy the opposite end of the power spectrum. The Mentat
+  frame glamorizes human computation work and obscures the labor
+  conditions of the people who actually do it.
+- **The prohibition premise is fictional** -- Herbert's Butlerian Jihad
+  is a plot device that removes AI from the story entirely. In reality,
+  AI and human computation coexist and interact. The Mentat metaphor
+  implies a clean binary (machines OR humans) that does not reflect the
+  messy reality of human-AI collaboration, where the interesting
+  questions are about hybrid systems, not substitution.
+- **Herbert's Mentats are individuals; real computation is distributed** --
+  a Mentat is a single extraordinary person. Real human computation
+  systems (Amazon Mechanical Turk, content moderation farms, RLHF
+  annotation pipelines) distribute the work across thousands of
+  ordinary people. The Mentat frame encourages thinking about human
+  computation as a matter of individual brilliance rather than
+  industrial-scale labor organization.
+- **The frame obscures what machines actually do well** -- by imagining
+  a world where humans do everything machines could do, the Mentat
+  metaphor understates the genuine advantages of machine computation:
+  speed, scale, consistency, and tirelessness. No human Mentat can
+  process a billion transactions per second. The metaphor is useful
+  for questioning AI dependency but misleading about the practical
+  irreplaceability of machines for many tasks.
+
+## Expressions
+
+- "Human in the loop" -- the standard AI safety term that echoes the
+  Mentat's role: a human performing computation that the system
+  cannot or should not do alone
+- "Mechanical Turk" -- Amazon's platform for human computation tasks,
+  named after an earlier version of the same metaphor (the 18th-century
+  chess-playing automaton that concealed a human operator)
+- "Ghost work" -- Mary Gray's term for the hidden human labor behind
+  AI systems, the contemporary Mentat workforce that nobody sees
+- "Butlerian Jihad" -- invoked in AI regulation debates to describe
+  proposals to ban or severely restrict AI development, usually by
+  opponents who consider such proposals impractical
+- "Sapho juice" -- used informally for cognitive enhancement drugs,
+  nootropics, or any substance consumed to sustain high-output
+  knowledge work
+- "Wetware" -- the human brain treated as computational hardware, a
+  term that carries the Mentat assumption: humans are computers made
+  of meat
+
+## Origin Story
+
+Herbert introduced Mentats in *Dune* (1965) as part of his broader
+project of imagining a future that rejected the assumptions of
+golden-age science fiction. Where Asimov built stories around robots
+and computers, Herbert removed them entirely and asked what would fill
+the vacuum. The Mentat was his answer for computation, as the Bene
+Gesserit were his answer for social manipulation and the Guild
+Navigators for space travel: human specialization pushed to
+superhuman extremes.
+
+The concept gained a second life in AI discourse after 2020, when the
+scale of hidden human labor behind AI systems became a public
+controversy. Reports on content moderation trauma, data labeling
+sweatshops, and the human annotation pipeline behind RLHF made the
+Mentat a ready-made frame for the argument that "AI" is partly a
+rebranding of human computation. The metaphor is now used by both AI
+critics (who invoke it to highlight exploitation) and AI skeptics
+(who invoke it to argue that current AI is less autonomous than
+advertised).
+
+## References
+
+- Herbert, F. *Dune* (1965), especially the appendix on the
+  Butlerian Jihad
+- Gray, M. L. and Suri, S. *Ghost Work: How to Stop Silicon Valley
+  from Building a New Global Underclass* (2019)
+- Roberts, S. T. *Behind the Screen: Content Moderation in the
+  Shadows of Social Media* (2019)
+- Perrigo, B. "OpenAI Used Kenyan Workers on Less Than $2 Per Hour
+  to Make ChatGPT Less Toxic" -- *Time* (2023)


### PR DESCRIPTION
## Summary
- Adds mapping for Herbert's Mentats (Dune) as frame for human computation and hidden labor behind AI
- Creates new `human-computation` source frame
- Resolves #1045

## Validator output
All content valid. No new errors introduced.

## Test plan
- [x] `uv run scripts/validate.py validate` passes

Generated with [Claude Code](https://claude.com/claude-code)