### PR TITLE
Add mapping: dyson-sphere-is-megastructure-ambition

### DIFF
--- a/catalog/frames/engineering-ambition.md
+++ b/catalog/frames/engineering-ambition.md
@@ -1,0 +1,24 @@
+---
+slug: engineering-ambition
+name: "Engineering Ambition"
+related:
+  - manufacturing
+  - physics
+  - governance
+roles:
+  - vision
+  - scale
+  - coordination
+  - resources
+  - feasibility
+  - timeline
+---
+
+The aspiration to solve problems through large-scale engineering
+projects: infrastructure, energy systems, planetary modification,
+compute scaling. As a target domain, engineering ambition is shaped
+by competing source metaphors that determine whether scale is seen
+as visionary (megastructure, moonshot) or hubristic (Tower of Babel,
+Icarus). The frame carries assumptions about the relationship
+between ambition and capability, and between the scale of a
+problem and the scale of its solution.

--- a/catalog/frames/megastructure.md
+++ b/catalog/frames/megastructure.md
@@ -1,0 +1,22 @@
+---
+slug: megastructure
+name: "Megastructure"
+related:
+  - physics
+  - manufacturing
+roles:
+  - structure
+  - scale
+  - resource-capture
+  - civilization
+  - construction
+  - coordination
+---
+
+Engineering constructions at planetary or stellar scale: Dyson spheres,
+ringworlds, orbital habitats, space elevators. As a source domain,
+megastructures import assumptions about civilizational ambition (bigger
+is more advanced), total resource utilization (capture everything), and
+the necessity of unprecedented coordination. The frame makes partial
+solutions feel like incomplete versions of the total solution, and
+treats engineering scale as a measure of civilizational maturity.

