### PR TITLE
Add mapping: midas-touch

### DIFF
--- a/catalog/mappings/midas-touch.md
+++ b/catalog/mappings/midas-touch.md
@@ -1,0 +1,139 @@
+---
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- economics-and-finance
+contributors:
+- fshot
+harness: Claude Code
+kind: conceptual-metaphor
+name: Midas Touch
+related:
+- pandora-box
+slug: midas-touch
+source_frame: mythology
+target_frame: economics
+---
+
+## What It Brings
+
+King Midas wished that everything he touched would turn to gold.
+Dionysus granted the wish. Midas was delighted until his food, his
+wine, and finally his daughter turned to gold at his touch. The
+metaphor operates on two registers simultaneously: the positive sense
+(an uncanny ability to generate wealth or success) and the cautionary
+sense (monomaniacal optimization that destroys everything it cannot
+measure).
+
+Key structural parallels:
+
+- **Uniform transformation** -- Midas's touch converts everything into
+  the same substance. The metaphor maps onto optimization regimes that
+  reduce diverse values to a single metric: revenue, engagement, test
+  scores, citations. When someone has "the Midas touch," they turn
+  everything they encounter into the one thing they value. This is
+  powerful when the metric is appropriate and destructive when it is
+  not.
+- **Success is effortless and automatic** -- Midas does not craft the
+  gold; it simply happens on contact. The positive use of the metaphor
+  captures the appearance of frictionless success: the entrepreneur
+  whose every venture succeeds, the investor who picks only winners,
+  the leader whose projects always deliver. The metaphor attributes
+  success to an innate quality rather than to effort, skill, or
+  circumstance.
+- **The gift becomes a curse** -- the myth's central reversal maps the
+  experience of getting exactly what you wished for and discovering it
+  is not what you wanted. The metaphor captures Goodhart's Law avant
+  la lettre: when a measure becomes a target, it ceases to be a good
+  measure. Midas optimized for gold and destroyed everything that
+  made gold worth having.
+- **Contact is corruption** -- in the cautionary register, the touch
+  is contagious and indiscriminate. Everything Midas reaches for is
+  ruined. The metaphor maps onto leaders, systems, or ideologies that
+  cannot engage with something without converting it to their own
+  terms. Corporate acquisition of independent companies, quantification
+  of qualitative goods, monetization of community spaces -- these are
+  all Midas touches.
+- **Isolation follows** -- Midas ends up surrounded by gold and unable
+  to eat, drink, or embrace. The metaphor captures the loneliness of
+  optimization: the person or system that converts everything to a
+  single currency eventually finds that currency cannot buy what
+  matters most.
+
+## Where It Breaks
+
+- **The positive and negative senses contradict each other** -- in
+  common usage, "she has the Midas touch" is a compliment, meaning
+  she succeeds at everything. But the myth is a tragedy about the
+  horror of getting what you want. The metaphor is internally
+  incoherent: it can mean either "brilliant at generating value" or
+  "dangerously indiscriminate in what you optimize for." This
+  ambiguity makes it unreliable as an analytical tool -- the speaker
+  may intend one meaning while the listener hears the other.
+- **It treats all value as commensurable** -- gold is fungible; one
+  ounce is like any other. The metaphor works because Midas's touch
+  makes everything the same. But real economic value is heterogeneous:
+  the value of a meal, a relationship, a work of art, and a stock
+  portfolio are not reducible to a common substance. The metaphor
+  presupposes the very commensurability it warns against.
+- **The metaphor personalizes systemic outcomes** -- Midas is a single
+  person with a magical gift. But real "Midas touch" outcomes are
+  usually systemic: market structures, institutional incentives,
+  regulatory capture, network effects. Attributing them to an
+  individual's special power obscures the machinery that actually
+  produces concentrated success or destructive optimization.
+- **It implies the wish was the mistake** -- Midas's error, in the
+  myth, was wanting gold too much. But in practice, the problem is
+  often not desire but lack of foresight about second-order effects.
+  The metaphor moralizes (greed is punished) when the more useful
+  frame is analytical (optimization without constraint produces
+  pathological outcomes).
+- **The cure is too easy** -- Midas washes his hands in the river
+  Pactolus and the curse is lifted. Real monocultures of value --
+  financialization, metric fixation, growth-at-all-costs -- do not
+  wash off. The myth provides a tidy resolution that the metaphor's
+  real-world referents do not support.
+
+## Expressions
+
+- "He has the Midas touch" -- everything he does turns to profit
+  or success
+- "The Midas touch of Silicon Valley" -- a tech ecosystem's perceived
+  ability to turn any idea into a billion-dollar company
+- "Be careful what you wish for -- the Midas touch" -- warning that
+  getting exactly what you optimize for may destroy what you actually
+  need
+- "Turning everything to gold" -- converting diverse activities into
+  revenue, often with a note of criticism
+- "Their Midas touch finally failed" -- the end of a streak of
+  effortless success
+- "The Midas curse of financialization" -- the cautionary register,
+  where converting everything to monetary value destroys non-monetary
+  goods
+- "She has the reverse Midas touch" -- humorous inversion: everything
+  she touches falls apart
+
+## Origin Story
+
+The myth of Midas appears in Ovid's *Metamorphoses* (8 CE) and in
+earlier Greek sources including Aristotle's *Politics*, which uses
+Midas as an illustration of the difference between use-value and
+exchange-value -- a remarkably early instance of the myth as economic
+metaphor. The positive sense ("the Midas touch" as a compliment)
+developed primarily in 19th and 20th century English, detaching from
+the myth's cautionary structure. The two registers now coexist
+uneasily: business journalism uses "Midas touch" admiringly while
+cultural criticism uses it as a warning about the reductive logic
+of markets. This bifurcation makes the metaphor a useful barometer
+of the speaker's relationship to capitalism.
+
+## References
+
+- Ovid. *Metamorphoses* (8 CE), Book XI -- the canonical version of
+  the Midas myth
+- Aristotle. *Politics* (c. 350 BCE), Book I -- Midas as illustration
+  of the sterility of pure exchange-value
+- Sandel, M. *What Money Can't Buy* (2012) -- contemporary argument
+  about the Midas-like effects of marketization on non-market goods
+- Muller, J.Z. *The Tyranny of Metrics* (2018) -- the pathology of
+  reducing diverse values to single measures, a modern Midas problem


### PR DESCRIPTION
## Summary
- Adds `midas-touch` dead-metaphor mapping (Greek mythology -> economics)
- Notes that the modern usage has inverted the myth's cautionary meaning
- Validator passes with zero errors

Closes #1075

## Validator output
```
All content valid.
```

## Test plan
- [ ] Validator passes (`uv run scripts/validate.py validate`)
- [ ] Frontmatter schema correct
- [ ] All three required body sections present
- [ ] "Where It Breaks" is substantive

🤖 Generated with [Claude Code](https://claude.com/claude-code)