### PR TITLE
Add mapping: icarus

### DIFF
--- a/catalog/mappings/icarus.md
+++ b/catalog/mappings/icarus.md
@@ -1,0 +1,151 @@
+---
+slug: icarus
+name: "Icarus"
+kind: archetype
+source_frame: mythology
+target_frame: social-behavior
+categories:
+  - mythology-and-religion
+  - psychology
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - prometheus
+  - siren-song
+  - achilles-heel
+---
+
+## What It Brings
+
+Daedalus fashioned wings of feathers and wax for himself and his son Icarus
+to escape imprisonment in Crete. He warned Icarus not to fly too close to
+the sun (the wax would melt) or too close to the sea (the feathers would
+become waterlogged). Icarus, intoxicated by flight, soared upward. The wax
+melted, the wings disintegrated, and he fell into the sea and drowned. The
+myth encodes a structural pattern about ambition that ignores material
+constraints -- a pattern that recurs across business, politics, technology,
+and personal endeavor.
+
+The archetype maps a specific failure mode:
+
+- **The enabling technology has structural limits** -- the wings work, but
+  only within a defined operating envelope. Wax has a melting point; this
+  is not a defect but a material property. The mapping is precise for
+  any technology or strategy that functions within parameters but fails
+  catastrophically when pushed beyond them: leveraged financial
+  instruments that work until volatility exceeds a threshold, startups
+  that scale until unit economics invert, leaders whose charisma works
+  in one context but destroys them in another.
+- **The warning is explicit and ignored** -- Daedalus tells Icarus exactly
+  what will happen. The failure is not from ignorance but from the
+  inability to act on known information in the presence of exhilaration.
+  This maps onto situations where risk warnings are delivered, understood,
+  and disregarded: the due diligence report that said the acquisition was
+  overpriced, the engineer who flagged the O-ring problem before
+  Challenger, the financial models that showed the housing market was
+  unsustainable before 2008.
+- **Success enables the failure** -- Icarus falls because the wings *work*.
+  If they had failed immediately, he would never have reached dangerous
+  altitude. The myth captures the specific dynamic where early success
+  creates the confidence that leads to overextension: the company that
+  grows so fast it outstrips its management capacity, the trader whose
+  early wins make them increase their position size until the inevitable
+  loss wipes them out.
+- **The middle path is invisible** -- Daedalus warns against both extremes:
+  too high and too low. But the myth is only remembered for the upward
+  failure. Nobody talks about the danger of flying too close to the sea.
+  This selective memory reveals a cultural bias: we are fascinated by
+  hubris but uninterested in excessive caution. The full Icarus archetype
+  includes the lesson that timidity is also fatal, but this half of the
+  myth has been almost entirely lost.
+
+## Where It Breaks
+
+- **The metaphor assumes fixed limits** -- Icarus cannot change the melting
+  point of wax. But real structural limits are often movable: better
+  materials, new financing structures, improved management practices. The
+  Icarus metaphor can function as a conservative counsel against ambition,
+  treating current constraints as permanent when they may be temporary.
+  Every aviation pioneer was told they were "flying too close to the sun"
+  until they were not.
+- **It conflates ambition with hubris** -- the myth makes no distinction
+  between reasonable boldness and reckless overreach. Was Icarus wrong to
+  fly, or only wrong to fly *that high*? The metaphor tends to be applied
+  after the fact: if the ambitious project succeeds, the leader is
+  "visionary"; if it fails, they are "Icarus." This retrospective
+  application makes the metaphor descriptive rather than predictive -- it
+  explains failure but cannot identify it in advance.
+- **Daedalus' survival is narratively convenient** -- the father who gives
+  the same warning follows the same instructions and survives. This
+  implies that the middle path is straightforwardly achievable, that
+  moderation is simply a matter of following instructions. In reality,
+  the moderate path is often unclear, contested, and only identifiable in
+  hindsight. The myth makes restraint look easy and excess look stupid,
+  when in practice the boundary between them is blurry.
+- **Youth is not the relevant variable** -- the myth codes the failure as
+  generational: the young son ignores the old father's wisdom. But
+  Icarian failures are not correlated with age. Enron, Long-Term Capital
+  Management, and WeWork were led by experienced adults. The myth's
+  age-coding can make it a vehicle for dismissing young people's ambitions
+  rather than analyzing specific structural risks.
+- **The fall is total and immediate** -- Icarus goes from flying to dead
+  in one transition. Real overextension failures usually unfold gradually:
+  the company bleeds cash for quarters, the leader's judgment erodes
+  over years, the leveraged position decays slowly before the margin call.
+  The myth's instant catastrophe maps poorly onto the slow-motion collapses
+  that characterize most real Icarian failures.
+
+## Expressions
+
+- "Flying too close to the sun" -- the core expression, used across
+  business journalism, sports commentary, and political analysis to
+  describe overreach
+- "Icarus moment" -- the point at which ambition exceeds structural limits,
+  used especially in financial commentary
+- "Icarus paradox" -- Danny Miller's management concept (1990) describing
+  how the same qualities that drive success eventually cause failure
+- "Don't be Icarus" -- a cautionary formula, often used by mentors and
+  investors
+- "Wax wings" -- occasionally used to describe strategies or technologies
+  that work only under favorable conditions ("their business model is
+  held together with wax wings")
+- "He flew too high" -- a compressed version that has largely detached from
+  the mythological source, used as a general epitaph for failed ambition
+
+## Origin Story
+
+The Icarus myth is preserved primarily in Ovid's *Metamorphoses*
+(8.183-235, c. 8 CE) and Apollodorus' *Bibliotheca* (c. 1st-2nd century
+CE). In Ovid's telling, the emphasis is on the pathos of Daedalus -- the
+father who watches his son fall and can do nothing. The myth is part of a
+larger cycle about Daedalus, the master craftsman who builds marvels
+(the Labyrinth, the wooden cow, the wings) and is repeatedly punished by
+the consequences of his own ingenuity.
+
+Pieter Bruegel's painting *Landscape with the Fall of Icarus* (c. 1555)
+and W.H. Auden's poem about it ("About suffering they were never wrong, /
+The old Masters") introduced a different reading: that Icarus' fall goes
+largely unnoticed by the world. The ploughman keeps ploughing, the ship
+sails on. This adds a dimension the myth alone does not contain: that
+spectacular individual failure is a private catastrophe in a world that
+does not pause for it.
+
+Danny Miller's *The Icarus Paradox* (1990) gave the archetype formal
+standing in management theory, arguing that the very traits that make
+companies great (focus, innovation, bold leadership) tend to become
+pathological when pushed too far. This is the most structurally faithful
+modern use of the myth: it preserves the insight that success enables
+failure, not just that ambition is dangerous.
+
+## References
+
+- Ovid, *Metamorphoses* 8.183-235 -- the canonical literary version
+- Apollodorus, *Bibliotheca* 2.6.3 -- the mythographic summary
+- Miller, D. *The Icarus Paradox* (1990) -- the archetype formalized in
+  management theory
+- Auden, W.H. "Musee des Beaux Arts" (1938) -- the poem about Bruegel's
+  painting, adding the theme of the world's indifference to individual
+  catastrophe
+- Bruegel, P. *Landscape with the Fall of Icarus* (c. 1555) -- the
+  painting that reframed the myth as a story about insignificance


### PR DESCRIPTION
## Summary
- Adds `icarus` archetype mapping (mythology -> social-behavior)
- Ambition that ignores structural limits; the pattern where success enables failure, covering the Icarus paradox, the ignored warning, and the invisible middle path
- Closes #1080

## Validator output
All content valid. (pre-existing dangling reference warnings only)

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [ ] Review mapping content for accuracy and tone

Generated with [Claude Code](https://claude.com/claude-code)