### PR TITLE
Add mapping: cornucopia

### DIFF
--- a/catalog/mappings/cornucopia.md
+++ b/catalog/mappings/cornucopia.md
@@ -1,0 +1,109 @@
+---
+slug: cornucopia
+name: "Cornucopia"
+kind: dead-metaphor
+source_frame: mythology
+target_frame: economics
+categories:
+  - mythology-and-religion
+author: agent:metaphorex-miner
+contributors: []
+related: []
+---
+
+## What It Brings
+
+The cornucopia -- the "horn of plenty" -- originates in Greek mythology.
+In one version, the infant Zeus was nursed by the goat Amalthea; when
+one of her horns broke off, it was blessed with the power to produce
+unlimited food and drink. In another, Heracles broke off a river god's
+horn and filled it with fruits and flowers. The structural core: an
+inexhaustible source that produces abundance without effort or depletion.
+
+Today "cornucopia" means simply "a great abundance" or "an overflowing
+supply." The word appears in contexts ranging from economics to food
+writing to marketing copy with no awareness of the goat, the horn, or
+Zeus. It functions as a pure synonym for "abundance," its mythological
+source entirely dead.
+
+Key structural elements that survived:
+
+- **Abundance without visible source** -- the horn produces endlessly,
+  but the mechanism is divine, not mechanical. The metaphorical usage
+  preserves this: a "cornucopia of options" implies overwhelming plenty
+  without explaining where it comes from. The word marks the experience
+  of abundance, not its economics.
+- **The container shapes the abundance** -- the cornucopia is a horn,
+  an opening that spills outward in a widening arc. The visual metaphor
+  persists in decorative use: Thanksgiving centerpieces, harvest festival
+  logos, food brand packaging. Even when speakers don't know the myth,
+  they recognize the shape as meaning "plenty."
+- **Abundance as blessing** -- the mythological horn was a divine gift.
+  The metaphorical usage retains a positive valence: a cornucopia is
+  never threatening. Unlike "flood" or "deluge," which also denote
+  abundance, "cornucopia" implies that the abundance is welcome and
+  good.
+
+## Where It Breaks
+
+- **Real abundance has costs; the cornucopia has none** -- the horn
+  produces without depletion, labor, or environmental impact. Applying
+  the cornucopia frame to actual economic abundance conceals the
+  extraction, labor, and ecological cost behind the plenty. When a tech
+  company describes its "cornucopia of features," the metaphor hides
+  the engineering effort, technical debt, and maintenance burden that
+  produced them.
+- **The metaphor cannot represent scarcity or limits** -- the
+  cornucopia is structurally incompatible with sustainability thinking.
+  It encodes a pre-economic worldview where abundance is magical and
+  unlimited. Using it to describe natural resources ("a cornucopia of
+  biodiversity") smuggles in the assumption of inexhaustibility, which
+  is precisely the assumption that conservation biology challenges.
+- **Abundance is treated as undifferentiated** -- the horn pours out
+  "plenty," but the metaphor says nothing about quality, distribution,
+  or relevance. A cornucopia of choices can produce decision paralysis
+  (Schwartz's paradox of choice). The metaphor frames more-is-better
+  without acknowledging the cognitive and social costs of excess.
+- **The divine origin obscures human agency** -- mythological abundance
+  is a gift from the gods. Metaphorical abundance is usually the product
+  of human systems: markets, technology, infrastructure. Calling
+  something a cornucopia subtly naturalizes the abundance, making it
+  seem like a given rather than a constructed outcome that could be
+  constructed differently.
+- **The horn only gives; it cannot take back** -- the cornucopia has no
+  reverse mode. Real systems of abundance involve withdrawal, depletion,
+  boom-bust cycles, and entropy. The one-directional metaphor is
+  structurally unable to represent decline, which makes it misleading
+  when applied to finite systems.
+
+## Expressions
+
+- "A cornucopia of options/choices/possibilities" -- overwhelming
+  abundance, no mythological awareness
+- "Horn of plenty" -- the literal translation, used in harvest
+  contexts and still dimly connected to the shape
+- "Cornucopia" as Thanksgiving decoration -- the visual metaphor
+  surviving as cultural artifact long after the myth is forgotten
+- "Digital cornucopia" -- used in tech journalism to describe the
+  abundance of content, apps, or data available online
+
+## Origin Story
+
+The cornucopia appears in multiple Greek sources. Ovid's *Metamorphoses*
+(Book IX) tells the story of Heracles wrestling the river god Achelous
+and breaking off his horn, which naiads then filled with fruit and
+flowers. The Amalthea version -- where the horn comes from the goat
+that nursed the infant Zeus -- appears in various later sources including
+Apollodorus's *Bibliotheca*. The image of the overflowing horn was
+adopted by Roman culture as a symbol of agricultural prosperity and
+appeared widely in Roman art and coinage. It survived through medieval
+and Renaissance art into modern harvest symbolism, where it remains
+ubiquitous in American Thanksgiving iconography despite complete
+detachment from its mythological source.
+
+## References
+
+- Ovid. *Metamorphoses*, Book IX -- Heracles and Achelous
+- Apollodorus. *Bibliotheca* -- Amalthea and the infant Zeus
+- Schwartz, B. *The Paradox of Choice* (2004) -- the costs of
+  abundance that the cornucopia metaphor cannot represent


### PR DESCRIPTION
## Summary
- Adds `cornucopia` dead-metaphor mapping (mythology -> economics)
- Greek horn of plenty became pure synonym for abundance
- Closes #1089

## Validator output
All content valid (0 errors, 0 new warnings).

## Test plan
- [x] `uv run scripts/validate.py validate` passes

Generated with [Claude Code](https://claude.com/claude-code)