### PR TITLE
Add mapping: cassandra

### DIFF
--- a/catalog/mappings/cassandra.md
+++ b/catalog/mappings/cassandra.md
@@ -1,0 +1,136 @@
+---
+slug: cassandra
+name: "Cassandra"
+kind: conceptual-metaphor
+source_frame: mythology
+target_frame: social-behavior
+categories:
+  - mythology-and-religion
+  - social-dynamics
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - nemesis
+---
+
+## What It Brings
+
+Cassandra, daughter of King Priam of Troy, was granted the gift of
+prophecy by Apollo. When she rejected his advances, he cursed her: she
+would always see the future correctly but would never be believed. She
+predicted the fall of Troy and was ignored. The metaphor maps this
+structure onto any situation where accurate warnings are systematically
+dismissed.
+
+- **Correctness without credibility** -- the core structural insight is
+  that being right is not sufficient for being heard. Cassandra's
+  predictions are perfect; her credibility is zero. The metaphor
+  identifies a failure mode in social epistemology: the accuracy of a
+  warning and its reception are independent variables. A climate
+  scientist whose models are correct but whose policy recommendations
+  are ignored, a risk analyst who flags a systemic vulnerability that
+  management dismisses, a whistleblower whose evidence is impeccable but
+  whose organizational position makes them easy to marginalize -- all
+  occupy the Cassandra position.
+- **The curse is social, not epistemic** -- Cassandra does not suffer
+  from a knowledge problem. She sees clearly. The curse operates on
+  everyone else: they are rendered incapable of believing her. The
+  metaphor locates the failure not in the warner but in the audience.
+  This is a powerful reframing. It shifts the question from "why didn't
+  anyone predict this?" to "why didn't anyone listen to the people who
+  did?"
+- **Structural recurrence** -- the Cassandra pattern repeats because the
+  forces that suppress uncomfortable predictions are structural, not
+  personal. Organizations reward consensus and penalize dissent.
+  Decision-makers suffer from confirmation bias and optimism bias.
+  Warnings about low-probability, high-consequence events are
+  systematically discounted because the base rate of false alarms is
+  high. The metaphor names a pattern that is built into how groups
+  process information.
+
+## Where It Breaks
+
+- **Cassandra's curse was supernatural; real-world dismissal has mundane
+  causes** -- Apollo's curse guaranteed that no one would believe
+  Cassandra, regardless of evidence or argument. In reality, the reasons
+  people dismiss accurate warnings are varied, prosaic, and often
+  rational: the warner has cried wolf before, the warning is vague, the
+  proposed remedy is too costly, the decision-maker has different
+  information, or the warning conflicts with institutional incentives.
+  Calling someone a "Cassandra" implies a cosmic injustice where there
+  is often a mundane explanation for the dismissal.
+- **Many self-proclaimed Cassandras are wrong** -- the metaphor is almost
+  always self-applied retrospectively, after the predicted disaster has
+  occurred. But for every ignored warning that proved correct, there are
+  hundreds of dire predictions that were wrong. The person warning of
+  imminent financial collapse for fifteen consecutive years will
+  eventually be right once and will claim Cassandra status while
+  forgetting the fourteen years of incorrect prediction. The metaphor
+  has no mechanism for distinguishing genuine foresight from a broken
+  clock.
+- **It removes the obligation to persuade** -- the myth says persuasion
+  is impossible because the curse makes it so. Real-world Cassandras
+  often fail not because belief is supernaturally blocked but because
+  they present their warnings poorly: wrong audience, wrong framing,
+  wrong timing, too much technical detail, too little political savvy.
+  The Cassandra metaphor excuses the warner from the work of effective
+  communication by blaming the audience for a structural incapacity to
+  listen. Sometimes the audience is the problem; sometimes the
+  presentation is.
+- **The binary outcome obscures partial listening** -- Cassandra is either
+  believed or not; there is no middle ground. In reality, warnings are
+  often partially heeded: a risk committee acknowledges the concern but
+  assigns it lower priority, a government commissions a study but delays
+  action, a manager adds the risk to a register but does not change
+  plans. This partial response -- insufficient but not zero -- has no
+  place in the Cassandra metaphor, which requires total dismissal to
+  function narratively.
+
+## Expressions
+
+- "Playing Cassandra" -- issuing warnings that one expects will be
+  ignored, sometimes with a note of self-pity
+- "Cassandra complex" -- a psychological pattern of believing one's
+  insights will never be heard, which can become self-defeating
+- "The Cassandra problem" -- in decision theory and risk management,
+  the structural difficulty of acting on low-probability, high-consequence
+  warnings
+- "No one listened" -- the compressed Cassandra narrative, used
+  retrospectively after a predicted disaster
+- "Cassandra curse" -- the specific condition of being right and being
+  dismissed, used in journalism and political commentary
+
+## Origin Story
+
+Cassandra appears in Homer's *Iliad* and in the tragedies of Aeschylus
+(*Agamemnon*), Euripides (*Trojan Women*), and others. The curse
+narrative -- prophecy granted by Apollo, then rendered useless when she
+refused him -- is most fully developed in Aeschylus, where Cassandra
+foresees her own murder by Clytemnestra and the chorus fails to
+understand her.
+
+The metaphorical usage emerged in the 20th century as a term for
+unheeded warning, particularly in political and military contexts.
+During the Cold War, strategists who warned of nuclear vulnerabilities
+that went unaddressed were called Cassandras. The term gained renewed
+currency after the September 11 attacks, when investigations revealed
+that multiple intelligence analysts had warned of the threat and been
+ignored. Richard Clarke titled his memoir *Against All Enemies* but the
+media consistently described him using the Cassandra frame.
+
+Today "Cassandra" is a standard term in risk management, intelligence
+analysis, and climate discourse. It has also become a common self-
+description for people who feel their expertise is dismissed -- a usage
+that often says more about the speaker's frustration than about the
+audience's epistemic failure.
+
+## References
+
+- Aeschylus, *Agamemnon* 1072-1330 -- the definitive dramatic treatment
+  of Cassandra's prophecy and its rejection
+- Clarke, R. and Eddy, R.P. *Warnings: Finding Cassandras to Stop
+  Catastrophes* (2017) -- systematic study of why accurate warnings are
+  ignored, using the Cassandra framework
+- Tetlock, P. *Expert Political Judgment* (2005) -- empirical evidence
+  on the difficulty of distinguishing genuine Cassandras from chronic
+  pessimists


### PR DESCRIPTION
## Summary
- Reworked `cassandra` mapping: mythology-sourced conceptual metaphor mapping unheeded prophecy onto dismissed accurate warnings
- All frames and categories already exist; no new ones needed
- Refs #1086 (sub-issue of #219, fantasy-mythology-folklore)

## Validator output
All content valid. Zero errors. (25 pre-existing dangling-reference warnings, none from this PR)

## Test plan
- [x] `uv run scripts/validate.py validate` passes

Generated with [Claude Code](https://claude.com/claude-code)