### PR TITLE
Add mapping: nemesis

### DIFF
--- a/catalog/mappings/nemesis.md
+++ b/catalog/mappings/nemesis.md
@@ -1,0 +1,117 @@
+---
+slug: nemesis
+name: "Nemesis"
+kind: conceptual-metaphor
+source_frame: mythology
+target_frame: social-behavior
+categories:
+  - mythology-and-religion
+  - social-dynamics
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - cassandra
+---
+
+## What It Brings
+
+In Greek mythology, Nemesis is the goddess of retribution -- the divine
+force that punishes *hubris* (excessive pride or overreach) and restores
+balance. She is not malicious but structural: she represents the universe's
+tendency to cut down those who rise too high. The metaphor maps this
+corrective mechanism onto any rival, obstacle, or consequence that someone
+cannot escape.
+
+- **Inescapability** -- Nemesis is not an opponent you might defeat with
+  better strategy; she is the mechanism by which overreach is corrected.
+  When someone calls a competitor their "nemesis," they are importing this
+  sense of fated opposition -- a rivalry that cannot be resolved by
+  cleverness or effort because it is built into the structure of the
+  situation. Batman and the Joker, Federer and Nadal, a startup and its
+  relentless incumbent competitor -- the nemesis relationship implies that
+  the opposition is constitutive, not contingent.
+- **Proportionality to overreach** -- Nemesis does not punish the humble.
+  She activates in response to *hubris*, which means the punishment is
+  proportional to the transgression. The metaphor carries this moral
+  logic: your nemesis is a consequence of your own ambition or success.
+  The bigger you get, the more powerful the corrective force becomes. This
+  explains why the word is used more often for successful people and
+  organizations than for obscure ones -- obscurity provides no target
+  for Nemesis.
+- **Inevitability without malice** -- Nemesis is not evil; she is
+  necessary. The metaphor codes the rival not as an enemy who wishes you
+  harm but as a structural counterweight whose existence maintains
+  balance. This is a subtler framing than "enemy" or "rival" and carries
+  a resignation that fighting is futile -- you cannot defeat what the
+  universe sends to balance you.
+
+## Where It Breaks
+
+- **Modern usage strips the moral dimension** -- in Greek religion,
+  Nemesis punishes a specific sin: *hubris*, the claim to be more than
+  human. A modern "nemesis" is just a persistent rival or recurring
+  problem. The word has lost its moral logic entirely. A chess player's
+  nemesis is simply the opponent they keep losing to, not a cosmic
+  correction for overreach. This flattening turns a concept about justice
+  into a concept about inconvenience.
+- **The original is impersonal; the modern is personal** -- Nemesis is a
+  cosmic principle, not a person with grudges. She does not hate anyone;
+  she maintains equilibrium. The modern nemesis is deeply personal: "he
+  is my nemesis" implies a specific, often emotional antagonism between
+  two individuals. The impersonal machinery of divine retribution has been
+  replaced by interpersonal rivalry, which is structurally different.
+- **Real rivals are not inevitable** -- Nemesis cannot be avoided because
+  she is divine. Real competitors can be outmaneuvered, outlasted, or
+  bought out. The metaphor imports a fatalism that is rarely warranted.
+  Calling a competitor your "nemesis" can become a self-fulfilling
+  prophecy: if you believe the rivalry is fated and inescapable, you may
+  stop looking for ways to change the competitive landscape.
+- **It flatters the person using it** -- calling someone your nemesis
+  implicitly casts yourself as significant enough to attract divine
+  correction. Nemesis only targets the great. The word carries a subtle
+  self-aggrandizement: my problems are not ordinary setbacks but cosmic
+  retribution for my extraordinary qualities. This is *hubris* about
+  *hubris* -- exactly the kind of overreach Nemesis was supposed to punish.
+
+## Expressions
+
+- "My nemesis" -- a rival who repeatedly defeats or frustrates, stripped
+  of the original moral dimension
+- "Meeting one's nemesis" -- encountering the person or situation that
+  finally brings you down
+- "Nemesis effect" -- in ecology and business, the idea that dominant
+  players attract disproportionate opposition
+- "Hubris and nemesis" -- the paired concept, used in political commentary
+  to describe leaders brought down by their own overconfidence
+- "He was his own nemesis" -- self-destructive behavior framed as
+  self-inflicted retribution
+
+## Origin Story
+
+Nemesis appears in Hesiod's *Theogony* (c. 700 BCE) as a daughter of Nyx
+(Night). Her name derives from the Greek *nemein* (to distribute, to allot),
+emphasizing her role as the force that ensures everyone receives their due
+portion -- especially those who have taken more than their share. She had a
+cult center at Rhamnus in Attica, where she was worshipped alongside Themis
+(Law).
+
+The concept migrated into English through Latin and French. By the 16th
+century, "nemesis" was used in English to mean "retributive justice," and by
+the 19th century it had narrowed to mean "an agent of retribution" or simply
+"a persistent rival." The moral and theological dimensions eroded steadily:
+modern usage retains the sense of inescapability but discards the cosmic
+mechanism that made the concept coherent.
+
+In popular culture, "nemesis" became a standard term for the villain who
+mirrors the hero -- the narrative device of the dark double. This usage is
+structurally different from the Greek original, which was about correction,
+not opposition.
+
+## References
+
+- Hesiod, *Theogony* 223 -- Nemesis as daughter of Night
+- Hornum, M. *Nemesis, the Roman State, and the Games* (1993) -- the cult
+  and iconography of Nemesis in the Roman world
+- Cairns, D. "Hybris, Dishonour, and Thinking Big," *Journal of Hellenic
+  Studies* 116 (1996) -- scholarly treatment of hubris-nemesis as paired
+  concept


### PR DESCRIPTION
## Summary
- Reworked `nemesis` mapping: mythology-sourced conceptual metaphor mapping divine retribution and inescapable rivalry onto social behavior
- All frames and categories already exist; no new ones needed
- Refs #1082 (sub-issue of #219, fantasy-mythology-folklore)

## Validator output
All content valid. Zero errors. (25 pre-existing dangling-reference warnings, none from this PR)

## Test plan
- [x] `uv run scripts/validate.py validate` passes

Generated with [Claude Code](https://claude.com/claude-code)