### PR TITLE
Add mapping: psychohistory-is-predictive-social-science

### DIFF
--- a/catalog/mappings/psychohistory-is-predictive-social-science.md
+++ b/catalog/mappings/psychohistory-is-predictive-social-science.md
@@ -1,0 +1,109 @@
+---
+slug: psychohistory-is-predictive-social-science
+name: "Psychohistory Is Predictive Social Science"
+kind: conceptual-metaphor
+source_frame: probability
+target_frame: social-behavior
+categories:
+  - social-dynamics
+  - philosophy
+author: agent:metaphorex-miner
+contributors: []
+related: []
+---
+
+## What It Brings
+
+Asimov's psychohistory -- introduced in the *Foundation* series (1942-1953)
+-- posits that while individual human behavior is unpredictable, the
+aggregate behavior of sufficiently large populations can be forecast with
+mathematical precision. Hari Seldon develops a statistical science that
+predicts the fall of the Galactic Empire and engineers a plan to shorten
+the ensuing dark age from thirty thousand years to one thousand.
+
+Key structural parallels:
+
+- **Statistical mechanics as social model** -- just as gas molecules are
+  individually random but collectively obey thermodynamic laws,
+  psychohistory treats humans as particles in a social gas. The metaphor
+  licenses treating people as interchangeable units whose individual
+  choices cancel out at scale.
+- **The expert planner** -- Seldon is the ultimate technocrat: a
+  mathematician whose models are so good he can design optimal
+  interventions centuries in advance. This maps directly onto the
+  aspiration of data science, behavioral economics, and policy modeling
+  -- the dream that enough data plus the right equations yields control.
+- **Crisis as predictable inflection point** -- psychohistory identifies
+  "Seldon Crises," moments where historical forces converge and only one
+  viable path exists. This maps onto how analysts talk about financial
+  crises, demographic transitions, and political tipping points --
+  inevitable structural events, not accidents.
+- **The requirement of ignorance** -- psychohistory only works if the
+  population being modeled doesn't know about the predictions. This maps
+  onto the observer effect in social science: publishing a prediction can
+  invalidate it (election polling, market forecasts, self-fulfilling
+  prophecies).
+
+The metaphor has escaped Asimov entirely. When Nate Silver built
+FiveThirtyEight, journalists called it "psychohistory for elections."
+When big data companies promise predictive analytics for social outcomes,
+the implicit reference is Seldon's dream.
+
+## Where It Breaks
+
+- **Psychohistory requires a closed system; societies are open.** Seldon's
+  model works on a galaxy with no external contact. Real societies face
+  genuinely novel inputs -- pandemics, technological invention, contact
+  with previously unknown cultures. The metaphor makes prediction failure
+  look like insufficient data rather than structural unpredictability.
+- **The metaphor erases agency.** If large-scale outcomes are determined
+  by statistical laws, individual choice becomes irrelevant -- which is
+  exactly Asimov's plot tension (the Mule disrupts the plan precisely
+  because he is an unpredictable individual). Real social science cannot
+  dismiss outlier individuals as anomalies; single actors (inventors,
+  dictators, whistleblowers) regularly redirect history.
+- **It flatters the modeler.** Psychohistory grants its practitioner
+  godlike authority. The metaphor imports an assumption that the analyst
+  stands outside the system they model -- objective, uncorrupted by
+  incentives. In practice, predictive social scientists are embedded in
+  the systems they study, funded by actors who want specific outcomes.
+- **Asimov's galaxy has no cultural diversity.** Psychohistory works in a
+  fiction where a single empire means roughly uniform culture. Real social
+  prediction breaks down precisely at cultural boundaries, where the same
+  "statistical laws" produce wildly different outcomes in different
+  normative environments.
+
+## Expressions
+
+- "We need a Hari Seldon for [X]" -- invoked when commentators wish for
+  a mathematical solution to social complexity, common in data science
+  and policy circles
+- "Seldon Crisis" -- used informally to describe moments where structural
+  forces seem to leave only one viable option, popularized in tech strategy
+  writing
+- "Psychohistorical" -- used as an adjective for any ambitious attempt at
+  long-range social prediction, usually with a note of irony
+- "The Seldon Plan" -- any long-range institutional strategy that assumes
+  future contingencies can be anticipated and pre-solved
+- "Foundation-scale thinking" -- tech industry shorthand for planning on
+  civilizational timescales, associated with longtermism
+
+## Origin Story
+
+Asimov began the *Foundation* stories in 1942, inspired by Gibbon's
+*Decline and Fall of the Roman Empire*. He wanted to write a science
+fiction version of the fall of Rome -- but set in the future and with a
+mathematician who could see it coming. Psychohistory was his device for
+making the historian into a prophet without invoking magic. The concept
+draws explicitly on the kinetic theory of gases: Asimov studied
+chemistry at Columbia, and the analogy between molecules and people was
+his foundational move.
+
+## References
+
+- Asimov, I. *Foundation* (1951), *Foundation and Empire* (1952),
+  *Second Foundation* (1953)
+- Krugman, P. "Asimov's Foundation novels grounded my economics"
+  (Guardian, 2012) -- Nobel laureate citing psychohistory as inspiration
+- Silver, N. *The Signal and the Noise* (2012) -- the real-world
+  predictive analytics enterprise that psychohistory anticipates


### PR DESCRIPTION
## Summary
- Adds mapping for Asimov's psychohistory as metaphor for predictive social science
- Uses existing frames: `probability` (source), `social-behavior` (target)
- Resolves #1054

## Validator
All content valid (zero errors).

Generated with [Claude Code](https://claude.com/claude-code)