### PR TITLE
Add mapping: siren-song

### DIFF
--- a/catalog/mappings/siren-song.md
+++ b/catalog/mappings/siren-song.md
@@ -1,0 +1,124 @@
+---
+slug: siren-song
+name: "Siren Song"
+kind: dead-metaphor
+source_frame: mythology
+target_frame: social-behavior
+categories:
+  - mythology-and-religion
+  - psychology
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - pandora-box
+  - icarus
+  - trojan-horse
+---
+
+## What It Brings
+
+In Homer's Odyssey, the Sirens are creatures whose singing is so beautiful
+that sailors steer toward them and wreck on the rocks. Odysseus survives
+only by having his crew plug their ears with wax while he listens tied to
+the mast -- the first recorded case of someone engineering a commitment
+device against their own future weakness.
+
+The metaphor maps a precise structure onto temptation:
+
+- **The attraction is the danger** -- the Siren does not threaten and then
+  lure. The lure *is* the threat. This maps cleanly onto addictive products,
+  predatory pricing, and engagement-maximizing algorithms: the thing that
+  draws you in is the same thing that destroys you. There is no separate
+  bait and trap; the bait is the trap.
+- **Knowledge does not protect** -- the Sirens' song is dangerous even to
+  those who know it is dangerous. Odysseus *knows* the Sirens will kill him
+  and still begs to be untied. This maps onto situations where awareness of
+  a trap provides no defense against it: knowing that slot machines are
+  designed to addict does not make you immune. The metaphor insists that
+  willpower alone is insufficient.
+- **Structural prevention is the only defense** -- wax in the ears, ropes
+  on the mast. Odysseus' solution is not greater resolve but physical
+  constraint. In modern usage, this maps onto commitment devices, cooling-off
+  periods, regulatory guardrails, and any mechanism that removes the choice
+  rather than relying on the chooser's strength.
+- **The song promises knowledge** -- in some versions, the Sirens do not
+  sing of pleasure but of *knowledge*: they claim to know everything that
+  happens on earth. The temptation is epistemic, not merely hedonic. This
+  maps onto the allure of insider information, conspiracy theories, and any
+  offer that says "we have the truth they won't tell you."
+
+## Where It Breaks
+
+- **Real temptations are not usually lethal** -- the Sirens kill everyone
+  who listens. Most real-world temptations are costly but survivable. The
+  metaphor's all-or-nothing lethality makes it hard to apply to situations
+  where the rational response is partial engagement rather than total
+  avoidance. A startup that calls venture capital a "siren song" implies
+  it should be avoided entirely, when in reality the question is how much
+  to take and on what terms.
+- **The metaphor erases the Siren's perspective** -- Sirens are pure
+  mechanism in the Odyssey: they exist only to lure and kill. When we call
+  something a "siren song," we deny that the attractive thing has any
+  legitimate value. This is misleading when applied to, say, a competitor's
+  job offer or a new technology: the attraction may be partly genuine.
+  Treating all appeal as deception is itself a cognitive distortion.
+- **It implies a single, identifiable moment of danger** -- Odysseus sails
+  past the Sirens and then he is safe. But most real temptations are
+  chronic, not episodic. Calling social media a "siren song" suggests you
+  can sail past it once, when the reality is that the song never stops
+  playing.
+- **The metaphor is largely dead** -- most speakers using "siren song" or
+  "siren call" have only the vaguest awareness of Homer. The phrase has
+  flattened to mean "dangerously attractive thing," losing the structural
+  specifics (the commitment device, the knowledge promise, the inadequacy
+  of willpower) that make the myth actually useful. Emergency sirens have
+  further muddied the etymology, though they share no connection -- the
+  emergency device was named for the mythological creature, but the
+  association now runs backward, making "siren" evoke warning rather than
+  temptation.
+
+## Expressions
+
+- "The siren song of easy money" -- financial temptation framed as
+  inevitably destructive, used in journalism and investment commentary
+  with no awareness of Homer
+- "Siren call of the startup world" -- the tech industry's appeal framed
+  as dangerous, implying that the attractiveness itself is the warning sign
+- "Don't listen to the siren song of [X]" -- a formulaic warning pattern
+  where "siren song" functions as a dead synonym for "temptation"
+- "Siren server" -- Jaron Lanier's coinage for platforms that attract users
+  and extract value, one of the rare modern uses that consciously revives
+  the mythological structure
+- "Tied to the mast" -- the commitment-device half of the metaphor,
+  occasionally used independently ("I need to tie myself to the mast and
+  not check email")
+
+## Origin Story
+
+The Sirens appear in Book 12 of the Odyssey (c. 8th century BCE). Homer
+does not describe their appearance -- the visual image of bird-women comes
+from later Greek art. What Homer emphasizes is exclusively auditory: their
+song is irresistible, their island is surrounded by the bones of previous
+listeners, and Circe warns Odysseus that the only defense is not to hear
+them at all.
+
+The metaphorical usage appears in English by the 14th century and is
+thoroughly conventional by the 17th. By the 20th century, "siren song" is
+a fixed phrase in newspapers and political rhetoric, applied to anything
+from communism to consumer credit. The phrase's productivity in modern
+English is inversely proportional to most speakers' knowledge of its
+source: it survives as a dead metaphor precisely because its surface
+meaning ("dangerously attractive thing") requires no mythological literacy.
+
+## References
+
+- Homer, *Odyssey*, Book 12, trans. Fagles (1996) -- the original Siren
+  episode
+- Elster, J. *Ulysses and the Sirens* (1979) -- foundational work on
+  precommitment and rationality, using the Siren myth as its organizing
+  metaphor
+- Lanier, J. *Who Owns the Future?* (2013) -- coins "Siren server" to
+  describe platforms that concentrate wealth by attracting users
+- Pucci, P. "The Song of the Sirens," *Arethusa* 12.2 (1979) -- analysis
+  of the Sirens' promise of knowledge rather than pleasure


### PR DESCRIPTION
## Summary
- Adds `siren-song` dead-metaphor mapping (mythology -> social-behavior)
- Dangerously attractive temptation that leads to ruin; covers the commitment-device structure, the knowledge promise, and the inadequacy of willpower
- Closes #1076

## Validator output
All content valid. (28 pre-existing dangling reference warnings, none introduced by this PR)

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [ ] Review mapping content for accuracy and tone

Generated with [Claude Code](https://claude.com/claude-code)