### PR TITLE
Add mapping: holodeck-is-total-simulation

### DIFF
--- a/catalog/frames/science-fiction.md
+++ b/catalog/frames/science-fiction.md
@@ -1,0 +1,28 @@
+---
+slug: science-fiction
+name: "Science Fiction"
+related:
+  - narrative
+  - mythology
+roles:
+  - technology
+  - society
+  - alien
+  - future
+  - device
+  - governance
+  - warning
+  - utopia
+  - dystopia
+---
+
+Speculative narratives that extrapolate from current science and technology
+to explore possible futures, alternative societies, and the consequences of
+invention. As a source domain for metaphor, science fiction is uniquely
+productive because its concepts are designed to be structurally legible --
+a tricorder is not just a prop but a thought experiment about universal
+sensing, a holodeck is not just a set but a thought experiment about total
+simulation. These fictional constructs escape their source material and
+become load-bearing frames for reasoning about real technology, policy,
+and culture. The metaphorical transfer runs one direction: fictional concept
+to real-world framing device.

--- a/catalog/frames/simulation.md
+++ b/catalog/frames/simulation.md
@@ -1,0 +1,23 @@
+---
+slug: simulation
+name: "Simulation"
+related:
+  - computing
+  - representation
+roles:
+  - model
+  - environment
+  - agent
+  - fidelity
+  - boundary
+  - immersion
+  - scenario
+---
+
+The construction of artificial environments or processes that replicate
+aspects of real ones. Simulation involves choosing what to model and what
+to omit, defining the boundary between the simulated world and the real
+one, and managing the fidelity trade-off between accuracy and tractability.
+As a target domain, simulation draws on spatial metaphors (worlds, rooms,
+landscapes) and theatrical metaphors (scenarios, actors, stages) to make
+the abstract activity of modeling feel inhabitable.

