### PR TITLE
Add mapping: black-mirror-is-technology-dark-side

### DIFF
--- a/catalog/mappings/black-mirror-is-technology-dark-side.md
+++ b/catalog/mappings/black-mirror-is-technology-dark-side.md
@@ -1,0 +1,124 @@
+---
+slug: black-mirror-is-technology-dark-side
+name: "Black Mirror Is Technology's Dark Side"
+kind: conceptual-metaphor
+source_frame: vision
+target_frame: ethics-and-morality
+categories:
+  - ai-discourse
+  - social-dynamics
+author: agent:metaphorex-miner
+contributors: []
+related: []
+---
+
+## What It Brings
+
+The "black mirror" is the dark, reflective screen of a phone, laptop, or
+television when it is turned off -- a mirror that shows you a distorted,
+darkened version of yourself. Charlie Brooker named his anthology series
+(2011-present) after this image, and the phrase has become shorthand for
+any scenario where technology reveals or amplifies the worst aspects of
+human nature. To call something "very Black Mirror" is to invoke a
+specific mode of technological pessimism: not that machines will rebel,
+but that we will use them to destroy ourselves.
+
+Key structural parallels:
+
+- **The mirror as moral reflector** -- a mirror shows you yourself. A
+  black mirror shows you yourself, darkly. The metaphor frames
+  technology not as an external threat but as a revelation of what was
+  always inside us: vanity (social media), cruelty (online harassment),
+  conformity (algorithmic curation), surveillance (smart devices). The
+  problem is not the technology; the problem is what the technology
+  shows us about ourselves.
+- **The dark screen as latent danger** -- a turned-off screen looks
+  innocent but contains the potential for everything you do when it
+  turns on. The metaphor captures the dual-use nature of technology:
+  the same phone that connects you to loved ones also tracks your
+  location, records your conversations, and feeds your attention to
+  advertisers. The danger is not in the device but in the activation.
+- **Each episode as thought experiment** -- the anthology format means
+  each Black Mirror episode isolates a single technological what-if
+  and follows it to its darkest conclusion. This maps onto how tech
+  critics reason: take one feature (social credit scores, digital
+  afterlife, memory recording) and ask "what's the worst that could
+  happen?" The metaphor privileges worst-case reasoning.
+- **The near future as inevitability** -- Black Mirror episodes are
+  set slightly ahead of the present, using technologies that feel
+  imminent. This collapses the distance between speculation and
+  prediction, making dystopian scenarios feel like spoilers rather
+  than fiction.
+
+## Where It Breaks
+
+- **The mirror metaphor implies technology is passive; it is not.**
+  A mirror merely reflects. Real technology actively shapes behavior
+  through algorithmic design, notification patterns, and engagement
+  optimization. Calling technology a mirror understates its agency:
+  social media does not just reflect human cruelty; it architecturally
+  incentivizes and amplifies it. The metaphor lets platform designers
+  off the hook by framing consequences as reflections of human nature
+  rather than design choices.
+- **Black Mirror stories are unfalsifiable warnings.** Because each
+  episode shows a worst case, the metaphor biases discourse toward
+  catastrophism. Any technology can be made to look dangerous if you
+  imagine its most extreme misuse. The metaphor provides no framework
+  for weighing benefits against risks -- it is structurally incapable
+  of producing the conclusion "this technology is net positive."
+- **The metaphor assumes a stable human nature to reflect.** If the
+  mirror shows our darkness, the darkness must have been there all
+  along. But technology does not just reveal existing tendencies; it
+  creates new ones. No one had "doomscrolling" as a behavioral
+  tendency before infinite-scroll feeds existed. The mirror metaphor
+  cannot account for emergent behaviors that have no pre-technological
+  analog.
+- **Individual moral framing obscures structural critique.** Black
+  Mirror episodes typically center on individuals making bad choices
+  with technology. This frames technological harm as a moral failing
+  rather than a systemic outcome, making regulation seem like an
+  intrusion on personal responsibility rather than a structural
+  necessity.
+
+## Expressions
+
+- "Very Black Mirror" -- all-purpose descriptor for any unsettling
+  technological development, from deepfakes to social credit systems
+- "Black mirror moment" -- when real-world tech news feels
+  indistinguishable from dystopian fiction
+- "We're living in a Black Mirror episode" -- the collapse of
+  speculative fiction into perceived reality, especially common
+  during the 2020s
+- "Dark reflection" -- the mirror metaphor applied to any technology
+  that reveals uncomfortable truths about its users
+- "Screen time" -- while not from the show, the phrase carries the
+  same anxiety: the screen as site of moral danger
+- "The Nosedive problem" -- from the social-rating episode, used to
+  describe reputation systems that incentivize performative niceness
+  and punish authenticity
+
+## Origin Story
+
+Charlie Brooker, a technology journalist turned screenwriter, created
+*Black Mirror* in 2011 for Channel 4. The title references the
+ubiquitous dark screens in modern life -- "the cold, shiny screen of
+a TV, a monitor, a smartphone," as Brooker described it. The show's
+cultural impact exceeded its viewership: it became a reference frame
+for technology journalism, policy discussion, and everyday conversation
+about tech anxiety. When China announced its social credit system,
+Western media immediately called it "Nosedive in real life." When
+deepfakes emerged, they were "that Black Mirror episode." The metaphor
+is now self-sustaining: Brooker does not need to write new episodes
+for "Black Mirror" to function as a warning label that the public
+applies to technologies independently.
+
+## References
+
+- Brooker, C. *Black Mirror* (2011-present)
+- Postman, N. *Technopoly: The Surrender of Culture to Technology*
+  (1992) -- the intellectual tradition Black Mirror inherits
+- Morozov, E. *To Save Everything, Click Here* (2013) -- "solutionism"
+  critique that parallels Black Mirror's skepticism
+- Turkle, S. *Alone Together* (2011) -- published the same year as
+  Black Mirror, exploring the same anxieties about technology and
+  human connection


### PR DESCRIPTION
## Summary
- Adds mapping for "Black Mirror" as metaphor for technology's dark reflection
- Uses existing frames: `vision` (source), `ethics-and-morality` (target)
- Resolves #1060

## Validator
All content valid (zero errors).

Generated with [Claude Code](https://claude.com/claude-code)