### PR TITLE
Add mapping: uploading-is-digital-immortality

### DIFF
--- a/catalog/mappings/uploading-is-digital-immortality.md
+++ b/catalog/mappings/uploading-is-digital-immortality.md
@@ -1,0 +1,147 @@
+---
+slug: uploading-is-digital-immortality
+name: "Uploading Is Digital Immortality"
+kind: conceptual-metaphor
+source_frame: computing
+target_frame: life-course
+categories:
+  - ai-discourse
+  - philosophy
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - cryonics-is-death-deferral
+  - replicant-is-artificial-person
+---
+
+## What It Brings
+
+Mind uploading -- scanning the brain's structure and running it as
+software on a computer -- is a recurring premise in science fiction from
+Greg Egan's *Permutation City* (1994) to the *Black Mirror* episode
+"San Junipero" (2016) to the *Altered Carbon* series (2002-2018). The
+concept frames consciousness as software: something that can be copied
+from biological hardware to digital hardware, preserving the person
+while discarding the body. The metaphor has escaped fiction entirely --
+it is now a serious research aspiration (the Brain Preservation
+Foundation, Nectome) and a core tenet of transhumanist philosophy.
+
+Key structural parallels:
+
+- **Mind as software, brain as hardware** -- the foundational move.
+  If consciousness is a pattern running on neurons, it should be
+  substrate-independent: runnable on silicon as easily as on carbon.
+  This is computationalism applied to personal identity. The metaphor
+  licenses treating the brain as a hard drive and death as a hardware
+  failure -- tragic but technically solvable by migrating to better
+  hardware.
+- **Uploading as file transfer** -- the language is explicitly
+  computational. You "upload" your mind to "the cloud." The person
+  becomes a file, copyable, backupable, transferable. This maps onto
+  how we already think about digital preservation: photos, documents,
+  and music are immortal once digitized. The metaphor extends this
+  logic to persons.
+- **The backup as insurance against death** -- if your mind is
+  uploaded, your biological death is an inconvenience, not an
+  extinction. This maps onto data backup strategies: redundancy
+  eliminates single points of failure. The metaphor reframes death
+  as a data-loss event that proper backup discipline could prevent.
+- **Virtual worlds as afterlife** -- uploaded minds need somewhere to
+  live. Science fiction consistently provides virtual paradises
+  ("San Junipero"), simulated worlds (*Permutation City*), or
+  virtual bodies (*Altered Carbon*'s "stacks"). The metaphor converts
+  religious afterlife into a technical service: heaven is a server
+  farm, and eternal life is an uptime guarantee.
+- **Version control as personal continuity** -- if you can copy a
+  mind, you can fork it. Multiple copies of "you" can diverge,
+  raising questions about which one is the "real" you. This maps
+  onto software version control: branches, merges, and conflicts
+  become identity crises.
+
+## Where It Breaks
+
+- **Consciousness may not be computable.** The uploading metaphor
+  assumes functionalism: that consciousness is defined by what it
+  does, not what it's made of. But Searle's Chinese Room argument,
+  Penrose's quantum consciousness hypothesis, and the hard problem of
+  consciousness all challenge this assumption. If consciousness
+  depends on specific physical properties of neurons (not just their
+  connectivity), uploading preserves the map but loses the territory.
+- **A copy is not a continuation.** If I scan my brain and run the
+  scan on a computer, there are now two of me: the original (still
+  mortal) and the copy (potentially immortal). The original still
+  dies. The uploading metaphor's promise of immortality is really a
+  promise that a copy of you will persist -- which is comforting only
+  if you accept that copies are continuations. The file-transfer
+  metaphor obscures this by implying the original is deleted after
+  upload, but there is no reason it must be.
+- **The metaphor assumes identity is information.** You are your
+  connectome, your synaptic weights, your neural patterns -- and
+  nothing else. This discards embodiment, hormonal state, gut
+  microbiome, immune system, and every other biological process that
+  contributes to subjective experience. A mind without a body is not
+  a preserved person but a radically different entity wearing the
+  person's memories.
+- **Digital systems degrade.** The promise of digital immortality
+  assumes perfect data preservation. But bit rot, format obsolescence,
+  and infrastructure collapse are real: we cannot reliably read a
+  floppy disk from 1995, but we are supposed to maintain a conscious
+  mind for eternity? The metaphor imports digital durability that
+  does not exist.
+- **Who pays for the servers?** An uploaded mind requires continuous
+  computation, storage, and energy. For eternity. The metaphor's
+  economic implications are staggering and usually unexamined: digital
+  immortality requires an immortal institution willing to foot an
+  infinite bill. The religious afterlife at least has a deity to
+  cover the costs.
+
+## Expressions
+
+- "Upload your mind" -- the core expression, treating consciousness
+  as a transferable file
+- "Digital afterlife" -- the explicit fusion of computing and religion
+- "Substrate independence" -- the philosophical term for the claim
+  that consciousness is hardware-agnostic, borrowed from software
+  engineering's platform independence
+- "Mind backup" -- treating personality preservation as a data backup
+  operation
+- "Living in the cloud" -- uploaded existence described in
+  cloud-computing terms
+- "Whole brain emulation" -- the technical term, itself a metaphor
+  (the brain is "emulated" like vintage hardware running on modern
+  chips)
+- "Stack" -- from *Altered Carbon*, a device that stores consciousness
+  and survives the body's death, making biological death a "sleeve"
+  change rather than an ending
+- "Digital twin" -- originally an engineering concept (a virtual model
+  of a physical system), now extended to the idea of a virtual model
+  of a person
+
+## Origin Story
+
+Mind uploading entered science fiction through Hans Moravec's *Mind
+Children* (1988), which argued that uploading was both technically
+feasible and philosophically coherent. Greg Egan's *Permutation City*
+(1994) and *Diaspora* (1997) explored the implications with
+unprecedented rigor: what happens to identity when minds can be
+copied, modified, and run at variable speeds? The concept reached
+mass culture through *The Matrix* (1999) -- which asked "what if
+we're already uploaded?" -- and through *Altered Carbon* (2002),
+which treated consciousness-transfer as routine technology with
+profound class implications. The *Black Mirror* episode "San Junipero"
+(2016) became the emotional touchstone: it presented uploading as
+a genuine afterlife that preserved love, making the concept feel
+desirable rather than merely possible.
+
+## References
+
+- Moravec, H. *Mind Children* (1988) -- the founding text of
+  uploading as serious aspiration
+- Egan, G. *Permutation City* (1994) -- the deepest fictional
+  exploration of uploading's implications
+- Chalmers, D. "The Singularity: A Philosophical Analysis" (2010) --
+  philosophical treatment of uploading and consciousness
+- Schneider, S. *Artificial You: AI and the Future of Your Mind*
+  (2019) -- examines whether uploads would be conscious
+- Morgan, R. *Altered Carbon* (2002) -- the class-politics-of-
+  uploading novel


### PR DESCRIPTION
## Summary
- Adds mapping for mind uploading as metaphor for digital immortality
- Uses existing frames: `computing` (source), `life-course` (target)
- Resolves #1063

## Validator
All content valid (zero errors).

Generated with [Claude Code](https://claude.com/claude-code)