--- a/catalog/mappings/holodeck-is-total-simulation.md
+++ b/catalog/mappings/holodeck-is-total-simulation.md
@@ -1,0 +1,137 @@
+---
+slug: holodeck-is-total-simulation
+name: "Holodeck Is Total Simulation"
+kind: conceptual-metaphor
+source_frame: science-fiction
+target_frame: simulation
+categories:
+  - computer-science
+  - arts-and-culture
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - tricorder-is-universal-sensor
+---
+
+## What It Brings
+
+The Star Trek holodeck -- a room-sized environment that generates
+photorealistic, physically interactive simulations indistinguishable from
+reality -- has become the aspirational frame for immersive simulation
+technology. When VR researchers, military trainers, and game designers
+invoke the holodeck, they are mapping a specific fictional architecture
+onto their design goals.
+
+- **Total immersion as the end state** -- the holodeck does not approximate
+  reality; it replaces it. Users walk on holographic ground, touch
+  holographic objects, and interact with holographic people who pass the
+  Turing test. This frames the trajectory of simulation technology as
+  convergence toward indistinguishability from reality. Every VR headset,
+  haptic glove, and mixed-reality system is implicitly positioned on a
+  spectrum that ends at the holodeck.
+- **The room as interface** -- the holodeck is not worn on the head or
+  viewed on a screen. It is a room you walk into. This architectural
+  framing has shaped real simulation design: CAVE systems (Cave Automatic
+  Virtual Environments), military simulation domes, and immersive theater
+  installations all adopt the room-as-computer paradigm that the holodeck
+  introduced to popular imagination.
+- **Scenario as the unit of experience** -- holodeck programs are not
+  applications in the software sense; they are scenarios: "a Victorian
+  mystery," "a Klingon battle," "a jazz club in 1944 New Orleans." This
+  frames simulation as narrative rather than computational, which has
+  influenced how training simulations, serious games, and therapeutic VR
+  are designed and marketed. You do not run a program; you enter a story.
+- **Safety through containment** -- the holodeck has walls. The simulation
+  ends when you say "computer, end program." This frames total simulation
+  as fundamentally safe because it is bounded -- a contained space where
+  consequences are reversible. The frame powerfully shapes attitudes
+  toward VR therapy, flight simulation, and military training: the
+  holodeck metaphor promises that immersion and safety are compatible.
+
+## Where It Breaks
+
+- **The holodeck malfunctions are the real lesson** -- Star Trek's holodeck
+  episodes are almost always about the holodeck going wrong: safeties
+  failing, characters becoming self-aware, simulations that cannot be
+  ended. The fiction itself repeatedly demonstrates that total simulation
+  is dangerous, but the metaphorical borrowing consistently ignores this
+  and takes only the aspirational frame. Engineers cite the holodeck as
+  a goal while forgetting that the show treats it as a recurring source
+  of catastrophe.
+- **Indistinguishability is not a spectrum** -- the holodeck frame implies
+  that simulation fidelity exists on a continuum from "crude" to
+  "perfect," and that progress means moving rightward. But the uncanny
+  valley suggests the relationship is non-monotonic: increasing fidelity
+  can decrease effectiveness. A stylized, abstract simulation may train
+  better than a photorealistic one because it reduces cognitive load and
+  focuses attention on the relevant features. The holodeck metaphor has
+  no vocabulary for "good enough" or "deliberately unrealistic."
+- **The frame erases the body** -- real VR causes motion sickness,
+  disorientation, eye strain, and proprioceptive confusion precisely
+  because the body is not in the simulated environment. The holodeck
+  hand-waves this with "inertial dampeners" and "force fields." By
+  treating the body as a solved problem, the metaphor systematically
+  underestimates the hardest engineering challenges in immersive
+  simulation.
+- **Containment is an illusion** -- the holodeck's walls promise that
+  simulation stays in the room. Real immersive experiences do not stay
+  contained. PTSD from VR exposure therapy, behavioral changes from
+  training simulations, and social effects of prolonged virtual
+  immersion all demonstrate that the boundaries between simulated and
+  real experience are porous. The holodeck frame's clean on/off
+  distinction conceals the psychological bleed that is characteristic
+  of powerful simulations.
+- **Total simulation requires total surveillance** -- to simulate a
+  responsive environment, the holodeck must continuously monitor every
+  aspect of the user's body, position, gaze, and intention. The frame
+  presents this as a neutral technical requirement, but real immersive
+  systems collect extraordinary amounts of biometric data. The holodeck
+  metaphor naturalizes total surveillance as the price of total
+  immersion.
+
+## Expressions
+
+- "We're building the holodeck" -- the mission statement of numerous VR
+  companies, used with varying degrees of irony
+- "Holodeck moment" -- the point at which a simulation becomes immersive
+  enough to forget you are in one, used in VR/AR industry discourse
+- "Computer, end program" -- invoked humorously when leaving a VR session
+  or, more seriously, as a design principle for simulation exit protocols
+- "Holodeck for training" -- military, medical, and industrial shorthand
+  for immersive training simulation, often used in procurement documents
+  and grant proposals
+- "The holodeck problem" -- the philosophical and engineering challenge
+  of distinguishing simulated from real experience, echoing Baudrillard
+  but in a pop-culture register
+
+## Origin Story
+
+The holodeck first appeared in Star Trek: The Animated Series (1974) as
+the "recreation room" and was fully developed in Star Trek: The Next
+Generation (1987-1994), where it became a major plot device. Created by
+Gene Roddenberry and developed by the TNG writing staff, the holodeck
+served a dual narrative purpose: it provided exotic settings without
+location shoots, and it generated stories about the boundary between
+real and simulated experience.
+
+The concept entered engineering and design vocabulary in the 1990s as
+VR technology matured. CAVE systems at the University of Illinois
+(1992) were explicitly described in holodeck terms. The word became
+standard in VR industry pitches, military simulation procurement, and
+popular science writing about immersive technology. By the 2010s,
+"building the holodeck" had become a cliche of VR startup culture,
+used so frequently that its fictional origin sometimes needed to be
+pointed out.
+
+## References
+
+- Roddenberry, G. *Star Trek: The Next Generation* (1987-1994) -- the
+  source material that established the holodeck concept
+- Cruz-Neira, C. et al. "The CAVE: Audio Visual Experience Automatic
+  Virtual Environment," *SIGGRAPH* (1992) -- the first real "holodeck"
+- Bailenson, J. *Experience on Demand* (2018) -- VR research that
+  engages with the holodeck frame and its limitations
+- Murray, J. *Hamlet on the Holodeck* (1997) -- foundational text on
+  narrative in digital environments, using the holodeck as organizing
+  metaphor


### PR DESCRIPTION
## Summary

- Adds `holodeck-is-total-simulation` mapping (kind: `conceptual-metaphor`)
- Creates `science-fiction` source frame and `simulation` target frame
- Star Trek's holodeck as the aspirational frame for immersive VR/simulation technology

Closes #1050
Sub-issue of #218

## Validator output

All content valid (0 errors, 0 new warnings besides expected dangling cross-ref to tricorder on separate branch).

## Test plan

- [x] `uv run scripts/validate.py validate` passes

Generated with [Claude Code](https://claude.com/claude-code)