### PR TITLE
Add mapping: mentor

### DIFF
--- a/catalog/mappings/mentor.md
+++ b/catalog/mappings/mentor.md
@@ -1,0 +1,137 @@
+---
+slug: mentor
+name: "Mentor"
+kind: dead-metaphor
+source_frame: mythology
+target_frame: authority-and-mentorship
+categories:
+  - mythology-and-religion
+  - education-and-learning
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - aegis
+  - narcissism
+---
+
+## What It Brings
+
+Mentor was a character in Homer's *Odyssey* -- an old friend of
+Odysseus who was entrusted with the care of Odysseus's household and
+the education of his son Telemachus during the Trojan War. Crucially,
+the goddess Athena repeatedly assumed Mentor's form to guide Telemachus,
+so the figure that later generations took as the archetype of the
+wise teacher was actually a divine being in disguise for much of the
+narrative.
+
+Today "mentor" is a common English noun meaning a trusted adviser or
+experienced guide. The word is so thoroughly naturalized that it
+functions as a verb ("she mentored three junior engineers"), generates
+derivatives ("mentorship," "mentee"), and appears in HR policies,
+university programs, and self-help books with no trace of its
+Homeric origin. It is one of the most successful dead metaphors in
+English -- a proper noun that became a common noun so completely
+that its mythological source is invisible.
+
+Key structural elements that survived:
+
+- **The mentor is older and wiser** -- Mentor was an elder entrusted
+  with guidance. The modern usage preserves the age and experience
+  differential: a mentor is assumed to be senior to the mentee. Peer
+  mentoring is a recognized variation, but it is marked as an exception
+  precisely because the default assumption is hierarchical.
+- **The relationship is personal, not institutional** -- Odysseus
+  chose Mentor as a trusted friend, not as a hired tutor. Modern
+  mentorship retains this personal quality even when it occurs within
+  institutional frameworks. The word implies a relationship deeper
+  than instruction -- involving trust, advocacy, and personal
+  investment in the mentee's development.
+- **The mentor acts in the absence of the primary authority** --
+  Mentor guided Telemachus because Odysseus was away at war. The
+  structural parallel persists: mentors often fill a gap left by
+  absent or unavailable authorities. A workplace mentor compensates
+  for a manager who is too busy, too distant, or too focused on
+  deliverables to develop their reports.
+- **Guidance, not control** -- Mentor advised Telemachus but did not
+  command him. The modern concept preserves this distinction: a
+  mentor suggests, models, and supports but does not direct. This is
+  what differentiates mentorship from management or teaching.
+
+## Where It Breaks
+
+- **The mythological Mentor was mostly Athena in disguise** -- the
+  actual Mentor, the human, is a relatively passive character in the
+  *Odyssey*. The wise guidance that Telemachus received came from
+  Athena wearing Mentor's face. The modern concept of mentorship is
+  therefore built on a misreading: it attributes to a human
+  relationship what was actually divine intervention. This is not
+  a minor detail -- it means the archetype of "the mentor" was never
+  a real mentoring relationship but a god impersonating one.
+- **The divine mentor had perfect knowledge; human mentors do not** --
+  Athena-as-Mentor knew the future, understood the gods' plans, and
+  could manipulate events. Real mentors operate with incomplete
+  information, personal biases, and outdated experience. The dead
+  metaphor's invisible divine source may contribute to the
+  idealization of mentors -- the unspoken assumption that a good
+  mentor will simply know the right path.
+- **Mentorship programs try to systematize what was personal** --
+  Odysseus chose Mentor from deep personal trust. Corporate mentorship
+  programs assign mentors algorithmically or by HR matching.
+  The word carries expectations of personal connection that
+  institutional programs cannot reliably deliver, creating a gap
+  between the mentorship ideal and its bureaucratic implementation.
+- **The metaphor assumes the mentee wants guidance** -- Telemachus
+  actively sought help. Modern "mentees" are sometimes assigned
+  mentors they did not request, creating relationships that are
+  mentorship in name only. The dead metaphor cannot distinguish
+  between sought and imposed guidance, which is a critical difference
+  in practice.
+- **The mentor's own development is invisible** -- the Mentor
+  archetype is a finished product: wise, stable, ready to give.
+  Real mentors are still learning, still making mistakes, still
+  developing. The dead metaphor freezes the mentor in a posture of
+  completed wisdom, which can discourage potential mentors who feel
+  they are not yet "ready" and can blind mentees to their mentor's
+  limitations.
+- **"Mentee" is a back-formation that reveals the metaphor's death**
+  -- Homer never used a word for "person being mentored." "Mentee"
+  was coined in the 20th century by analogy with "employee" (from
+  French "-e"), treating "mentor" as if it contained an agentive
+  suffix rather than being a proper noun. The word's morphology has
+  been reanalyzed to fit a pattern the original never had.
+
+## Expressions
+
+- "She's my mentor" -- no mythological awareness; means trusted
+  professional guide
+- "Mentorship program" -- institutional framework for what the myth
+  presented as a personal bond
+- "Mentee" -- the back-formation, treating the proper noun as if it
+  were a root with an agent suffix
+- "Mentor/mentee relationship" -- standard HR and academic terminology
+- "To mentor someone" -- the noun fully verbified, no trace of Homer
+- "Reverse mentoring" -- a modern inversion where junior employees
+  mentor senior ones; structurally impossible in the Homeric original
+
+## Origin Story
+
+Mentor appears in Homer's *Odyssey* (c. 8th century BCE), Books II and
+III. Fenelon's *Les Aventures de Telemaque* (1699) recast Mentor as
+the central guiding figure and elevated the name into a byword for wise
+counsel in French and English. By the mid-18th century, "mentor" was
+used as a common noun in English. The modern mentorship movement in
+business and education traces to the 1970s, when developmental
+psychologists (Levinson, Kram) formalized the concept. Kathy Kram's
+*Mentoring at Work* (1985) established the academic framework for
+organizational mentorship, completing the word's journey from Homeric
+proper noun to HR terminology.
+
+## References
+
+- Homer. *Odyssey*, Books II-III -- Mentor and Athena-as-Mentor
+- Fenelon, F. *Les Aventures de Telemaque* (1699) -- the text that
+  popularized "mentor" as a common noun
+- Levinson, D. J. *The Seasons of a Man's Life* (1978) -- developmental
+  psychology of mentoring
+- Kram, K. E. *Mentoring at Work* (1985) -- foundational academic
+  framework for organizational mentorship


### PR DESCRIPTION
## Summary
- Adds `mentor` dead-metaphor mapping (mythology -> authority-and-mentorship)
- Homeric proper noun became universal common noun for trusted guide
- Closes #1091

## Validator output
All content valid (0 errors, 0 new warnings).

## Test plan
- [x] `uv run scripts/validate.py validate` passes

Generated with [Claude Code](https://claude.com/claude-code)