### PR TITLE
Add mapping: prometheus

### DIFF
--- a/catalog/mappings/prometheus.md
+++ b/catalog/mappings/prometheus.md
@@ -1,0 +1,137 @@
+---
+slug: prometheus
+name: "Prometheus"
+kind: archetype
+source_frame: mythology
+target_frame: ethics-and-morality
+categories:
+  - mythology-and-religion
+  - philosophy
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - icarus
+  - pandora-box
+  - frankenstein-is-technology-risk
+---
+
+## What It Brings
+
+Prometheus stole fire from the gods and gave it to humanity. Zeus punished
+him by chaining him to a rock where an eagle ate his liver daily, only for
+it to regenerate each night. The myth encodes a structural pattern that
+recurs wherever someone democratizes a dangerous capability: the innovator
+who liberates powerful knowledge pays a personal, recurring, and
+disproportionate price.
+
+The archetype maps a tight set of roles:
+
+- **The technology is divine property** -- fire belongs to the gods, not to
+  mortals. Prometheus does not invent fire; he *steals* it. This maps onto
+  any situation where powerful knowledge is treated as the legitimate
+  monopoly of an elite: nuclear secrets, gain-of-function research,
+  encryption tools, open-source weapons designs. The Promethean act is not
+  creation but redistribution -- making the powerful thing available to
+  those who were not supposed to have it.
+- **The beneficiaries are ungovernable once empowered** -- once humans have
+  fire, Zeus cannot take it back. This is the Promethean irreversibility:
+  published knowledge cannot be unpublished. It maps onto open-source
+  software, leaked classified documents, and any technology whose
+  dissemination makes centralized control impossible. The gods' dilemma
+  is every regulator's dilemma.
+- **The punishment is perpetual, not terminal** -- Prometheus is not killed.
+  He is tortured indefinitely, his liver regenerating so the eagle can
+  return. This maps onto the ongoing costs borne by whistleblowers,
+  open-source maintainers, and disruptive innovators: Oppenheimer's
+  security clearance revocation, Snowden's exile, Aaron Swartz's
+  prosecution. The punishment does not end because the transgression
+  cannot be undone.
+- **The act is ambiguously heroic** -- Prometheus is simultaneously a
+  benefactor of humanity and a rebel against legitimate authority. This
+  irreducible ambiguity maps onto figures like Julian Assange, the
+  creators of PGP encryption, and the scientists who published the 1918
+  flu genome: are they heroes or reckless endangerers? The myth refuses
+  to resolve this question, which is precisely its power.
+
+## Where It Breaks
+
+- **Most technology transfer is not theft** -- the Promethean frame implies
+  that democratizing knowledge is transgressive, that the proper order is
+  for elites to control powerful tools. This can be deployed reactively:
+  calling open-source AI development "Promethean" smuggles in the
+  assumption that AI *should* be the monopoly of a few companies. The myth
+  naturalizes the idea that some knowledge is properly forbidden, which is
+  a contestable political position, not a universal truth.
+- **The punishment is not natural but political** -- in the myth, Zeus
+  *chooses* to punish Prometheus. The eagle is not a consequence of the
+  fire-theft but a separate act of divine retribution. When we call
+  someone "Promethean," we risk treating their punishment as inevitable
+  ("that's what happens when you defy the gods") when it is actually the
+  result of specific power structures choosing to retaliate. Snowden's
+  exile is not a law of nature; it is a policy decision.
+- **The binary of gods and mortals oversimplifies** -- Prometheus divides
+  the world into three roles: the divine monopolist, the heroic thief,
+  and the passive beneficiary. Real technology dissemination involves
+  many more actors: regulators, investors, competing firms, civil society.
+  The myth's three-role structure makes it hard to think about cases
+  where the "fire" was developed collaboratively or where the "mortals"
+  actively demanded it.
+- **The archetype valorizes individual sacrifice** -- Prometheus acts alone
+  and suffers alone. This maps poorly onto collective innovation, where
+  breakthroughs emerge from communities rather than lone geniuses. The
+  Promethean frame can distort our understanding by encouraging us to
+  look for a single heroic individual when the actual story involves
+  many contributors.
+- **Fire is unambiguously good** -- in the myth, fire is pure benefit to
+  humanity. But most real "Promethean" technologies are genuinely
+  dual-use: nuclear energy and nuclear weapons, CRISPR and bioweapons,
+  open-source AI and deepfakes. The myth's clarity about the gift's
+  value makes it harder to think about technologies where the question
+  is not "should everyone have this?" but "what should we do about the
+  fact that this thing is both wonderful and terrible?"
+
+## Expressions
+
+- "Promethean ambition" -- the drive to bring transformative technology to
+  the masses, used in both admiring and cautionary registers
+- "Promethean bargain" -- accepting personal cost for collective benefit,
+  common in bioethics and technology policy writing
+- "Playing Prometheus" -- stealing fire from established powers, often used
+  in open-source and hacker culture
+- "Project Prometheus" -- a naming pattern for ambitious technology
+  programs (NASA's nuclear propulsion project, various AI labs), invoking
+  the fire-giving aspect while quietly omitting the liver-eating
+- Mary Shelley's subtitle: *Frankenstein; or, The Modern Prometheus* --
+  the most influential modern deployment of the archetype, mapping the
+  Promethean pattern onto scientific creation and its consequences
+- "Promethean unbound" -- after Shelley's husband's poem, used to describe
+  technology finally freed from regulatory constraint
+
+## Origin Story
+
+The Prometheus myth appears in Hesiod's *Theogony* and *Works and Days*
+(c. 700 BCE) and Aeschylus' *Prometheus Bound* (c. 460 BCE). Hesiod
+presents Prometheus as a trickster whose gift of fire leads directly to
+Pandora and all human suffering -- a cautionary tale about defying divine
+order. Aeschylus reframes him as a tragic hero, the champion of humanity
+against tyrannical Zeus.
+
+This split -- is the fire-bringer a cautionary example or a hero? -- has
+defined the archetype's entire afterlife. The Romantics (Shelley, Byron,
+Goethe) embraced the heroic reading. Mary Shelley's *Frankenstein* (1818)
+reintroduced the cautionary one. Modern usage oscillates between both,
+which is why "Promethean" can be used as either praise or warning depending
+on the speaker's relationship to institutional authority.
+
+## References
+
+- Hesiod, *Theogony* and *Works and Days* (c. 700 BCE) -- the earliest
+  written versions of the Prometheus myth
+- Aeschylus, *Prometheus Bound* (c. 460 BCE) -- the heroic reframing
+- Shelley, M. *Frankenstein; or, The Modern Prometheus* (1818) -- the
+  defining modern deployment of the archetype
+- Dougherty, C. *Prometheus* (Routledge, 2006) -- comprehensive survey of
+  the myth's reception history
+- Kerr, P. "The Promethean Bargain," *Issues in Science and Technology*
+  (2003) -- the archetype in technology policy discourse


### PR DESCRIPTION
## Summary
- Adds `prometheus` archetype mapping (mythology -> ethics-and-morality)
- Democratizing dangerous technology at personal cost; the recurring pattern of the fire-bringer across technology, bioethics, and open-source culture
- Closes #1077

## Validator output
All content valid. (pre-existing dangling reference warnings only)

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [ ] Review mapping content for accuracy and tone

Generated with [Claude Code](https://claude.com/claude-code)