### PR TITLE
Add mapping: valhalla

### DIFF
--- a/catalog/mappings/valhalla.md
+++ b/catalog/mappings/valhalla.md
@@ -1,0 +1,130 @@
+---
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- social-dynamics
+contributors:
+- fshot
+harness: Claude Code
+kind: dead-metaphor
+name: Valhalla
+related:
+- ragnarok
+- berserker
+slug: valhalla
+source_frame: mythology
+target_frame: social-behavior
+---
+
+## What It Brings
+
+Valhalla -- the hall of the slain, where warriors chosen by the
+Valkyries feast with Odin until Ragnarok. In modern usage, "Valhalla"
+has detached from its Norse source and become shorthand for the
+ultimate reward reserved for those who gave everything. Most speakers
+who use the word could not describe Odin's hall or explain why its
+inhabitants were chosen. What survives is the structure: an exclusive
+place of honor, earned through sacrifice, where the worthy are
+recognized by their peers.
+
+The dead metaphor preserves several structural features:
+
+- **Admission by sacrifice** -- you do not buy your way into Valhalla;
+  you die in battle. The mapping insists that the highest honor is
+  reserved for those who paid the highest price. "The Valhalla of
+  rock and roll" does not include everyone who played guitar; it
+  includes those who gave their lives to the craft (sometimes
+  literally). The metaphor filters for total commitment, not mere
+  competence.
+- **Selection by higher authority** -- the Valkyries chose who entered
+  Valhalla; the warriors did not choose themselves. The metaphor
+  imports the idea that ultimate recognition comes from judges you
+  cannot lobby or influence. A "hall of fame" that anyone can join
+  is not Valhalla. The metaphor requires gatekeepers whose criteria
+  are beyond negotiation.
+- **Eternal fellowship of equals** -- inside Valhalla, the warriors
+  feast together. There is no further hierarchy; the king and the
+  common soldier share the same hall. The metaphor maps onto any
+  context where the highest achievers are imagined as a community
+  of peers: the pantheon of great physicists, the canon of Western
+  literature, the all-time greats of a sport. Once you are in, you
+  are simply among your kind.
+- **Glory requires an audience** -- Valhalla is not solitary retirement.
+  The warriors fight each day and feast each night, performing their
+  excellence before each other. The metaphor insists that the ultimate
+  reward is not rest but continued action in the company of those
+  who understand what you do. Retirement homes are not Valhalla; the
+  metaphor demands ongoing vitality.
+
+## Where It Breaks
+
+- **Valhalla was not a reward** -- it was a recruitment depot. Odin
+  gathered the einherjar to fight at Ragnarok, the final battle they
+  would lose. The warriors in Valhalla were not being honored; they
+  were being stockpiled for a suicide mission. Modern usage completely
+  inverts this: "Valhalla" is treated as a final reward, when the
+  original was a staging ground for the last war. The metaphor
+  imports the grandeur while discarding the grim purpose.
+- **The selection criteria were amoral** -- the Valkyries did not choose
+  the most virtuous, the most skilled, or the most deserving. They
+  chose those who died in combat. A coward who happened to die with
+  a sword in his hand was eligible; a hero who died in bed was not.
+  Modern usage assumes Valhalla selects for excellence, but the
+  original selected for circumstance.
+- **The metaphor glamorizes death-in-service** -- "he's in Valhalla
+  now" about a deceased colleague imports a framework where dying
+  for the cause is the highest possible achievement. This is
+  problematic in any context where burnout and overwork are real
+  risks. The metaphor's logic says: the ultimate honor goes to those
+  who destroyed themselves for the mission. That is not always a
+  value worth celebrating.
+- **Exclusivity creates a distortion** -- if the highest honor is
+  an exclusive hall, then the contribution of everyone not in that
+  hall is implicitly devalued. The Valhalla metaphor has no room for
+  collective achievement; it is fundamentally individualist and
+  competitive. Teams that adopt it risk elevating individual sacrifice
+  over sustainable collaboration.
+
+## Expressions
+
+- "The Valhalla of jazz" -- the canon of greatest jazz musicians,
+  imagined as a heavenly gathering of peers
+- "He earned his place in Valhalla" -- ultimate recognition after a
+  career of sacrifice, with no awareness of Norse mythology
+- "Welcome to Valhalla" -- greeting someone into an elite group,
+  implying they have proven themselves through ordeal
+- "Tech Valhalla" -- the imagined afterlife of legendary engineers,
+  used both sincerely and ironically
+- "Sent to Valhalla" -- in gaming and combat sports, defeating an
+  opponent with honor, one of the few usages that retains a trace
+  of the warrior origin
+
+## Origin Story
+
+Valhalla (Old Norse *Valholl*, "hall of the slain") is described in
+the Prose Edda and Poetic Edda. Snorri Sturluson's account in
+Gylfaginning describes a hall roofed with golden shields, where
+warriors feast on the boar Saehrimnir and drink mead poured by
+Valkyries. The hall has 540 doors, each wide enough for 800 warriors
+to march through abreast -- the scale emphasizing that this is an
+army, not a retirement community.
+
+The word entered English through 19th-century translations of Norse
+literature and Wagner's operatic adaptations. By the 20th century,
+"Valhalla" had become a generic English word for "hall of fame" or
+"ultimate reward," fully detached from its mythological source. The
+1970 film *Valhalla Rising* and the *Mad Max: Fury Road* (2015)
+line "Witness me!" helped re-inject some warrior-death connotation
+into popular culture, but for most English speakers, Valhalla is
+simply a prestigious-sounding synonym for "the best of the best."
+
+## References
+
+- Sturluson, S. *Prose Edda* (c. 1220), Gylfaginning -- primary
+  description of Valhalla
+- *Grimnismal*, Poetic Edda -- detailed account of Valhalla's
+  physical structure
+- Lindow, J. *Norse Mythology: A Guide to the Gods, Heroes, Rituals,
+  and Beliefs* (2001)
+- Simek, R. *Dictionary of Northern Mythology* (1993) -- etymological
+  and cultural analysis of Valholl


### PR DESCRIPTION
## Summary
- Adds mapping for Valhalla as `dead-metaphor` (Norse hall of slain -> ultimate reward)
- Source: `mythology`, Target: `social-behavior`
- Resolves #1094

## Validator output
All content valid. Warnings for related mappings in separate PRs only.

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [ ] Review mapping body sections for accuracy and depth

Generated with [Claude Code](https://claude.com/claude-code)