### PR TITLE
Add mapping: ragnarok

### DIFF
--- a/catalog/mappings/ragnarok.md
+++ b/catalog/mappings/ragnarok.md
@@ -1,0 +1,131 @@
+---
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- systems-thinking
+contributors:
+- fshot
+harness: Claude Code
+kind: conceptual-metaphor
+name: Ragnarok
+related:
+- the-trickster
+- zombie-process
+slug: ragnarok
+source_frame: mythology
+target_frame: destruction
+---
+
+## What It Brings
+
+The twilight of the gods -- a prophesied cataclysm in which the entire
+cosmic order collapses. The gods die, the world-serpent poisons the sky,
+the earth sinks into the sea. And then, crucially, it rises again.
+A new world emerges from the wreckage, green and renewed, populated by
+survivors who build from nothing.
+
+When someone invokes Ragnarok as metaphor, they are importing a very
+specific structure of catastrophe -- not mere destruction but total
+systemic collapse followed by regeneration:
+
+- **Inevitability** -- Ragnarok is foretold. The gods know it is coming
+  and cannot prevent it. This maps onto situations where systemic failure
+  is predictable, even visible, but structurally unavoidable: technical
+  debt that will eventually bring down the monolith, a market bubble
+  that must pop, a political order whose contradictions will resolve
+  violently. The metaphor says: you can see it coming, and that changes
+  nothing.
+- **Totality** -- this is not partial failure. Every god has a
+  designated killer; every cosmic structure has a scheduled collapse. The
+  metaphor distinguishes itself from ordinary disaster by insisting on
+  comprehensiveness. When engineers say "it was Ragnarok," they mean
+  nothing survived -- the entire stack went down, every service failed,
+  every backup was corrupted. Not a fire in one building but the end
+  of the city.
+- **Rebirth from the ashes** -- the Norse apocalypse is cyclical, not
+  terminal. After the destruction, a new world rises. This structural
+  feature is what makes Ragnarok distinct from simple apocalypse: it
+  carries the promise that total destruction clears the ground for
+  something genuinely new. The rewrite that follows the catastrophic
+  legacy system failure. The startup that rises from the ashes of the
+  bankrupt corporation. The metaphor insists that what comes after is
+  not a repair but a fresh creation.
+- **The old order was complicit** -- in the Norse telling, the gods'
+  own flaws produce Ragnarok. Odin's hunger for knowledge, the gods'
+  mistreatment of Loki, their broken oaths. The catastrophe is not
+  an external attack but the system's own contradictions reaching
+  their logical endpoint. This maps onto organizations where the
+  culture that built success also builds the conditions for collapse.
+
+## Where It Breaks
+
+- **Most "Ragnaroks" are just bad outages** -- the metaphor demands
+  total systemic collapse followed by genuine rebirth. In practice,
+  people invoke it for any sufficiently dramatic failure, even when
+  the system was patched and resumed normal operations by Tuesday.
+  The metaphor's grandeur inflates ordinary incidents into mythic
+  events, which feels satisfying but obscures the difference between
+  a recoverable failure and a genuinely transformative one.
+- **The rebirth is not guaranteed** -- Norse mythology promises renewal
+  because it is a story with a narrator who controls the outcome. Real
+  systems that collapse totally often stay collapsed. Companies that
+  implode do not necessarily produce successor companies. Codebases
+  that rot past the point of maintenance sometimes just get abandoned.
+  The metaphor imports an optimism about post-catastrophic renewal that
+  reality does not reliably deliver.
+- **Inevitability is retroactive** -- Ragnarok is foretold because the
+  story is already written. In actual systems, catastrophic failure
+  looks inevitable only in hindsight. Before the collapse, the same
+  warning signs could have been interpreted as manageable risks. The
+  metaphor smuggles in narrative determinism that makes prevention
+  seem futile when it might not have been.
+- **The metaphor aestheticizes suffering** -- there is something
+  uncomfortably appealing about the Ragnarok frame. It transforms
+  a painful event (losing the production database, the company going
+  bankrupt, the project being cancelled) into an epic saga. This
+  mythologization can serve as a coping mechanism, but it can also
+  distract from accountability: if it was Ragnarok, then nobody is
+  to blame -- it was fate.
+
+## Expressions
+
+- "It was total Ragnarok in production last night" -- a cascading
+  outage that took down every service, used when the scale of failure
+  felt mythic
+- "We need a Ragnarok event to fix this codebase" -- arguing that
+  incremental improvement is insufficient and only total destruction
+  and rewrite will work
+- "Ragnarok-proof your backups" -- preparing for the scenario where
+  everything fails simultaneously, not just individual components
+- "Every system has its Ragnarok" -- the fatalistic observation that
+  all architectures eventually reach end-of-life, and the only question
+  is whether you plan for it
+- "Post-Ragnarok greenfield" -- the fresh start after total collapse,
+  the clean slate that could only exist because everything was destroyed
+
+## Origin Story
+
+Ragnarok (Old Norse: "fate of the gods" or "twilight of the gods")
+is described primarily in the Voluspa, the first poem of the Poetic
+Edda, composed in the 10th century. The account details a sequence
+of catastrophes -- the Fimbulwinter, the breaking of bonds, the
+final battle at Vigrid -- followed by the emergence of a renewed
+earth. The myth is unusual among apocalyptic narratives in its
+insistence on cyclicality: the world is not ended but reset.
+
+The metaphorical use of Ragnarok for catastrophic systemic failure
+is informal and modern, appearing in technology and business
+discourse alongside other mythological catastrophe terms (apocalypse,
+armageddon). Ragnarok distinguishes itself from these alternatives
+by its emphasis on rebirth -- people reach for it specifically when
+they want to frame destruction as a precondition for renewal, not
+merely as an ending.
+
+## References
+
+- Sturluson, S. *Prose Edda* (c. 1220), Gylfaginning -- the primary
+  narrative source for Ragnarok
+- *Voluspa* (c. 10th century), Poetic Edda -- the earliest and most
+  detailed prophetic account
+- Lindow, J. *Norse Mythology: A Guide to the Gods, Heroes, Rituals,
+  and Beliefs* (2001) -- modern scholarly overview


### PR DESCRIPTION
## Summary
- Adds mapping for Ragnarok (Norse catastrophic collapse/rebirth) as `conceptual-metaphor`
- Source: `mythology`, Target: `destruction`
- Resolves #1092

## Validator output
All content valid. No new warnings introduced.

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [ ] Review mapping body sections for accuracy and depth

Generated with [Claude Code](https://claude.com/claude-code)