### PR TITLE
Add mapping: herculean-task

### DIFF
--- a/catalog/mappings/herculean-task.md
+++ b/catalog/mappings/herculean-task.md
@@ -1,0 +1,117 @@
+---
+slug: herculean-task
+name: "Herculean Task"
+kind: conceptual-metaphor
+source_frame: mythology
+target_frame: event-structure
+categories:
+  - mythology-and-religion
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - odyssey
+---
+
+## What It Brings
+
+Heracles (Hercules in the Roman tradition) was condemned to perform twelve
+labors as penance for killing his family in a madness sent by Hera. The
+labors were designed to be impossible: slay the Hydra, clean the Augean
+stables, capture Cerberus. Each required not just strength but ingenuity,
+endurance, and the willingness to enter domains no mortal should enter.
+The metaphor maps this structure onto any task that seems to exceed human
+capacity.
+
+- **Difficulty beyond normal scale** -- a "herculean task" is not merely
+  hard; it is hard in a way that makes reasonable people doubt it can be
+  done at all. The metaphor draws a line between ordinary difficulty
+  (which can be overcome by competence and effort) and extraordinary
+  difficulty (which requires something qualitatively different). Moving
+  house is hard; rebuilding a national healthcare system is herculean.
+  The word signals that standard approaches will not suffice.
+- **Penance structure** -- the original labors were imposed as punishment,
+  not chosen freely. The metaphor sometimes carries this subtext: the
+  person facing the herculean task did not volunteer for it but was
+  assigned it by forces beyond their control. A new CEO inheriting a
+  bankrupt company, a government tasked with post-disaster reconstruction,
+  a team asked to ship an impossible deadline -- the herculean framing
+  implies compulsion rather than ambition.
+- **Sequential impossibility** -- Heracles did not face one impossible
+  task but twelve, in sequence. Completing one did not earn rest but
+  merely qualified him for the next. The metaphor captures the experience
+  of projects where solving one problem reveals the next: each milestone
+  exposes a new labor. The Augean stables are clean, but now there is a
+  Hydra.
+
+## Where It Breaks
+
+- **Heracles was superhuman; most people are not** -- the entire point
+  of the myth is that Heracles could perform the labors because he was
+  the son of Zeus. He had divine strength that no mortal possessed. The
+  metaphor flatters the person facing the task by implying they might be
+  capable of superhuman feats, but it also sets an impossible standard.
+  If the task truly requires Heracles, then assigning it to an ordinary
+  team is not inspiring -- it is negligent.
+- **The labors were designed to fail** -- Eurystheus assigned the twelve
+  labors hoping Heracles would die attempting them. They were not
+  legitimate work assignments but traps. When a manager describes a
+  project as "herculean," the mythological parallel suggests the task was
+  designed to be impossible -- which raises the question of whether it
+  should be attempted at all rather than renegotiated.
+- **Strength is rarely the bottleneck** -- the metaphor foregrounds
+  physical or heroic strength as the key resource. Most genuinely
+  difficult modern tasks fail for other reasons: misaligned incentives,
+  political opposition, coordination failure, insufficient funding, or
+  poor problem definition. Calling something "herculean" frames the
+  challenge as a test of will and muscle, which may be exactly the
+  wrong framing for problems that require patience, coalition-building,
+  or structural reform.
+- **It individuates collective work** -- Heracles performed the labors
+  alone (with occasional help from Iolaus and Athena). The metaphor
+  imports this individualism: a "herculean effort" is imagined as one
+  person or team straining heroically. Large-scale difficult work is
+  almost always distributed, iterative, and institutional. Framing it as
+  a single hero's labor obscures the actual structure of how hard things
+  get done.
+
+## Expressions
+
+- "A herculean task" -- any undertaking of extraordinary difficulty,
+  the most common form
+- "Herculean effort" -- the exertion required to accomplish something
+  nearly impossible
+- "A labor of Hercules" -- older form, closer to the mythological
+  source, used in more formal or literary contexts
+- "Cleaning the Augean stables" -- a specific labor that became its
+  own metaphor: fixing a situation of long-accumulated filth or
+  corruption, often through radical means
+- "Twelve labors" -- invoked when a project has multiple sequential
+  phases, each difficult in its own right
+
+## Origin Story
+
+The twelve labors of Heracles were codified by Apollodorus in the
+*Bibliotheca* (1st-2nd century CE), though the individual labors appear
+in much earlier sources including Euripides and Pindar. The mythological
+cycle was well established by the 5th century BCE.
+
+"Herculean" entered English in the 16th century, drawing on the Roman
+name Hercules rather than the Greek Heracles. Shakespeare uses it in
+*King John* and *Coriolanus*. By the 18th century, "herculean" was a
+standard English adjective meaning "requiring extraordinary strength or
+effort," and the mythological specificity had largely faded. Most people
+who use the word today could not name more than one or two of the
+twelve labors.
+
+The Augean stables labor developed its own independent metaphorical
+life, particularly in political discourse, where "cleaning the Augean
+stables" means purging institutional corruption. This sub-metaphor has
+outlived the parent: people use the Augean stables expression who have
+never heard of the other eleven labors.
+
+## References
+
+- Apollodorus, *Bibliotheca* 2.5 -- the canonical list of twelve labors
+- Pindar, *Olympian Ode* 3 -- early poetic treatment of Heracles' labors
+- Stafford, E. *Herakles* (2012) -- scholarly survey of the hero's
+  mythology and reception across cultures


### PR DESCRIPTION
## Summary
- Reworked `herculean-task` mapping: mythology-sourced conceptual metaphor mapping the twelve labors onto tasks of extraordinary difficulty
- All frames and categories already exist; no new ones needed
- Refs #1083 (sub-issue of #219, fantasy-mythology-folklore)

## Validator output
All content valid. Zero errors. (25 pre-existing dangling-reference warnings, none from this PR)

## Test plan
- [x] `uv run scripts/validate.py validate` passes

Generated with [Claude Code](https://claude.com/claude-code)