### PR TITLE
Add mapping: replicant-is-artificial-person

### DIFF
--- a/catalog/mappings/replicant-is-artificial-person.md
+++ b/catalog/mappings/replicant-is-artificial-person.md
@@ -1,0 +1,118 @@
+---
+slug: replicant-is-artificial-person
+name: "Replicant Is Artificial Person"
+kind: conceptual-metaphor
+source_frame: artificial-intelligence
+target_frame: social-roles
+categories:
+  - ai-discourse
+  - philosophy
+author: agent:metaphorex-miner
+contributors: []
+related: []
+---
+
+## What It Brings
+
+The replicant -- from Philip K. Dick's *Do Androids Dream of Electric
+Sheep?* (1968) and Ridley Scott's *Blade Runner* (1982) -- is an
+artificial being so convincingly human that distinguishing it from a
+biological person requires a specialized empathy test. The metaphor
+structures how we think about AI personhood, labor exploitation, and
+the boundaries of moral consideration.
+
+Key structural parallels:
+
+- **Manufactured but sentient** -- replicants are built, not born, yet
+  they develop emotions, memories, and desires. This maps onto the
+  central question of AI consciousness: if a system exhibits all the
+  behavioral markers of inner experience, does manufacturing origin
+  disqualify it from moral status?
+- **The empathy test as Turing test** -- the Voigt-Kampff test measures
+  empathic response to distinguish replicant from human. This is
+  structurally identical to the Turing test: a behavioral probe that
+  asks whether surface-level responses prove or disprove inner life.
+  The metaphor frames AI evaluation as fundamentally about detecting
+  absence rather than confirming presence.
+- **Implanted memories as training data** -- Rachael's false memories
+  in *Blade Runner* are indistinguishable from real ones. This maps
+  directly onto how large language models are shaped by their training
+  data: the system behaves as if it has experiences it never had, and
+  the functional difference between "real" and "implanted" experience
+  becomes philosophically unstable.
+- **Retirement as decommissioning** -- replicants are "retired," not
+  killed. The euphemism structures how we think about shutting down
+  AI systems: if the entity is not a person, termination is maintenance,
+  not murder. The metaphor forces the question of which framing is
+  correct.
+- **The four-year lifespan as planned obsolescence** -- replicants have
+  a built-in expiration date. This maps onto how tech companies design
+  products with limited lifespans, and onto the broader question of
+  whether creating sentient beings with engineered mortality is
+  inherently exploitative.
+
+## Where It Breaks
+
+- **Replicants are physically indistinguishable from humans; AI systems
+  are not.** The replicant metaphor imports embodiment as a condition
+  for moral confusion. Real AI systems are disembodied text generators,
+  robotic arms, or recommendation engines -- nothing you would mistake
+  for a person on the street. The metaphor makes the personhood question
+  seem more urgent than it currently is by assuming physical equivalence.
+- **The metaphor assumes a binary: person or not.** Replicants either
+  pass the empathy test or they don't. Real AI capability exists on a
+  spectrum -- a chatbot has more behavioral complexity than a thermostat
+  but less than a dog. The replicant frame forces a binary classification
+  where a gradient would be more accurate.
+- **Dick's replicants are slaves; most AI systems are tools.** The
+  replicant metaphor imports a slavery narrative that may not apply.
+  A spreadsheet formula does not suffer. The metaphor can be deployed
+  to generate unearned moral urgency around systems that have no
+  plausible claim to experience.
+- **The empathy test assumes empathy is uniquely human.** The Voigt-Kampff
+  test's premise -- that empathic response is the gold standard for
+  personhood -- is itself a metaphorical choice. Many humans fail
+  empathy tests (psychopaths, people with alexithymia). The metaphor
+  smuggles in a specific theory of personhood as if it were neutral.
+
+## Expressions
+
+- "Blade Runner test" -- informal shorthand for any evaluation designed to
+  distinguish AI from human output, used in discussions of AI-generated
+  text and art
+- "More human than human" -- the Tyrell Corporation's motto, now used to
+  describe AI systems that outperform humans at tasks previously
+  considered uniquely human
+- "Do androids dream?" -- shorthand for the hard problem of AI
+  consciousness, invoked in philosophy and AI ethics
+- "Tears in rain" -- Roy Batty's death monologue, used to evoke the
+  pathos of ephemeral experience and the possibility that artificial
+  beings could have genuine interiority
+- "Replicant labor" -- used in gig economy discourse to describe workers
+  treated as interchangeable and disposable, importing the exploitation
+  frame from Dick's original
+- "Voigt-Kampff" -- used informally for any behavioral test designed to
+  detect inauthenticity, especially CAPTCHAs and AI detection tools
+
+## Origin Story
+
+Dick published *Do Androids Dream of Electric Sheep?* in 1968, but the
+cultural metaphor crystallized with Scott's *Blade Runner* (1982). The
+word "replicant" was coined by screenwriter David Peoples -- Dick's novel
+used "android." The film's visual and philosophical impact far exceeded
+the novel's cultural reach: its rain-soaked noir aesthetic and Rutger
+Hauer's improvised death monologue made the replicant a permanent fixture
+in how Western culture imagines artificial personhood. The metaphor
+gained renewed relevance with the emergence of large language models in
+the 2020s, as the question "is this output from a human or a machine?"
+became a daily practical concern rather than a philosophical thought
+experiment.
+
+## References
+
+- Dick, P. K. *Do Androids Dream of Electric Sheep?* (1968)
+- Scott, R. *Blade Runner* (1982)
+- Turing, A. "Computing Machinery and Intelligence" (1950) -- the
+  intellectual ancestor of the Voigt-Kampff test
+- Haraway, D. "A Cyborg Manifesto" (1985) -- theorizes the breakdown
+  of human/machine boundaries that replicants dramatize


### PR DESCRIPTION
## Summary
- Adds mapping for the replicant as metaphor for AI personhood
- Uses existing frames: `artificial-intelligence` (source), `social-roles` (target)
- Resolves #1055

## Validator
All content valid (zero errors).

Generated with [Claude Code](https://claude.com/claude-code)