### PR TITLE
Add mapping: holy-grail

### DIFF
--- a/catalog/mappings/holy-grail.md
+++ b/catalog/mappings/holy-grail.md
@@ -1,0 +1,145 @@
+---
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- cognitive-science
+contributors:
+- fshot
+harness: Claude Code
+kind: dead-metaphor
+name: Holy Grail
+related:
+- world-tree
+slug: holy-grail
+source_frame: mythology
+target_frame: intellectual-inquiry
+---
+
+## What It Brings
+
+The Holy Grail -- the cup used by Christ at the Last Supper, sought
+by the Knights of the Round Table across an entire literary tradition.
+In modern usage, "the holy grail of X" has shed its Arthurian and
+Christian origins almost completely. Most speakers who call something
+"the holy grail" could not name a single Grail knight. What the dead
+metaphor preserves is a precise structure of aspiration: the goal so
+important that the quest for it defines the identity of the seeker,
+even though -- especially though -- it may never be found.
+
+The mapping carries several structural features:
+
+- **The goal defines the field** -- the Grail quest gave the Knights
+  of the Round Table their purpose. Without it, they were just armed
+  aristocrats. "The holy grail of physics" (a unified field theory),
+  "the holy grail of medicine" (a cure for cancer), "the holy grail
+  of AI" (artificial general intelligence) -- in each case, the
+  metaphor says this is not merely a research problem but the problem
+  that gives the entire field its animating purpose. Solve this and
+  you have completed the quest the field was created to undertake.
+- **Unattainability is a feature, not a bug** -- only Galahad achieved
+  the Grail, and he immediately ascended to heaven, leaving the mortal
+  world behind. The metaphor imports the structural insight that the
+  ultimate goal may be approachable but not reachable by ordinary
+  means. "The holy grail of X" often describes something that has
+  resisted all attempts, and whose resistance is part of what makes
+  it compelling. If it were easy, it would not be the Grail.
+- **The quest transforms the seeker** -- the Grail quest in Arthurian
+  literature is not really about the cup. It is about what the knights
+  become through seeking. The metaphor maps this onto research: the
+  value of pursuing the holy grail of a field lies partly in the
+  discoveries made along the way, the techniques developed, the
+  understanding gained. The destination may be unreachable, but the
+  journey is productive.
+- **Purity of purpose** -- in the Grail romances, only the pure of
+  heart can find the Grail. Lancelot, the greatest knight, fails
+  because of his moral impurity. The metaphor imports a notion that
+  the ultimate goal requires not just skill but the right kind of
+  motivation. Commercial motives, ego, shortcuts -- these are the
+  moral failings that the metaphor says will prevent you from
+  reaching the Grail.
+
+## Where It Breaks
+
+- **The metaphor discourages pragmatism** -- by framing the ultimate
+  goal as a holy object, the metaphor implies that anything less than
+  the complete solution is unworthy. But most progress in science and
+  engineering comes from solving pieces of the problem, not the whole
+  thing at once. Calling AGI "the holy grail of AI" subtly devalues
+  every practical AI system that falls short of general intelligence.
+  The Grail metaphor has no room for "good enough."
+- **It smuggles in a single-winner narrative** -- only one knight
+  finds the Grail. The metaphor implies that the holy grail of a field
+  will be found by one researcher, one team, one company. But most
+  major scientific advances are convergent: multiple groups approaching
+  the same insight from different directions. The metaphor's narrative
+  structure (one hero, one quest, one achievement) distorts how
+  discovery actually works.
+- **Purity requirements are gatekeeping** -- the Grail romances' moral
+  purity test maps onto real exclusionary dynamics: the idea that only
+  certain kinds of people, with certain kinds of motivation, deserve
+  to make the breakthrough. This has been used, consciously and
+  unconsciously, to exclude commercial researchers, applied scientists,
+  and anyone whose motives are deemed insufficiently pure.
+- **The metaphor romanticizes futility** -- "the holy grail" can
+  become an excuse for not delivering results. If the goal is
+  understood as noble-but-unattainable, then indefinite failure is
+  reframed as heroic persistence. The metaphor provides cover for
+  research programs that consume resources without producing outcomes,
+  as long as the goal sounds sufficiently grand.
+- **The sacred framing is inappropriately grandiose** -- calling a
+  technical goal a "holy grail" borrows the emotional weight of
+  religious devotion for secular purposes. The phrase has become so
+  common that this dissonance is invisible, but it is still doing
+  work: it elevates engineering problems to spiritual quests, which
+  inflates their importance in ways that resist critical examination.
+
+## Expressions
+
+- "The holy grail of battery technology" -- a battery with extreme
+  energy density, fast charging, and long life, sought by every
+  materials science lab
+- "AGI is the holy grail of artificial intelligence" -- the most
+  common contemporary usage, framing general intelligence as the
+  quest that defines the field
+- "We found the holy grail" -- announcing a major breakthrough,
+  always slightly hyperbolic, always implying that a long quest has
+  ended
+- "Still searching for the holy grail" -- acknowledging that a
+  fundamental problem remains unsolved, with no shame because the
+  Grail metaphor makes unsolved-ness noble
+- "The holy grail of customer acquisition" -- marketing usage,
+  demonstrating how far the metaphor has traveled from Arthurian
+  romance and into utterly mundane commercial contexts
+
+## Origin Story
+
+The Holy Grail first appears in Chretien de Troyes's unfinished
+romance *Perceval, the Story of the Grail* (c. 1190), where it is
+a mysterious serving dish in a procession. Robert de Boron's
+*Joseph d'Arimathie* (c. 1200) transformed it into the cup of the
+Last Supper, connecting it to Christian salvation history. The Vulgate
+Cycle (c. 1215-1235) established the quest narrative that persists:
+the knights of the Round Table dispersing to seek the Grail, most
+failing, only the purest succeeding.
+
+The metaphorical usage -- "the holy grail of X" -- appears to have
+become common in English by the mid-20th century, accelerating as
+the phrase entered scientific and technical discourse. By the 1990s,
+it was a standard journalistic formula for framing any important
+unsolved problem. The Arthurian source is now so distant from common
+usage that the phrase functions as a fixed idiom rather than a live
+metaphor. Most speakers parse "holy grail" as a single lexical unit
+meaning "ultimate goal," with no awareness of cups, knights, or
+medieval romance.
+
+## References
+
+- Chretien de Troyes, *Perceval, the Story of the Grail* (c. 1190)
+  -- the first literary appearance of the Grail
+- Loomis, R.S. *The Grail: From Celtic Myth to Christian Symbol*
+  (1963) -- tracing the Grail's pre-Christian origins
+- Barber, R. *The Holy Grail: Imagination and Belief* (2004) --
+  comprehensive history of the Grail in literature and culture
+- Lakoff, G. & Turner, M. *More Than Cool Reason* (1989) -- on
+  how conventional metaphors like "holy grail" become invisible
+  through repeated use


### PR DESCRIPTION
## Summary
- Adds mapping for Holy Grail as `dead-metaphor` (Arthurian quest -> ultimate research goal)
- Source: `mythology`, Target: `intellectual-inquiry` (corrected from prospector's `journeys`)
- Resolves #1096

## Validator output
All content valid. One warning for related mapping in separate PR.

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [ ] Review mapping body sections for accuracy and depth

Generated with [Claude Code](https://claude.com/claude-code)