### PR TITLE
Add mapping: labyrinth

### DIFF
--- a/catalog/mappings/labyrinth.md
+++ b/catalog/mappings/labyrinth.md
@@ -1,0 +1,139 @@
+---
+slug: labyrinth
+name: "Labyrinth"
+kind: dead-metaphor
+source_frame: mythology
+target_frame: governance
+categories:
+  - mythology-and-religion
+  - law-and-governance
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - red-tape
+  - silo
+---
+
+## What It Brings
+
+Daedalus built the Labyrinth on Crete to contain the Minotaur -- a
+structure so complex that even its architect could barely escape it.
+Theseus navigated it only with Ariadne's thread, a continuous line back
+to the entrance that turned an impossible maze into a solvable one. The
+myth encodes a precise architecture of entrapment: complexity that is
+*designed* to prevent exit, not merely difficult to navigate.
+
+The metaphor maps several structural features:
+
+- **Complexity is intentional, not accidental** -- the Labyrinth was
+  built to confuse. When we call a bureaucracy or legal system
+  "labyrinthine," we imply (often correctly) that the complexity serves
+  someone's interest. Tax codes, immigration procedures, and corporate
+  compliance frameworks are not accidentally difficult; their difficulty
+  filters out those without resources to navigate them. The metaphor
+  carries an embedded accusation: someone built this to trap you.
+- **The inhabitant is monstrous** -- at the center of the Labyrinth sits
+  the Minotaur, a creature that devours those who enter. This maps onto
+  the hidden cost or predatory outcome that waits at the end of a
+  bureaucratic process: the denied claim, the expired visa, the
+  regulatory penalty. The labyrinth does not just confuse; it delivers
+  you to something harmful.
+- **The thread is the only salvation** -- Ariadne's thread is a continuous,
+  traceable path through arbitrary complexity. In modern usage, this maps
+  onto audit trails, documentation, process maps, and any mechanism that
+  makes a complex system navigable. The myth insists that labyrinths are
+  not solved by intelligence alone but by maintaining an external record
+  of where you have been.
+- **The builder can be trapped by their own creation** -- Daedalus himself
+  was imprisoned in the Labyrinth he built. This maps onto the recurring
+  phenomenon of institutional designers who become subject to their own
+  rules: legislators bound by laws they wrote, architects of corporate
+  hierarchies who cannot get decisions made within them, software engineers
+  unable to navigate the systems they created.
+
+## Where It Breaks
+
+- **Most complex systems are not designed to trap** -- calling a healthcare
+  system "labyrinthine" implies deliberate obstruction, when the reality
+  may be accumulated regulatory layers, competing stakeholder requirements,
+  and historical path dependency. The myth's attribution of intentional
+  design can distract from the more common cause of institutional
+  complexity: nobody designed it, it just grew. A labyrinth has an
+  architect; most bureaucratic tangles do not.
+- **Labyrinths have a solution; some complex systems do not** -- Theseus
+  gets through the Labyrinth. There is a path from entrance to center and
+  back. But some institutional complexity is genuinely irreducible: the
+  tax code is complex because taxation is complex, and no thread of
+  Ariadne will make the underlying policy questions simple. The metaphor
+  implies that complexity is always a solvable navigation problem, when
+  sometimes the complexity *is* the substance.
+- **The metaphor is thoroughly dead** -- "labyrinthine" is a standard
+  English adjective meaning "very complex" with no mythological charge.
+  Most speakers using it have never heard of Daedalus, the Minotaur, or
+  Ariadne's thread. The word has been fully absorbed into everyday
+  vocabulary, losing the specific structural insights (intentional
+  design, monstrous inhabitant, external thread) that make the myth
+  useful. "Labyrinthine regulations" means nothing more than
+  "complicated regulations" to most speakers.
+- **The maze/labyrinth distinction is collapsed** -- technically, a
+  labyrinth is unicursal (one winding path, no choices) while a maze is
+  multicursal (branching paths, dead ends). The mythological Labyrinth
+  was likely multicursal (otherwise the thread would be unnecessary). But
+  in modern English, the distinction is lost, and "labyrinthine" covers
+  both. This matters because unicursal complexity (long but deterministic)
+  is fundamentally different from multicursal complexity (branching and
+  uncertain). Bureaucracies can be either kind, but the metaphor does not
+  help us distinguish them.
+
+## Expressions
+
+- "Labyrinthine bureaucracy" -- complex administrative structures, used
+  with no mythological awareness
+- "A labyrinth of regulations" -- tangled rules, a journalistic formula
+- "Navigate the labyrinth" -- find your way through institutional
+  complexity, preserving the journey metaphor but not the myth
+- "Ariadne's thread" -- occasionally used in technical contexts
+  (programming, data analysis) for a traceable path through complexity,
+  one of the few expressions that retains awareness of the source myth
+- "Labyrinthine prose" -- writing that is difficult to follow, extending
+  the metaphor from physical to textual navigation
+
+## Origin Story
+
+The Labyrinth appears in Greek mythology as a creation of Daedalus,
+the master craftsman, commissioned by King Minos of Crete to contain
+the Minotaur -- the half-bull offspring of Minos' wife Pasiphae. The
+earliest references are in Homer's *Iliad* (18.590-592), where a
+"dancing-floor" at Knossos is mentioned, and more fully in later sources
+like Apollodorus and Ovid.
+
+The archaeological discovery of the palace at Knossos by Arthur Evans
+(1900) -- with its complex, multi-level layout -- lent physical
+plausibility to the myth and reinforced the metaphorical association
+between labyrinthine architecture and Cretan civilization. The word
+"labyrinth" itself may derive from *labrys*, the Minoan double axe, or
+from a pre-Greek word meaning "stone quarry" (Plutarch). Either etymology
+points to something built, not natural -- reinforcing the myth's
+emphasis on designed complexity.
+
+By the Renaissance, "labyrinth" was already a standard metaphor for
+complexity in European languages. Comenius used it as the organizing
+metaphor for his critique of human knowledge (*The Labyrinth of the
+World*, 1623). By the 20th century, Borges and Eco made the labyrinth
+a primary metaphor for textual and epistemological complexity. Today
+the word's mythological origins are largely invisible to speakers who
+use "labyrinthine" as a routine adjective.
+
+## References
+
+- Homer, *Iliad* 18.590-592 -- earliest reference to Daedalus' work at
+  Knossos
+- Apollodorus, *Bibliotheca* 3.1.4, 3.15.8 -- the canonical account of
+  the Labyrinth, Minotaur, and Theseus
+- Ovid, *Metamorphoses* 8.152-168 -- Daedalus' construction of the
+  Labyrinth
+- Doob, P.R. *The Idea of the Labyrinth* (Cornell, 1990) -- comprehensive
+  history of the labyrinth as metaphor from antiquity to the Middle Ages
+- Borges, J.L. "The Garden of Forking Paths" (1941) and "The Library of
+  Babel" (1941) -- modern literary deployments of the labyrinth archetype


### PR DESCRIPTION
## Summary
- Adds `labyrinth` dead-metaphor mapping (mythology -> governance)
- Designed complexity that traps; covers intentional obstruction, the Minotaur at the center, Ariadne's thread as audit trail, and the builder trapped by their own creation
- Closes #1079

## Validator output
All content valid. (pre-existing dangling reference warnings only)

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [ ] Review mapping content for accuracy and tone

Generated with [Claude Code](https://claude.com/claude-code)