### PR TITLE
Add mapping: phoenix

### DIFF
--- a/catalog/mappings/phoenix.md
+++ b/catalog/mappings/phoenix.md
@@ -1,0 +1,118 @@
+---
+slug: phoenix
+name: "Phoenix"
+kind: conceptual-metaphor
+source_frame: mythology
+target_frame: destruction
+categories:
+  - mythology-and-religion
+  - organizational-behavior
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - activation-energy
+---
+
+## What It Brings
+
+A bird that dies in fire and is reborn from its own ashes. The myth appears
+across Greek, Egyptian, and Chinese traditions with the same core structure:
+a magnificent creature reaches the end of its cycle, combusts, and emerges
+renewed from the wreckage of its former self. The metaphor maps this cycle
+onto any situation where destruction becomes the precondition for renewal.
+
+- **Destruction as prerequisite, not obstacle** -- the phoenix does not
+  survive the fire; it requires the fire. Without combustion there is no
+  rebirth. The metaphor reframes catastrophic failure as a necessary stage
+  rather than a terminal event. A company that goes through bankruptcy and
+  re-emerges leaner, a career that collapses and is rebuilt in a different
+  direction, a city that burns and is reconstructed -- all borrow the
+  phoenix structure. The key insight is that the new form could not have
+  existed without the destruction of the old one.
+- **Continuity through discontinuity** -- the phoenix that rises is the
+  same creature, not a replacement. Identity persists across the rupture.
+  This is the metaphor's most powerful and most questionable claim: that
+  an organization, a person, or a movement that has been destroyed and
+  reconstituted is still fundamentally the same entity. The ashes are the
+  link. They are not discarded but serve as the medium of rebirth.
+- **Cyclical inevitability** -- the phoenix does not burn once; it burns
+  repeatedly, on a fixed cycle (500 years in most Greek accounts). The
+  metaphor imports this periodicity into organizational and personal
+  narratives: the idea that decline is not a failure of management but a
+  natural phase, and that renewal is not a lucky break but an expected
+  outcome for those who endure the burning.
+
+## Where It Breaks
+
+- **Most things that burn stay burned** -- the phoenix myth is remarkable
+  precisely because it describes something that does not happen in nature.
+  Fire destroys. Ash is an endpoint, not a beginning. The metaphor's
+  optimism is survivorship bias elevated to cosmology: we call the
+  companies that recovered "phoenixes" and forget the thousands that
+  burned and stayed dead. Kodak burned; Kodak did not rise. The metaphor
+  provides no way to distinguish in advance which fires are regenerative
+  and which are simply fatal.
+- **The new form is not the old form** -- when people invoke the phoenix,
+  they imply that what emerges is the same thing, improved. But a company
+  that goes through bankruptcy emerges with different shareholders,
+  different employees, different culture, and often different leadership.
+  A person who rebuilds after catastrophe is a different person. The
+  metaphor's promise of identity-through-destruction papers over genuine
+  discontinuity. The post-bankruptcy company is not the phoenix risen; it
+  is a new company wearing the old company's name.
+- **The myth removes agency** -- the phoenix burns and rises automatically,
+  without effort, decision, or external help. Real recovery from
+  destruction requires enormous deliberate effort, external support,
+  capital, luck, and time. Calling something a "phoenix moment" can
+  obscure the grinding work of reconstruction by implying that rebirth
+  is a natural, effortless emergence from the ashes rather than a
+  desperate, uncertain project.
+- **It romanticizes avoidable catastrophe** -- the phoenix framing can
+  make destruction seem desirable or at least acceptable. "We needed to
+  burn down to rebuild" is sometimes true and often a retroactive
+  justification for preventable failure. The metaphor provides cover
+  for leaders who presided over catastrophe: the fire was not
+  mismanagement, it was a necessary phase of the phoenix cycle.
+
+## Expressions
+
+- "Rising from the ashes" -- the standard phoenix invocation, used for
+  any comeback after catastrophic failure
+- "Phoenix moment" -- the turning point where destruction begins to
+  transform into renewal
+- "Burn it down and start over" -- a prescription that borrows the
+  phoenix logic: destruction is the fastest path to something better
+- "Phoenix company" -- a business that re-emerges after bankruptcy,
+  often retaining the brand while shedding the liabilities
+- "Like a phoenix" -- simile form used in journalism, sports, and
+  politics for any dramatic comeback narrative
+
+## Origin Story
+
+The phoenix appears in Herodotus (5th century BCE), who attributes it to
+Egyptian tradition. The bird lives for 500 years, builds a nest of
+aromatic wood, ignites it, and is reborn from the ashes. Roman writers
+including Ovid and Pliny elaborated the myth. Early Christians adopted
+the phoenix as a symbol of resurrection, mapping it onto the death and
+rebirth of Christ.
+
+The Chinese *fenghuang* and the Slavic *firebird* share structural
+elements but differ in important ways -- neither requires self-immolation.
+The Western phoenix, with its emphasis on destruction-as-prerequisite,
+is the version that became the dominant metaphor in English.
+
+The metaphor entered business and political language in the 20th century,
+particularly after World War II, when the reconstruction of bombed cities
+(especially in Germany and Japan) was frequently described in phoenix
+terms. Today it is a dead metaphor in business journalism -- "rising from
+the ashes" appears without any conscious reference to the mythological
+bird.
+
+## References
+
+- Herodotus, *Histories* 2.73 -- earliest Greek account of the phoenix,
+  attributed to Egyptian priests
+- Ovid, *Metamorphoses* 15.392-407 -- the phoenix as emblem of cyclical
+  transformation
+- Van den Broek, R. *The Myth of the Phoenix* (1972) -- comprehensive
+  scholarly treatment of the phoenix across cultures


### PR DESCRIPTION
## Summary
- Reworked `phoenix` mapping: mythology-sourced conceptual metaphor mapping renewal-from-destruction onto catastrophic failure and comeback narratives
- Reverted target_frame to `destruction` per original issue spec; renewal is the metaphorical contribution, not the target domain
- All frames and categories already exist; no new frame creation needed
- Refs #1081 (sub-issue of #219, fantasy-mythology-folklore)

## Validator output
All content valid. Zero errors. (25 pre-existing dangling-reference warnings, none from this PR)

## Test plan
- [x] `uv run scripts/validate.py validate` passes

Generated with [Claude Code](https://claude.com/claude-code)