### PR TITLE
Add mapping: world-tree

### DIFF
--- a/catalog/mappings/world-tree.md
+++ b/catalog/mappings/world-tree.md
@@ -1,0 +1,147 @@
+---
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- computer-science
+- systems-thinking
+contributors:
+- fshot
+harness: Claude Code
+kind: archetype
+name: World Tree
+related:
+- ragnarok
+- filesystem-tree
+slug: world-tree
+source_frame: mythology
+target_frame: ontological-hierarchy
+---
+
+## What It Brings
+
+A cosmic tree whose roots, trunk, and branches connect and organize all
+of reality. Yggdrasil in Norse mythology, the Kabbalistic Tree of Life,
+the Mesoamerican ceiba, the Hindu Ashvattha -- the image recurs across
+cultures that had no contact with each other. This cross-cultural
+persistence marks it as an archetype: a structural pattern so natural
+to human cognition that it emerges independently wherever people need
+to organize complexity into a connected, navigable hierarchy.
+
+The archetype maps a single structural insight onto wildly different
+domains:
+
+- **One root, branching into many** -- the tree grows from a single
+  point and divides. This is the structure of file systems (one root
+  directory, branching subdirectories), org charts (one CEO, branching
+  divisions), taxonomies (one kingdom, branching phyla), and inheritance
+  hierarchies (one base class, branching subclasses). The world tree
+  gave us the template for "everything connects upward to a single
+  origin and downward into increasing specificity."
+- **Realms connected by a single axis** -- Yggdrasil connects Asgard
+  (gods), Midgard (humans), and Hel (the dead). The tree is not just
+  a hierarchy but a conduit between categorically different domains.
+  This maps onto layered architectures where a single structure spans
+  multiple levels of abstraction: the OSI model, the compiler pipeline,
+  the organizational layer cake from board to individual contributor.
+  The tree says: these different worlds are not separate; they are
+  connected through me.
+- **Traversal as navigation** -- you move through the world tree by
+  climbing or descending. This maps directly onto tree traversal in
+  computer science (depth-first, breadth-first), directory navigation
+  (cd .., ls), and organizational escalation (going up the chain,
+  drilling down into a department). The metaphor provides a spatial
+  intuition for moving through abstract hierarchies.
+- **The tree is alive** -- unlike a ladder or a tower, a tree grows,
+  has seasons, and can be damaged. Yggdrasil is gnawed by the serpent
+  Nidhogg; the Tree of Life has barren branches. This vitality maps
+  onto the recognition that hierarchies are not static structures but
+  living systems that grow, decay, and require maintenance. An org
+  chart is not architecture; it is horticulture.
+
+## Where It Breaks
+
+- **Real hierarchies are not trees** -- they are directed acyclic
+  graphs at best, tangled webs at worst. A file can be symlinked from
+  multiple directories. An employee can report to two managers. A class
+  can inherit from multiple parents. The tree archetype imposes a
+  clean branching structure that actual systems routinely violate.
+  Every system modeled as a tree eventually needs escape hatches
+  (symlinks, dotted-line reporting, mixins) for the connections that
+  the tree shape cannot express.
+- **The archetype hides the root's fragility** -- a tree with a single
+  root is a single point of failure. If the root dies, the tree dies.
+  This maps onto the real vulnerability of hierarchical systems: kill
+  the root DNS server, fire the CEO with no succession plan, corrupt
+  the root node of the filesystem. The archetype presents the single
+  root as a source of unity, but it is equally a source of
+  catastrophic vulnerability.
+- **Trees impose a distance metric that may be artificial** -- in a
+  tree, nodes that are close in meaning may be far apart in structure.
+  Two related concepts on different branches must traverse up to the
+  common ancestor and back down. This is why cross-cutting concerns
+  are hard in hierarchical systems: the tree structure creates
+  artificial distances between things that are actually related.
+- **The cosmic tree is bidirectional; most technical trees are not** --
+  Yggdrasil connects realms that communicate in both directions. Gods
+  descend, humans ascend, the dead influence the living. But file
+  system trees, class hierarchies, and org charts are typically
+  navigated top-down. The archetype promises a richness of connection
+  that the technical implementations rarely deliver.
+- **Growth is not always good** -- a tree that grows without pruning
+  becomes unwieldy. The archetype celebrates organic growth, but
+  hierarchies that grow unchecked produce the pathologies that every
+  large organization knows: too many layers, too many branches, too
+  many leaves too far from the root. The archetype lacks a built-in
+  concept of when to stop growing.
+
+## Expressions
+
+- "Tree structure" -- the foundational data structure in computer
+  science, so pervasive that its mythological origin is invisible
+- "Root directory" -- the base of a file system, mapping the tree's
+  root directly onto digital organization
+- "Branch" in version control -- a divergent line of development
+  that can be merged back, preserving the tree's growth metaphor
+- "Leaf node" -- a terminal element with no children, botanical
+  language applied unselfconsciously to abstract data
+- "Pruning the org chart" -- removing unnecessary branches from an
+  organizational hierarchy, mixing tree horticulture with corporate
+  restructuring
+- "Drilling down" -- descending through tree levels to reach specific
+  data, mapping vertical tree navigation onto information retrieval
+- "Up the chain" -- ascending the hierarchy to reach authority,
+  treating the org structure as a tree to be climbed
+
+## Origin Story
+
+The world tree appears in the earliest recorded mythologies. Yggdrasil
+is described in the Poetic Edda (10th century) and Prose Edda (c. 1220)
+as an immense ash tree at the center of the cosmos, connecting nine
+worlds. The Kabbalistic Tree of Life (Etz Chaim) organizes ten
+sefirot into a structure that maps divine emanation. The Mesoamerican
+ceiba connects the thirteen heavens, the earth, and the nine levels
+of the underworld. The Hindu Ashvattha (Bhagavad Gita 15.1-4) grows
+with its roots above and branches below, inverting the tree to
+represent the relationship between the eternal and the manifest.
+
+The pattern's cross-cultural recurrence suggests it is rooted in
+something deeper than cultural diffusion: trees are among the largest,
+most visible, most structurally legible organisms on Earth. Their
+branching structure is self-similar, their vertical orientation is
+unmistakable, and their longevity makes them natural symbols of
+permanence. When computer scientists in the 1950s and 1960s needed a
+structure for hierarchical data, they reached for the tree -- likely
+without thinking of Yggdrasil, but drawing on the same cognitive
+archetype that the Norse poets did.
+
+## References
+
+- *Voluspa* and *Grimnismal*, Poetic Edda -- primary sources for
+  Yggdrasil
+- Sturluson, S. *Prose Edda* (c. 1220) -- Yggdrasil as cosmic axis
+- Knuth, D.E. *The Art of Computer Programming, Vol. 1* (1968) --
+  foundational treatment of tree data structures
+- Eliade, M. *Shamanism: Archaic Techniques of Ecstasy* (1951) --
+  the world tree as axis mundi across cultures
+- Cook, R. *The Tree of Life: Image for the Cosmos* (1974) --
+  cross-cultural survey of the world tree archetype


### PR DESCRIPTION
## Summary
- Adds mapping for World Tree as `archetype` (cross-cultural cosmic tree -> hierarchical structures)
- Source: `mythology`, Target: `ontological-hierarchy` (corrected from prospector's `governance`)
- Resolves #1095

## Validator output
All content valid. One warning for related mapping in separate PR.

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [ ] Review mapping body sections for accuracy and depth

Generated with [Claude Code](https://claude.com/claude-code)