### PR TITLE
Add mapping: time-travel-is-historical-counterfactual

### DIFF
--- a/catalog/mappings/time-travel-is-historical-counterfactual.md
+++ b/catalog/mappings/time-travel-is-historical-counterfactual.md
@@ -1,0 +1,127 @@
+---
+slug: time-travel-is-historical-counterfactual
+name: "Time Travel Is Historical Counterfactual"
+kind: conceptual-metaphor
+source_frame: time-and-temporality
+target_frame: causal-reasoning
+categories:
+  - philosophy
+  - social-dynamics
+author: agent:metaphorex-miner
+contributors: []
+related: []
+---
+
+## What It Brings
+
+Time travel narratives -- from Wells's *The Time Machine* (1895) through
+*Back to the Future* (1985) to the many-worlds branching of Marvel's
+*Endgame* (2019) -- give physical form to a mode of reasoning that
+historians, economists, and policymakers use constantly: the
+counterfactual. "What if the South had won the Civil War?" "What if
+we had invested in solar earlier?" These are time-travel stories
+without the machine.
+
+Key structural parallels:
+
+- **The past as a place you can visit** -- time travel literalizes the
+  metaphor TIME IS SPACE. The past is not gone; it is somewhere else,
+  and with the right technology you can go there. This maps onto how
+  historians treat the past as an accessible domain: archives are
+  portals, primary sources are windows, "going back to the sources"
+  is a temporal journey.
+- **The butterfly effect as causal sensitivity** -- time travel stories
+  obsess over small changes producing large consequences. Step on a
+  butterfly in the Cretaceous, return to a fascist present (Bradbury,
+  "A Sound of Thunder," 1952). This maps directly onto counterfactual
+  reasoning in economics and policy: "if Archduke Ferdinand had not
+  been assassinated..." The metaphor makes causal sensitivity vivid
+  and narratively compelling.
+- **The grandfather paradox as logical constraint** -- if you go back
+  and prevent your own birth, you cannot have gone back. This maps
+  onto the logical structure of self-defeating policies and reflexive
+  predictions: an economic forecast that changes behavior invalidates
+  itself, just as killing your grandfather invalidates your trip.
+- **Branching timelines as scenario planning** -- the many-worlds
+  interpretation of time travel (each change creates a new timeline)
+  maps precisely onto how strategists think about decisions: each
+  choice generates a distinct future, and good planning means
+  considering multiple branches simultaneously.
+- **The fixed point as historical determinism** -- some time travel
+  stories posit events that cannot be changed. This maps onto
+  structural determinism in historiography: the view that certain
+  outcomes were inevitable regardless of individual choices, because
+  the underlying forces (economic, demographic, technological) would
+  have produced them anyway.
+
+## Where It Breaks
+
+- **Counterfactuals have no observer.** A time traveler can see the
+  alternative timeline. A historian cannot. Real counterfactual
+  reasoning is pure thought experiment with no empirical check -- you
+  can never verify what "would have happened." The metaphor imports
+  an observability that does not exist, making counterfactuals feel
+  more rigorous than they are.
+- **Time travel implies reversibility; history does not.** The metaphor
+  suggests that wrong turns can be corrected by going back. Real
+  historical processes are irreversible: you cannot un-industrialize,
+  un-colonize, or un-invent nuclear weapons. The metaphor encourages
+  a fantasy of correction that obscures the permanence of
+  consequences.
+- **The "timeline" metaphor is itself a metaphor.** Time travel stories
+  assume time is a line that can be traversed in either direction.
+  This is a spatial metaphor for something that may not be spatial at
+  all. The metaphor is built on a metaphor, making it doubly
+  unfalsifiable.
+- **Individual agency is overweighted.** Time travel stories almost
+  always center on a single person making a single decisive choice.
+  Real historical causation involves millions of actors, structural
+  forces, and path dependencies. The metaphor systematically
+  overstates the importance of individual decision points and
+  understates systemic inertia.
+- **The entertainment value distorts the reasoning.** Counterfactual
+  history is fun in a way that actual history is not. "What if
+  Napoleon had won at Waterloo?" is more engaging than "What were the
+  structural causes of French imperial decline?" The time-travel
+  metaphor biases toward dramatic, identifiable turning points and
+  away from slow, distributed causation.
+
+## Expressions
+
+- "If I could go back in time..." -- the everyday counterfactual,
+  expressing regret or imagining alternative choices
+- "Sliding doors moment" -- from the 1998 film, a decision point
+  where small differences produce divergent life paths
+- "The butterfly effect" -- originally Lorenz's chaos theory concept,
+  now inseparable from time-travel fiction's causal sensitivity
+- "Fixed point in time" -- from *Doctor Who*, used to describe events
+  treated as historically inevitable
+- "Timeline" -- so naturalized that most speakers do not recognize it
+  as a spatial metaphor for temporal sequence
+- "Alternate history" -- a genre that is structured entirely by the
+  time-travel counterfactual, even when no literal time travel occurs
+- "Course correction" -- the idea that a bad trajectory can be
+  redirected by intervening at the right moment
+
+## Origin Story
+
+H. G. Wells published *The Time Machine* in 1895, establishing the
+template: a device that moves through time as a vehicle moves through
+space. But counterfactual reasoning is far older -- historians have
+asked "what if" since at least Livy (1st century BC), who speculated
+on what would have happened if Alexander the Great had turned west.
+Wells's contribution was to mechanize the counterfactual, making it
+a technology rather than a thought experiment. The metaphor's cultural
+dominance accelerated in the late 20th century through film (*Back to
+the Future*, *Terminator*, *Groundhog Day*) and became a dominant
+narrative device in 21st-century television (*Dark*, *Loki*, *Devs*).
+
+## References
+
+- Wells, H. G. *The Time Machine* (1895)
+- Bradbury, R. "A Sound of Thunder" (1952) -- the butterfly-effect
+  time travel story
+- Ferguson, N. *Virtual History: Alternatives and Counterfactuals*
+  (1997) -- the academic case for counterfactual history
+- Lewis, D. "Counterfactual Dependence and Time's Arrow" (1979) --
+  the philosophical framework connecting counterfactuals to causation


### PR DESCRIPTION
## Summary
- Adds mapping for time travel as metaphor for counterfactual reasoning
- Uses existing frames: `time-and-temporality` (source), `causal-reasoning` (target)
- Resolves #1059

## Validator
All content valid (zero errors).

Generated with [Claude Code](https://claude.com/claude-code)