--- a/catalog/mappings/dyson-sphere-is-megastructure-ambition.md
+++ b/catalog/mappings/dyson-sphere-is-megastructure-ambition.md
@@ -1,0 +1,151 @@
+---
+slug: dyson-sphere-is-megastructure-ambition
+name: "Dyson Sphere Is Megastructure Ambition"
+kind: conceptual-metaphor
+source_frame: megastructure
+target_frame: engineering-ambition
+categories:
+  - physics-and-engineering
+  - ai-discourse
+author: agent:metaphorex-miner
+contributors: []
+related: []
+---
+
+## What It Brings
+
+In 1960, Freeman Dyson proposed that an advanced civilization might
+construct a shell or swarm of structures around its star to capture
+the entirety of its energy output. The concept was not science fiction
+in origin -- it was a physics paper -- but science fiction adopted it
+so thoroughly (Larry Niven's *Ringworld*, Iain Banks's Orbitals, the
+Star Trek: The Next Generation episode "Relics") that it functions as
+a science fiction metaphor in public discourse. When people say "Dyson
+sphere," they rarely mean Dyson's original proposal. They mean the
+fictional image: a civilization so ambitious it wraps a star.
+
+The metaphor imports a specific structure when applied to real-world
+engineering ambitions:
+
+- **Total resource capture as design goal** -- a Dyson sphere captures
+  all of a star's energy, not a fraction. The metaphor maps onto
+  engineering visions that aim at total utilization: covering every
+  rooftop with solar panels, indexing all human knowledge, training AI
+  on "all the data." The Dyson sphere frame makes partial solutions
+  feel inadequate and total solutions feel like the natural endpoint.
+- **Civilization-scale coordination** -- building a Dyson sphere
+  requires resources and coordination beyond any single nation or
+  corporation. The metaphor maps onto projects that demand
+  unprecedented cooperation: climate mitigation, space colonization,
+  global AI governance. It imports the assumption that sufficiently
+  important problems justify civilization-scale mobilization.
+- **The Kardashev scale as progress narrative** -- Dyson spheres are
+  associated with the Kardashev scale, which classifies civilizations
+  by energy consumption (Type I: planet, Type II: star, Type III:
+  galaxy). The metaphor imports a linear progress narrative where
+  more energy equals more advanced. This maps onto tech industry
+  rhetoric about scaling: more compute, more data, more parameters
+  as the path to intelligence.
+- **Detection as proof of ambition** -- Dyson proposed his concept
+  partly as a method for detecting alien civilizations: look for
+  stars with anomalous infrared signatures. The metaphor imports the
+  idea that truly ambitious projects are visible at a distance. In
+  tech discourse, this maps onto the expectation that serious
+  companies should be building at scale: if you are not visible from
+  far away, you are not ambitious enough.
+
+## Where It Breaks
+
+- **Dyson himself preferred a swarm, not a sphere** -- the popular
+  image of a solid shell around a star is structurally impossible
+  (it would collapse under gravitational stress). Dyson proposed a
+  swarm of independent satellites. The metaphor has been corrupted
+  by science fiction into something its originator considered
+  physically implausible. When people invoke "Dyson sphere" to
+  describe engineering ambition, they are invoking the fictional
+  version that the actual physicist rejected.
+- **The frame conflates ambition with wisdom** -- a Dyson sphere is
+  impressive but not necessarily good. Capturing all of a star's
+  energy says nothing about what you do with it. The metaphor makes
+  scale intrinsically admirable, which maps onto the tech industry's
+  tendency to treat growth as a proxy for value. "We're building a
+  Dyson sphere" sounds visionary; "we're consuming all available
+  resources" sounds reckless. They describe the same action.
+- **Total capture ignores diminishing returns** -- the last ten
+  percent of a star's energy output costs enormously more to capture
+  than the first ten percent. Real engineering is dominated by
+  diminishing returns, but the Dyson sphere frame imagines a
+  project where total capture is the goal and partial capture is
+  merely unfinished. This distorts cost-benefit analysis by making
+  "good enough" feel like failure.
+- **The metaphor assumes a single, central resource** -- a Dyson
+  sphere wraps one star. Real energy and compute systems are
+  distributed: solar farms across continents, data centers across
+  regions, research labs across institutions. The centralized
+  megastructure frame discourages thinking about distributed,
+  resilient architectures in favor of monolithic, single-point
+  designs.
+- **It is not possible** -- at current or foreseeable technology
+  levels, a Dyson sphere or even a Dyson swarm is beyond
+  engineering capability by many orders of magnitude. Using it as
+  a frame for real projects imports an aspirational impossibility
+  that can distort planning horizons. "We're building toward a
+  Dyson sphere" can justify any timeline and any expenditure,
+  because the goal is acknowledged to be centuries away.
+
+## Expressions
+
+- "Dyson sphere project" -- used to describe any engineering effort
+  of extraordinary ambition and scale, especially in energy and
+  compute infrastructure
+- "Kardashev Type II" -- shorthand for civilization-scale energy
+  capture; invoked in discussions of long-term human potential
+- "Megastructure thinking" -- the disposition to solve problems by
+  building at the largest possible scale rather than optimizing at
+  smaller scales
+- "Wrapping the star" -- maximalist resource capture; applied to
+  data collection strategies, compute scaling, and market
+  consolidation
+- "We're not even Type I yet" -- used to deflate ambitious rhetoric
+  by pointing out that humanity has not mastered planetary-scale
+  energy, let alone stellar
+- "Ringworld" -- Niven's variant (a single ring rather than a full
+  sphere), sometimes used as a more "practical" version of the same
+  ambition
+
+## Origin Story
+
+Freeman Dyson published "Search for Artificial Stellar Sources of
+Infrared Radiation" in *Science* (1960), proposing that advanced
+civilizations would construct structures to capture stellar energy
+and that such structures would be detectable by their infrared
+emissions. The paper was a serious SETI proposal, not a blueprint
+for construction.
+
+Science fiction transformed the concept into a staple of
+megastructure fiction. Niven's *Ringworld* (1970), Banks's Culture
+novels (1987-2012), and numerous Star Trek episodes gave the concept
+visual and narrative form. By the time the concept entered mainstream
+technology discourse -- particularly during the scaling debates in
+AI and cloud computing around 2020-2024 -- "Dyson sphere" had
+become shorthand for "the most ambitious thing a civilization could
+build," divorced from its origins as an observational astronomy
+technique.
+
+The concept received renewed attention in 2015 when anomalous
+dimming of Tabby's Star (KIC 8462852) was briefly attributed to a
+possible Dyson structure, generating mainstream media coverage and
+reinforcing the concept's cultural availability as a frame for
+ambition.
+
+## References
+
+- Dyson, F. J. "Search for Artificial Stellar Sources of Infrared
+  Radiation" -- *Science* 131.3414 (1960)
+- Niven, L. *Ringworld* (1970) -- the most influential fictional
+  Dyson variant
+- Kardashev, N. S. "Transmission of Information by Extraterrestrial
+  Civilizations" -- *Soviet Astronomy* 8 (1964) -- the energy
+  classification scale associated with Dyson structures
+- Banks, I. M. *Consider Phlebas* (1987) and subsequent Culture
+  novels -- Orbitals as scaled-down Dyson variants


### PR DESCRIPTION
## Summary
- Adds mapping for Dyson sphere as frame for civilization-scale engineering ambition
- Creates new `megastructure` source frame and `engineering-ambition` target frame
- Resolves #1047

## Validator output
All content valid. No new errors introduced.

## Test plan
- [x] `uv run scripts/validate.py validate` passes

Generated with [Claude Code](https://claude.com/claude-code)