### PR TITLE
Add mapping: hydra

### DIFF
--- a/catalog/mappings/hydra.md
+++ b/catalog/mappings/hydra.md
@@ -1,0 +1,134 @@
+---
+slug: hydra
+name: "Hydra"
+kind: archetype
+source_frame: mythology
+target_frame: systems-thinking
+categories:
+  - mythology-and-religion
+  - systems-thinking
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - achilles-heel
+  - sisyphean-task
+---
+
+## What It Brings
+
+The Lernaean Hydra was a serpentine water monster with multiple heads. Cut
+one off, and two grew back in its place. Heracles defeated it only by
+cauterizing each stump immediately after severing the head -- the sole
+intervention that broke the regeneration cycle. The myth encodes a
+structural pattern about problems that are worsened by naive attempts to
+solve them, recurring across cybersecurity, counterinsurgency, regulation,
+and oncology.
+
+The archetype maps a distinctive feedback loop:
+
+- **The obvious intervention amplifies the problem** -- cutting a head is
+  the instinctive response to a head that is attacking you. But cutting
+  produces two heads. This maps onto situations where direct suppression
+  backfires: shutting down a file-sharing site spawns five mirrors,
+  killing a terrorist leader creates multiple successor factions, banning
+  a substance creates black markets with more vendors than the original
+  legal supply. The Hydra pattern names the specific failure mode where
+  the corrective action is the generative cause.
+- **The problem has multiple simultaneous attack surfaces** -- the Hydra
+  does not attack with one head at a time. All heads are active, all are
+  dangerous, and attending to one leaves you exposed to the others. This
+  maps onto multi-vector threats: a cybersecurity breach that
+  simultaneously exploits email phishing, unpatched servers, and social
+  engineering; a disease that presents with multiple resistant strains.
+  The metaphor captures the overwhelming quality of problems that refuse
+  to serialize.
+- **Only a qualitatively different intervention works** -- Heracles does
+  not defeat the Hydra by cutting faster or with a sharper sword. He
+  changes the type of intervention: cauterization instead of amputation.
+  This maps onto the insight that Hydra-type problems require a shift in
+  approach, not an escalation of the existing one. Counter-drug policy
+  that moves from interdiction to demand reduction, cybersecurity that
+  moves from perimeter defense to zero-trust architecture -- these are
+  cauterizations.
+- **There is one immortal head** -- in most versions, the Hydra has one
+  head that cannot be killed by any means. Heracles buries it under a
+  rock. This maps onto the irreducible core of certain problems: you
+  can contain it, you can suppress it, but you cannot eliminate it. Some
+  threats can only be managed, never solved.
+
+## Where It Breaks
+
+- **Most problems do not literally multiply when addressed** -- the Hydra
+  pattern is dramatic but relatively rare. Most problems respond to
+  incremental effort: fixing bugs does not create more bugs (usually),
+  arresting criminals does not create more criminals (necessarily). Calling
+  a problem "hydra-headed" can be a counsel of despair that discourages
+  any action, when the reality is that most problems yield to sustained,
+  unglamorous work.
+- **The metaphor implies a single root organism** -- the Hydra is one
+  creature with many heads. This suggests that diverse manifestations of
+  a problem share a common body. But real "hydra-headed" problems are
+  often genuinely independent actors who share no coordination:
+  ransomware gangs are not limbs of a single organism, even when their
+  behavior looks hydra-like. The metaphor can mislead strategists into
+  searching for a nonexistent central body to destroy.
+- **Cauterization is not always available** -- the myth provides a neat
+  solution: cauterize the stumps. But real feedback-loop problems often
+  have no cauterization equivalent. What is the cauterization for
+  online radicalization? For antibiotic resistance? The myth's clean
+  resolution can create false confidence that a qualitatively different
+  intervention exists and merely needs to be found.
+- **The metaphor erases scale and duration** -- Heracles defeats the Hydra
+  in a single battle. Real hydra-type problems (drug trafficking,
+  terrorism, malware) persist for decades across continents. The myth's
+  compact narrative makes these problems feel more tractable than they
+  are, by implying that the right hero with the right technique can
+  resolve them in one encounter.
+
+## Expressions
+
+- "Hydra-headed problem" -- a problem with multiple manifestations that
+  resist sequential solution, used in policy writing, medicine, and
+  cybersecurity
+- "Cut off one head, two more grow back" -- the core pattern stated as a
+  proverb, often used without awareness of its mythological source
+- "HYDRA" (Marvel) -- the fictional terrorist organization whose slogan
+  "cut off one head, two more shall take its place" has become more
+  culturally familiar than the Greek original for younger audiences
+- "Hydra cluster" -- in distributed computing, a system designed to
+  survive node removal by spawning replacements, using the myth's
+  structure as a positive design principle rather than a threat
+- "Lernaean" -- the adjective form, used in academic writing to describe
+  regenerative-threat dynamics ("the Lernaean nature of decentralized
+  networks")
+
+## Origin Story
+
+The Hydra appears as the second of Heracles' twelve labors in Greek
+mythology, documented in Apollodorus' *Bibliotheca* (c. 1st-2nd century
+CE) and referenced in Hesiod's *Theogony* (c. 700 BCE). The specific
+detail of head-regeneration -- cut one, two grow back -- is a later
+elaboration not present in the earliest sources, where the Hydra is
+simply described as having many heads (Hesiod says fifty, Alcaeus says
+nine, others say a hundred).
+
+The metaphorical usage entered European languages through Renaissance
+political writing. Machiavelli and his contemporaries used the Hydra to
+describe the problem of suppressing decentralized resistance. By the 19th
+century, "hydra-headed" was a standard English metaphor for any
+multi-faceted persistent threat. The 21st century has made the Hydra
+pattern newly relevant: decentralized networks, distributed malware,
+and leaderless movements all exhibit the structural property the myth
+describes -- they regenerate when attacked through conventional
+hierarchical means.
+
+## References
+
+- Apollodorus, *Bibliotheca* 2.5.2 -- the canonical account of Heracles
+  and the Hydra
+- Hesiod, *Theogony* 313-318 -- the earliest mention of the Hydra
+- Kilcullen, D. *The Accidental Guerrilla* (2009) -- uses hydra dynamics
+  to analyze counterinsurgency feedback loops
+- Rid, T. & Buchanan, B. "Attributing Cyber Attacks," *Journal of
+  Strategic Studies* (2015) -- discusses the hydra pattern in cybersecurity


### PR DESCRIPTION
## Summary
- Adds `hydra` archetype mapping (mythology -> systems-thinking)
- A problem that multiplies when you try to fix it; the feedback loop where corrective action is the generative cause
- Closes #1078

## Validator output
All content valid. (pre-existing dangling reference warnings only)

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [ ] Review mapping content for accuracy and tone

Generated with [Claude Code](https://claude.com/claude-code)