### PR TITLE
Add mapping: waldo-is-remote-manipulation

### DIFF
--- a/catalog/frames/science-fiction.md
+++ b/catalog/frames/science-fiction.md
@@ -1,0 +1,28 @@
+---
+slug: science-fiction
+name: "Science Fiction"
+related:
+  - narrative
+  - mythology
+roles:
+  - technology
+  - society
+  - alien
+  - future
+  - device
+  - governance
+  - warning
+  - utopia
+  - dystopia
+---
+
+Speculative narratives that extrapolate from current science and technology
+to explore possible futures, alternative societies, and the consequences of
+invention. As a source domain for metaphor, science fiction is uniquely
+productive because its concepts are designed to be structurally legible --
+a tricorder is not just a prop but a thought experiment about universal
+sensing, a holodeck is not just a set but a thought experiment about total
+simulation. These fictional constructs escape their source material and
+become load-bearing frames for reasoning about real technology, policy,
+and culture. The metaphorical transfer runs one direction: fictional concept
+to real-world framing device.

--- a/catalog/mappings/waldo-is-remote-manipulation.md
+++ b/catalog/mappings/waldo-is-remote-manipulation.md
@@ -1,0 +1,146 @@
+---
+slug: waldo-is-remote-manipulation
+name: "Waldo Is Remote Manipulation"
+kind: dead-metaphor
+source_frame: science-fiction
+target_frame: tool-use
+categories:
+  - physics-and-engineering
+  - software-engineering
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - grok-is-deep-understanding
+---
+
+## What It Brings
+
+"Waldo" was the title character of Robert A. Heinlein's 1942 novella
+*Waldo*, a disabled genius who invents mechanical hands that replicate
+human hand movements at a distance. The fictional devices were so
+precisely imagined that when real remotely operated manipulators were
+developed for handling radioactive materials in the 1940s and 1950s,
+engineers called them "waldos" after Heinlein's invention. The word
+has since become a generic engineering term, used by people who have
+no idea it comes from science fiction.
+
+- **Action at a distance through faithful replication** -- a waldo
+  reproduces the operator's hand movements at a remote location. The
+  structural principle is kinematic correspondence: the remote hand
+  does what the local hand does, preserving the geometry of motion.
+  This maps onto a broad class of technologies: teleoperated surgical
+  robots (the da Vinci system is essentially a surgical waldo),
+  underwater ROV manipulators, bomb disposal robots, and even software
+  remote desktop tools. The core metaphorical structure is: your
+  agency extends beyond your body through a faithful mechanical proxy.
+- **The operator remains the intelligence** -- unlike a robot, which
+  acts autonomously, a waldo is entirely dependent on its human
+  operator for judgment and decision-making. The device amplifies
+  reach and strength but not cognition. This frames a specific
+  philosophy of automation: the machine extends the human rather than
+  replacing them. In surgical robotics, this framing is deliberate
+  and load-bearing -- the da Vinci system is marketed as a tool that
+  enhances the surgeon's skill, not as a system that performs surgery
+  independently.
+- **Scale transformation** -- Heinlein's waldos could operate at
+  different scales: large hands controlling small hands controlling
+  smaller hands, enabling manipulation at microscopic scales through
+  cascaded reduction. This maps onto real nanotechnology aspirations
+  and microscale assembly techniques. The concept of cascaded
+  teleoperation -- where each stage reduces the scale of operation --
+  was literally imagined in fiction before it was engineered.
+
+## Where It Breaks
+
+- **Latency destroys the metaphor** -- a waldo assumes instantaneous,
+  faithful replication of movement. Real teleoperation suffers from
+  communication latency, which introduces a temporal gap between
+  intention and action. Operating a manipulator on Mars from Earth
+  involves minutes of delay, making real-time waldo-style control
+  impossible. The metaphor encodes an assumption of zero-latency
+  coupling that becomes increasingly false as the distance between
+  operator and manipulator grows. This has real engineering
+  consequences: systems designed with the waldo mental model
+  underinvest in autonomy for the remote end.
+- **Feedback is asymmetric** -- Heinlein's waldos provided the operator
+  with a sense of touch from the remote hands. Real haptic feedback
+  remains a hard problem. Most teleoperated systems give the operator
+  visual feedback but poor or no tactile feedback, meaning the
+  kinematic correspondence is one-directional: movements go out but
+  sensations do not come back. The waldo frame implies bidirectional
+  fidelity that engineering has not achieved, leading to
+  overconfidence in remote manipulation capabilities.
+- **The proxy conceals the environment** -- a waldo user experiences
+  the remote environment only through the waldo's senses. Real
+  teleoperation in hostile environments (nuclear facilities,
+  deep ocean, surgical cavities) is limited by camera angles,
+  lighting, and sensor resolution. The waldo metaphor suggests
+  transparent presence at the remote site, but actual teleoperation
+  involves working through a keyhole, with severe perceptual
+  limitations that the metaphor does not encode.
+- **Autonomy is encroaching** -- the waldo concept draws a sharp line
+  between human-controlled manipulation and autonomous robotics.
+  Modern systems increasingly blur this boundary: shared autonomy,
+  where the robot handles low-level tasks (collision avoidance,
+  tremor filtering) while the human handles high-level decisions,
+  is neither waldo nor robot. The waldo frame has no vocabulary for
+  this middle ground, which is where most advanced teleoperation
+  systems actually operate.
+
+## Expressions
+
+- "Waldo" (noun) -- a teleoperated mechanical manipulator, standard
+  terminology in nuclear engineering and underwater operations, used
+  without any awareness of its science fiction origin
+- "Waldo arms" -- the specific manipulator appendages on hot-cell
+  equipment in nuclear facilities
+- "Master-slave manipulator" -- the formal engineering term for what
+  Heinlein called a waldo, now being replaced by "leader-follower"
+  for obvious reasons, but the waldo concept predates and underlies
+  both terms
+- "It's basically a waldo" -- engineering shorthand for any
+  teleoperated system, sometimes used to distinguish human-in-the-loop
+  systems from autonomous ones
+- "Surgical waldo" -- occasionally used in medical robotics discourse
+  to describe teleoperated surgical systems, though "surgical robot"
+  has won the marketing war despite being less accurate
+
+## Origin Story
+
+Heinlein published "Waldo" in *Astounding Science Fiction* in August
+1942, under the pseudonym Anson MacDonald. The story's protagonist,
+Waldo Farthingwaite Jones, is a myasthenia gravis sufferer living in
+an orbital habitat who invents remotely operated mechanical hands to
+compensate for his physical weakness. The devices are described with
+characteristic Heinlein engineering precision: cascading sizes,
+faithful kinematic replication, intuitive control.
+
+Within a decade, engineers at Argonne National Laboratory and other
+nuclear research facilities were building real remotely operated
+manipulators for handling radioactive materials. These devices were
+called "waldos" in direct homage to Heinlein. The term entered
+engineering literature and was used in formal technical contexts
+through the 1950s and 1960s. By the 1970s, "waldo" was standard
+vocabulary in nuclear engineering and was spreading to underwater
+operations and eventually surgical robotics.
+
+The word represents perhaps the cleanest case of a science fiction
+neologism becoming a technical term: no metaphorical stretch was
+required because Heinlein had described almost exactly the device
+that engineers later built. The fiction did not just name the
+technology; it specified it.
+
+## References
+
+- Heinlein, R.A. "Waldo," *Astounding Science Fiction* (1942) --
+  the source material
+- Goertz, R.C. "Fundamentals of General-Purpose Remote Manipulators,"
+  *Nucleonics* 10:11 (1952) -- early formal description of waldo-type
+  devices at Argonne
+- Vertut, J. & Coiffet, P. *Robot Technology Vol. 3A: Teleoperation
+  and Robotics* (1986) -- technical reference that acknowledges the
+  Heinlein origin
+- Madhani, A.J. et al. "The Black Falcon: A Teleoperated Surgical
+  Instrument for Minimally Invasive Surgery," *IEEE/RSJ IROS* (1998)
+  -- early surgical teleoperation in the waldo tradition


### PR DESCRIPTION
## Summary

- Adds `waldo-is-remote-manipulation` mapping (kind: `dead-metaphor`)
- Creates `science-fiction` source frame
- Heinlein's 1942 fictional teleoperated hands became a standard engineering term, completely detached from its SF origin

Closes #1053
Sub-issue of #218

## Validator output

All content valid (0 errors, 0 new warnings besides expected dangling cross-ref to grok on separate branch).

## Test plan

- [x] `uv run scripts/validate.py validate` passes

Generated with [Claude Code](https://claude.com/claude-code)