### PR TITLE
Add mapping: narcissism

### DIFF
--- a/catalog/mappings/narcissism.md
+++ b/catalog/mappings/narcissism.md
@@ -1,0 +1,121 @@
+---
+slug: narcissism
+name: "Narcissism"
+kind: dead-metaphor
+source_frame: mythology
+target_frame: mental-experience
+categories:
+  - mythology-and-religion
+  - psychology
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - mentor
+---
+
+## What It Brings
+
+Narcissus was a hunter in Greek mythology of extraordinary beauty who
+rejected all romantic advances. As punishment, Nemesis led him to a pool
+where he fell in love with his own reflection and, unable to leave it,
+wasted away and died. The story encodes a specific structural insight:
+self-regard, past a threshold, becomes self-destruction.
+
+The word "narcissism" entered clinical psychology through Havelock Ellis
+(1898) and was formalized by Freud (1914), who distinguished primary
+narcissism (a normal developmental stage) from secondary narcissism
+(a pathological regression to that stage). By the time the DSM-III codified
+Narcissistic Personality Disorder in 1980, the mythological source was
+essentially invisible. Today, "narcissist" is used in everyday speech to
+describe a self-absorbed person with no awareness that the word names a
+figure who died staring at his own reflection in a pool.
+
+Key structural elements that survived the transfer:
+
+- **Self-absorption as a trap** -- Narcissus cannot look away from his
+  reflection. The clinical concept preserves this: the narcissist is
+  trapped in a self-referential loop, unable to genuinely perceive others.
+  Every interaction becomes a mirror, reflecting the self back to the self.
+- **The reflection is not the person** -- Narcissus falls in love with
+  an image, not himself. The clinical concept partially preserves this:
+  narcissistic personality involves attachment to an idealized self-image
+  that may bear little resemblance to the actual person. The grandiose
+  self is the reflection in the pool.
+- **Rejection of others precedes the fall** -- Narcissus rejected Echo
+  and every other suitor before encountering the pool. The clinical
+  parallel: narcissistic withdrawal from genuine relationships creates
+  the conditions for the pathological self-focus.
+
+## Where It Breaks
+
+- **The myth is about punishment; the disorder is not** -- Nemesis
+  deliberately led Narcissus to the pool as divine retribution for his
+  cruelty to Echo. Clinical narcissism is not a punishment inflicted by
+  an external agent. It typically develops from childhood experiences --
+  excessive praise, neglect, or inconsistent caregiving. Importing the
+  punishment narrative encourages the moralistic view that narcissists
+  "deserve" their condition, which is clinically counterproductive and
+  impedes treatment.
+- **Narcissus knew he was beautiful; narcissists often don't know they
+  are fragile** -- the myth presents Narcissus as genuinely extraordinary.
+  Clinical narcissism often involves a grandiose exterior concealing
+  profound insecurity. The mythological figure's self-love is straightforward;
+  the clinical version is paradoxical. The dead metaphor obscures this
+  crucial distinction between genuine and compensatory self-regard.
+- **The myth ends in death; the clinical condition is chronic** --
+  Narcissus wastes away. NPD is a persistent personality pattern, not a
+  terminal trajectory. The mythological arc -- from beauty to destruction
+  -- imports a dramatic narrative that distorts the clinical reality of
+  a stable (if maladaptive) personality organization.
+- **"Narcissist" as insult collapses a spectrum** -- in everyday usage,
+  calling someone a narcissist means "selfish and vain." This flattens
+  the clinical spectrum from healthy self-regard through narcissistic
+  traits to full personality disorder. The dead metaphor's moralistic
+  overtone (Narcissus was punished for a sin) makes the word function
+  as a judgment rather than a description, which is precisely what a
+  clinical term should not do.
+- **The myth involves no other minds; the disorder is interpersonal** --
+  Narcissus's tragedy is solitary. Clinical narcissism is fundamentally
+  relational: it manifests in how the person treats others, demands
+  admiration, lacks empathy, and manages relationships as narcissistic
+  supply. The solitary-pool image misses the social devastation that
+  defines the clinical presentation.
+
+## Expressions
+
+- "He's such a narcissist" -- everyday usage with no mythological
+  awareness; means "self-centered"
+- "Narcissistic supply" -- clinical term for the admiration and
+  attention the narcissist requires, the pool of reflections made social
+- "Narcissistic injury" / "narcissistic wound" -- damage to the
+  grandiose self-image; the reflection is cracked
+- "Narcissistic personality disorder" -- the DSM diagnostic category,
+  fully severed from its mythological source
+- "Healthy narcissism" -- a modern coinage that would have baffled the
+  myth's authors, since Narcissus's self-love was entirely destructive
+- "Narcissistic rage" -- the fury triggered when the idealized self-image
+  is challenged; no parallel in the original myth, where Narcissus is
+  passive
+
+## Origin Story
+
+The myth of Narcissus appears in Ovid's *Metamorphoses* (8 CE), Book III.
+Havelock Ellis first used "narcissus-like" to describe autoeroticism in
+1898. Freud's 1914 essay "On Narcissism" established the term in
+psychoanalytic theory, distinguishing primary from secondary narcissism.
+Heinz Kohut's self-psychology (1971) reframed narcissism as a deficit in
+self-structure rather than an excess of self-love, moving the clinical
+concept further from its mythological source. The DSM-III (1980) codified
+Narcissistic Personality Disorder, completing the term's migration from
+mythology through psychoanalysis into mainstream psychiatry and, from
+there, into everyday language.
+
+## References
+
+- Ovid. *Metamorphoses*, Book III (8 CE) -- the primary mythological source
+- Ellis, H. "Auto-Erotism: A Psychological Study," *Alienist and
+  Neurologist* 19 (1898)
+- Freud, S. "On Narcissism: An Introduction" (1914)
+- Kohut, H. *The Analysis of the Self* (1971)
+- American Psychiatric Association. *DSM-III* (1980) -- codification
+  of Narcissistic Personality Disorder


### PR DESCRIPTION
## Summary
- Adds `narcissism` dead-metaphor mapping (mythology -> mental-experience)
- Greek myth of Narcissus became clinical psychology term with source domain fully invisible
- Closes #1087

## Validator output
All content valid (0 errors, 0 new warnings).

## Test plan
- [x] `uv run scripts/validate.py validate` passes

Generated with [Claude Code](https://claude.com/claude-code)