### PR TITLE
Add mapping: cryonics-is-death-deferral

### DIFF
--- a/catalog/mappings/cryonics-is-death-deferral.md
+++ b/catalog/mappings/cryonics-is-death-deferral.md
@@ -1,0 +1,126 @@
+---
+slug: cryonics-is-death-deferral
+name: "Cryonics Is Death Deferral"
+kind: conceptual-metaphor
+source_frame: medicine
+target_frame: life-course
+categories:
+  - philosophy
+  - health-and-medicine
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - uploading-is-digital-immortality
+---
+
+## What It Brings
+
+Cryonic suspension -- freezing the body (or head) at death in the hope
+that future technology will revive and cure it -- appears throughout
+science fiction from *2001: A Space Odyssey* (1968) to *Futurama*
+(1999) to *Passengers* (2016). The concept has escaped fiction into
+reality: companies like Alcor and the Cryonics Institute have preserved
+hundreds of bodies. The metaphor frames death not as an end but as a
+technical problem with a pending solution -- a medical condition that
+happens to be currently untreatable.
+
+Key structural parallels:
+
+- **Death as disease** -- cryonics reframes death from a philosophical
+  certainty into a medical condition. Just as we once considered
+  tuberculosis and smallpox incurable, cryonicists argue that death
+  is simply a disease we haven't yet learned to treat. The metaphor
+  converts a metaphysical boundary into an engineering problem,
+  making it feel solvable.
+- **Freezing as pausing** -- the cryonic patient is not dead but
+  "paused," suspended between life and death. This maps onto how we
+  think about other deferred states: paused projects, suspended
+  accounts, dormant companies. The metaphor frames the person as
+  still existing, just temporarily inactive -- a comforting fiction
+  that preserves the continuity of identity.
+- **The future as hospital** -- cryonics assumes that future
+  civilization will be able to cure whatever killed you AND reverse
+  the damage of freezing AND want to revive you. This is an extreme
+  version of the general faith in progress: the future is a place
+  where today's impossible problems have been solved. It maps onto
+  how tech optimists defer hard problems to future AI, future
+  medicine, future governance.
+- **The waiting room as afterlife** -- cryonic storage facilities
+  function as secular afterlife infrastructure. The liquid nitrogen
+  dewars are a materialist's heaven: not a place of reward, but a
+  place of indefinite waiting. The metaphor converts religious hope
+  (resurrection, reincarnation) into a technical service with a
+  monthly maintenance fee.
+
+## Where It Breaks
+
+- **Pausing is not preserving.** Current vitrification technology
+  causes massive cellular damage. The "frozen = paused" metaphor
+  implies that the person is intact and merely stopped, when in
+  reality the freezing process itself destroys much of the biological
+  structure that constitutes the person. The metaphor conceals the
+  gap between suspension and survival.
+- **The future has no obligation to revive you.** Cryonics assumes
+  continuity of institutional will across centuries. But corporations
+  dissolve, civilizations collapse, and future societies may have no
+  interest in reviving people from a past they find morally repugnant
+  or technologically primitive. The metaphor imports a customer-service
+  model ("we'll fix this later") where no service contract is
+  enforceable.
+- **Identity may not survive interruption.** Even if revival were
+  technically possible, the philosophical question remains: is a
+  revived cryonic patient the same person who was frozen, or a copy?
+  The metaphor of "pausing" assumes identity is a state that can be
+  stopped and restarted, but personal identity may require continuity
+  of consciousness, which cryonics definitively interrupts.
+- **The metaphor is class-bound.** Cryonic preservation costs between
+  $30,000 and $200,000, plus ongoing maintenance. It reframes death
+  as deferrable only for the wealthy, converting a universal human
+  condition into a premium service. The metaphor accidentally reveals
+  that its promise of technological salvation reproduces exactly the
+  economic hierarchies of the present.
+- **It defers grief.** Families of cryonic patients exist in an
+  ambiguous emotional state: the person is not alive but not fully
+  dead. The metaphor's refusal to accept finality can prevent the
+  mourning process that allows survivors to reconstruct their lives.
+
+## Expressions
+
+- "Frozen" -- used colloquially for any state of suspended activity,
+  from frozen bank accounts to frozen projects, all drawing on the
+  same preservation-through-stasis metaphor
+- "Put on ice" -- to defer a decision or project, directly borrowing
+  the cryonic metaphor's temporal logic
+- "Wake me when it's over" -- the cryo-sleep wish applied to any
+  unpleasant period one would rather skip
+- "Suspended animation" -- the science fiction term, now used for any
+  state of enforced inactivity
+- "Cold storage" -- data archiving language that borrows the cryonic
+  metaphor (Amazon's Glacier storage service literalizes this)
+- "Sleeper" -- someone frozen for future awakening, also used for
+  dormant agents, dormant investments, and dormant political movements
+
+## Origin Story
+
+Cryonics as a real practice was founded by Robert Ettinger, whose
+*The Prospect of Immortality* (1962) argued that freezing the dead
+was a rational bet on future technology. But the concept was already
+deeply embedded in science fiction: *The Jameson Satellite* (Neil R.
+Jones, 1931) featured a body preserved in space for revival by aliens.
+The idea reached mass culture through film -- *2001: A Space Odyssey*
+(1968) showed astronauts in cryo-sleep as routine technology, and
+*Demolition Man* (1993) and *Austin Powers* (1997) played it for
+comedy. *Futurama* (1999) made cryonic preservation its foundational
+plot device, introducing millions to the concept as humor rather
+than hope.
+
+## References
+
+- Ettinger, R. *The Prospect of Immortality* (1962) -- the founding
+  text of real-world cryonics
+- Kubrick, S. *2001: A Space Odyssey* (1968) -- cryo-sleep as
+  routine technology
+- Parfit, D. *Reasons and Persons* (1984) -- the philosophical
+  framework for questioning identity persistence through interruption
+- Alcor Life Extension Foundation (est. 1972) -- the operational
+  embodiment of the cryonics metaphor


### PR DESCRIPTION
## Summary
- Adds mapping for cryonics as metaphor for death deferral
- Uses existing frames: `medicine` (source), `life-course` (target)
- Resolves #1062

## Validator
All content valid (zero errors).

Generated with [Claude Code](https://claude.com/claude-code)