### PR TITLE
Add mapping: grok-is-deep-understanding

### DIFF
--- a/catalog/frames/science-fiction.md
+++ b/catalog/frames/science-fiction.md
@@ -1,0 +1,28 @@
+---
+slug: science-fiction
+name: "Science Fiction"
+related:
+  - narrative
+  - mythology
+roles:
+  - technology
+  - society
+  - alien
+  - future
+  - device
+  - governance
+  - warning
+  - utopia
+  - dystopia
+---
+
+Speculative narratives that extrapolate from current science and technology
+to explore possible futures, alternative societies, and the consequences of
+invention. As a source domain for metaphor, science fiction is uniquely
+productive because its concepts are designed to be structurally legible --
+a tricorder is not just a prop but a thought experiment about universal
+sensing, a holodeck is not just a set but a thought experiment about total
+simulation. These fictional constructs escape their source material and
+become load-bearing frames for reasoning about real technology, policy,
+and culture. The metaphorical transfer runs one direction: fictional concept
+to real-world framing device.

--- a/catalog/mappings/grok-is-deep-understanding.md
+++ b/catalog/mappings/grok-is-deep-understanding.md
@@ -1,0 +1,139 @@
+---
+slug: grok-is-deep-understanding
+name: "Grok Is Deep Understanding"
+kind: dead-metaphor
+source_frame: science-fiction
+target_frame: intellectual-inquiry
+categories:
+  - linguistics
+  - software-engineering
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related: []
+---
+
+## What It Brings
+
+"Grok" was coined by Robert A. Heinlein in *Stranger in a Strange Land*
+(1961) as a Martian word meaning to understand something so thoroughly
+that the observer becomes part of the observed. In the novel, to grok
+is to drink something in, to merge with it, to comprehend it at a level
+that transcends analysis. The word was adopted by 1960s counterculture,
+entered the Jargon File in the 1970s, and became standard programmer
+vocabulary by the 1980s. Most people who use it today have never read
+Heinlein.
+
+- **Understanding as ingestion** -- in Heinlein's Martian, "grok"
+  literally means "to drink." To grok something is to take it inside
+  yourself, to make it part of you. This maps onto a real cognitive
+  experience that English lacks a precise word for: the difference
+  between knowing *about* something and knowing it so deeply that it
+  becomes intuitive. A programmer who groks a codebase does not just
+  understand the API; they can predict how the system will behave in
+  novel situations because they have internalized its logic.
+- **A word for tacit knowledge** -- grok fills a lexical gap. English
+  has "understand," "comprehend," "know," and "appreciate," but none
+  of these captures the specific quality of deep, embodied, non-verbal
+  understanding that grok denotes. When a systems engineer says "I
+  grok distributed consensus," they mean something different from "I
+  understand distributed consensus." They mean they have built and
+  debugged enough consensus systems that the knowledge is in their
+  hands, not just their heads.
+- **Intellectual intimacy** -- the Heinlein original implies a merging
+  of identities between knower and known. This carries into technical
+  usage as a claim of intimacy with a system: "I grok this codebase"
+  implies not just competence but a relationship with the code, a
+  history of engagement that produced deep familiarity. The word
+  encodes the idea that real understanding requires time and immersion,
+  not just study.
+
+## Where It Breaks
+
+- **The mysticism is gone** -- in Heinlein's novel, grokking is a
+  quasi-religious act that can lead to telekinesis, telepathy, and the
+  ability to make things cease to exist. The computing usage has
+  stripped away everything supernatural, leaving only "deep
+  understanding." This is not a minor loss; the original concept's
+  power came from the claim that sufficiently deep understanding gives
+  you power over the thing understood. The dead metaphor retains the
+  cognitive claim (deep knowing) but discards the ontological claim
+  (deep knowing changes reality).
+- **Grok implies completeness that is impossible for complex systems**
+  -- to grok something is to understand it fully, but modern software
+  systems are too complex for any individual to fully understand. The
+  word encodes a pre-microservices, pre-distributed-systems assumption
+  that a single mind can hold an entire system. Using "I grok this"
+  for a system with millions of lines of code and dozens of services
+  is either self-deception or a redefinition of the word to mean
+  "I understand the parts I work with."
+- **It flatters the speaker** -- saying "I grok X" is a status claim.
+  It positions the speaker as having achieved a level of understanding
+  that others have not. The word has no built-in humility: there is no
+  "I partially grok" or "I used to grok but the system changed."
+  This makes it a tool for gatekeeping -- "you don't really grok
+  functional programming" is a dismissal dressed as an epistemological
+  observation.
+- **The counterculture context has evaporated** -- Heinlein's novel is
+  a 1960s countercultural text about free love, religious skepticism,
+  and alien consciousness. The word "grok" carried those associations
+  into early hacker culture, where it signaled membership in a
+  community that valued deep understanding over credentialism. In
+  contemporary usage, "grok" is just a synonym for "understand well,"
+  used by people who may have no connection to either Heinlein or
+  1960s counterculture. Elon Musk's AI company named "Grok" completes
+  the journey from countercultural shibboleth to corporate brand.
+
+## Expressions
+
+- "I grok it" -- the basic usage, meaning "I understand it deeply,"
+  common in engineering conversations
+- "Do you grok Kubernetes?" -- a technical interview-style question
+  that asks about depth of understanding, not just familiarity
+- "Once you grok monads, everything clicks" -- the pedagogical usage,
+  implying that certain concepts require a threshold crossing from
+  confusion to deep understanding
+- "I don't grok the error message" -- a softened version where grok
+  just means "understand," with no implication of depth -- evidence
+  of the metaphor's death
+- "Grok this" -- imperative form, meaning "try to understand this
+  deeply," sometimes used when introducing a difficult concept
+- "xAI's Grok" -- Elon Musk's AI chatbot (2023), named to suggest
+  deep understanding, completing the word's journey from Martian
+  religious concept to AI product name
+
+## Origin Story
+
+Robert A. Heinlein coined "grok" in *Stranger in a Strange Land* (1961),
+a novel about Valentine Michael Smith, a human raised by Martians who
+returns to Earth. In Martian, "grok" literally means "to drink" but
+connotes a total, identity-dissolving understanding. The novel was a
+bestseller and a countercultural touchstone; "grok" entered the vocabulary
+of the 1960s alongside concepts from Eastern philosophy and psychedelic
+experience.
+
+The word migrated to computing culture through the intersection of
+counterculture and early hacker culture at MIT and Stanford in the late
+1960s and 1970s. It appeared in the Jargon File (compiled by Raphael
+Finkel in 1975, later maintained by Guy Steele and Eric Raymond) as
+standard hacker vocabulary. By the 1990s, it was common in technical
+writing, conference talks, and programming tutorials. The *New Hacker's
+Dictionary* (1996) defined it as "to understand profoundly and
+intuitively."
+
+The word's journey from science fiction to general technical vocabulary
+took roughly 30 years. Its 2023 adoption as the name of an AI product
+marks a new phase: the word is now a brand, further detaching it from
+its Heinlein origins.
+
+## References
+
+- Heinlein, R.A. *Stranger in a Strange Land* (1961) -- the source
+  material
+- Raymond, E.S. *The New Hacker's Dictionary* (3rd ed., 1996) --
+  documents grok's absorption into hacker vocabulary
+- Steele, G.L. et al. *The Hacker's Dictionary* (1983) -- earlier
+  codification of the term
+- Pfaffenberger, B. "The Social Meaning of the Personal Computer,"
+  *Anthropological Quarterly* 61:1 (1988) -- discusses grok as part
+  of hacker subculture linguistics


### PR DESCRIPTION
## Summary

- Adds `grok-is-deep-understanding` mapping (kind: `dead-metaphor`)
- Creates `science-fiction` source frame
- Heinlein's Martian word for total understanding, now standard programmer vocabulary completely detached from its SF origin

Closes #1052
Sub-issue of #218

## Validator output

All content valid (0 errors, 0 new warnings).

## Test plan

- [x] `uv run scripts/validate.py validate` passes

Generated with [Claude Code](https://claude.com/claude-code)