### PR TITLE
Add mapping: sisyphean-task

### DIFF
--- a/catalog/mappings/sisyphean-task.md
+++ b/catalog/mappings/sisyphean-task.md
@@ -1,0 +1,137 @@
+---
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- organizational-behavior
+contributors:
+- fshot
+harness: Claude Code
+kind: conceptual-metaphor
+name: Sisyphean Task
+related:
+- achilles-heel
+slug: sisyphean-task
+source_frame: mythology
+target_frame: event-structure
+---
+
+## What It Brings
+
+Zeus condemned Sisyphus to roll a boulder up a hill for eternity. Each
+time he neared the summit, the boulder rolled back down. The metaphor
+maps this structure -- effortful labor that cycles endlessly without
+reaching completion -- onto tasks, jobs, projects, and existential
+conditions.
+
+Key structural parallels:
+
+- **Effort without progress** -- Sisyphus works hard. He is not lazy,
+  not incompetent, not confused about the goal. The problem is
+  structural: the task itself is designed to undo his labor. The
+  metaphor captures situations where the difficulty lies not in the
+  worker but in the work. Technical debt that accumulates faster than
+  it can be paid down, bureaucratic compliance requirements that reset
+  annually, inboxes that refill as fast as they are emptied -- these
+  are Sisyphean not because the worker fails but because the system
+  regenerates the problem.
+- **The illusion of a summit** -- Sisyphus can see the top of the hill.
+  He gets close. The metaphor maps the tantalizing proximity of
+  completion: the project that is always 90% done, the reform that is
+  always almost implemented, the goal that recedes as you approach.
+  The summit is real but unreachable, which is worse than having no
+  summit at all.
+- **Repetition without variation** -- each cycle is identical to the
+  last. The metaphor captures the specific misery of repetitive work
+  that teaches nothing, builds nothing, and leads nowhere. It
+  distinguishes Sisyphean tasks from merely difficult ones: difficult
+  tasks can be learned from, adapted to, eventually conquered.
+  Sisyphean tasks offer no such trajectory.
+- **Punishment as condition** -- in the myth, the repetition is a
+  divine sentence. The metaphor imports this moral weight: to call
+  something Sisyphean is to imply that someone or something has
+  imposed this condition, that it is not natural or necessary but
+  inflicted. The question "why are we doing this?" becomes urgent
+  when the task is framed as Sisyphean.
+- **Solitude** -- Sisyphus pushes alone. The metaphor maps the
+  isolation of people trapped in futile work: no one helps, no one
+  notices, no one cares about the boulder. When someone calls their
+  job Sisyphean, they are often describing not just futility but
+  invisibility.
+
+## Where It Breaks
+
+- **Most repetitive work does produce incremental value** -- the
+  Sisyphean frame treats all repetition as futile, but many repetitive
+  tasks are genuinely productive. Answering customer support tickets,
+  reviewing pull requests, grading papers -- these recur endlessly but
+  each instance produces real value for a real person. Calling them
+  Sisyphean dignifies a complaint about tedium by elevating it to
+  mythic futility, which can obscure the work's actual usefulness.
+- **The metaphor forecloses agency** -- Sisyphus cannot change the
+  rules, redesign the hill, or choose a different boulder. But real
+  workers usually can. Calling a task Sisyphean can become a learned
+  helplessness that prevents people from asking whether the task could
+  be automated, eliminated, or restructured. The myth is a story about
+  divine compulsion; most work situations allow more freedom than the
+  metaphor admits.
+- **It ignores Camus's reinterpretation** -- Albert Camus famously
+  argued that "one must imagine Sisyphus happy," reframing the myth
+  as an existential triumph of consciousness over absurdity. The
+  common metaphorical usage ignores this entirely, treating Sisyphean
+  as purely negative. This misses the possibility that repetitive,
+  unfinishable work might be meaningful if approached with the right
+  orientation -- a possibility that many contemplative traditions
+  and craft practices affirm.
+- **Cycles are not always futile** -- the seasons cycle, heartbeats
+  repeat, maintenance is ongoing. The Sisyphean frame treats cyclical
+  structure as inherently punishing, but cycles are also the structure
+  of sustainability, ritual, and rhythm. Painting a bridge that will
+  need repainting is not futile; it is maintenance. The metaphor
+  cannot distinguish destructive repetition from sustaining repetition.
+- **It assumes a single metric of progress** -- Sisyphus fails by one
+  measure: the boulder does not stay at the top. But a person doing
+  "Sisyphean" work might be developing skills, building relationships,
+  earning a living, or maintaining a system that others depend on. The
+  metaphor's single axis (boulder up or down) flattens the multiple
+  dimensions along which work can matter.
+
+## Expressions
+
+- "It's a Sisyphean task" -- work that will never reach completion no
+  matter how much effort is applied
+- "Pushing the boulder uphill" -- effortful labor against structural
+  resistance (often without the name Sisyphus)
+- "The Sisyphean grind of compliance reporting" -- regulatory work that
+  resets and must be redone each cycle
+- "Email is my Sisyphean boulder" -- a recurring obligation that
+  refills as fast as it is addressed
+- "We must imagine Sisyphus happy" -- Camus's existentialist
+  reframing, used to find meaning in repetitive work
+- "A Sisyphean struggle against bureaucracy" -- institutional processes
+  that resist all attempts at reform
+- "Debugging legacy code is Sisyphean" -- technical work where fixing
+  one issue reveals or creates another
+
+## Origin Story
+
+The punishment of Sisyphus appears in Homer's *Odyssey* (c. 8th century
+BCE), where Odysseus sees him in the underworld endlessly pushing his
+stone. The myth was widely known in Greek culture and used as an
+exemplar of futile labor. Its modern philosophical significance owes
+primarily to Albert Camus's essay *The Myth of Sisyphus* (1942), which
+reframed the myth as a meditation on the absurd: the gap between
+humanity's desire for meaning and the universe's indifference. Camus's
+reading gave the metaphor a second life, making "Sisyphean" not just a
+synonym for futile but a philosophical stance on how to live with
+futility. In contemporary usage, the term straddles both registers --
+sometimes a simple complaint about repetitive work, sometimes an
+allusion to existentialist endurance.
+
+## References
+
+- Homer. *Odyssey* (c. 8th century BCE), Book XI -- Odysseus's account
+  of Sisyphus in the underworld
+- Camus, A. *The Myth of Sisyphus* (1942) -- the existentialist
+  reinterpretation that transformed the metaphor's meaning
+- Lakoff, G. & Turner, M. *More Than Cool Reason* (1989) -- on
+  mythological and literary source domains in everyday metaphor


### PR DESCRIPTION
## Summary
- Adds `sisyphean-task` conceptual-metaphor mapping (Greek mythology -> event-structure)
- Kept as `conceptual-metaphor` (not `dead-metaphor`) because speakers who use "Sisyphean" generally retain active awareness of the myth
- Validator passes with zero errors

Closes #1074

## Validator output
```
All content valid.
```

## Test plan
- [ ] Validator passes (`uv run scripts/validate.py validate`)
- [ ] Frontmatter schema correct
- [ ] All three required body sections present
- [ ] "Where It Breaks" is substantive

🤖 Generated with [Claude Code](https://claude.com/claude-code)