### PR TITLE
Add mapping: excalibur

### DIFF
--- a/catalog/mappings/excalibur.md
+++ b/catalog/mappings/excalibur.md
@@ -1,0 +1,96 @@
+---
+slug: excalibur
+name: "Excalibur"
+kind: conceptual-metaphor
+source_frame: mythology
+target_frame: social-behavior
+categories:
+  - mythology-and-religion
+author: agent:metaphorex-miner
+contributors: []
+related: []
+---
+
+## What It Brings
+
+In Arthurian legend, the sword Excalibur (or the sword in the stone, which
+some traditions treat as a separate weapon) can only be drawn by the
+rightful king. The artifact does not merely belong to the worthy -- it
+reveals who the worthy person is. The structural insight: legitimacy is not
+conferred by argument or election but by a test that only one person can
+pass.
+
+- **The tool selects the wielder** -- normally, people choose their tools.
+  Excalibur inverts this: the tool chooses its user. In organizational and
+  technical contexts, "finding your Excalibur" means discovering the role,
+  project, or challenge that fits your capabilities so precisely that your
+  suitability becomes self-evident. A programmer who can untangle the
+  legacy codebase nobody else can read has found their Excalibur -- the
+  task that proves their indispensability.
+- **Legitimacy through demonstration, not credential** -- Arthur does not
+  become king because of his bloodline (which is unknown at the time) or
+  because a council selects him. He becomes king because he pulls the
+  sword when nobody else can. The metaphor maps onto meritocratic ideals:
+  the person who can do the thing that nobody else can do has an
+  unchallengeable claim, regardless of background or formal qualification.
+- **The artifact as proof of fitness** -- Excalibur is both the test and
+  the reward. Pulling the sword is the qualification for kingship, and
+  the sword itself becomes the instrument of rule. In business, a
+  founder's early product is often their Excalibur -- the thing that
+  simultaneously proves they can build and gives them the tool to compete.
+
+## Where It Breaks
+
+- **The test is binary; real competence is not** -- Excalibur either comes
+  out of the stone or it does not. There is no partial extraction, no
+  "almost worthy." Real-world fitness for leadership or responsibility is
+  a matter of degree, context, and growth over time. The metaphor
+  encourages a dangerous binary: either you are the chosen one or you are
+  nobody. It has no room for the competent-but-not-singular.
+- **Legitimacy-by-artifact concentrates power dangerously** -- the Excalibur
+  model implies that exactly one person is rightful. This maps poorly onto
+  collaborative environments where distributed competence is the norm and
+  "the one true leader" is a dysfunction, not an ideal. Startups that
+  organize around a single visionary (the one who pulled the sword) often
+  struggle when the founder's singular fitness turns into a single point
+  of failure.
+- **The metaphor erases the work of becoming ready** -- in most versions
+  of the legend, Arthur pulls the sword effortlessly. There is no training
+  montage, no gradual skill-building. The metaphor can therefore be used
+  to naturalize talent and dismiss effort: "either you have it or you
+  don't." This is the opposite of what most skill-development research
+  shows -- that readiness is constructed, not revealed.
+- **Once pulled, the sword cannot be put back** -- the Excalibur moment is
+  irreversible. In organizations, legitimacy is constantly re-earned.
+  Markets shift, technologies change, and the person who pulled the sword
+  five years ago may no longer be the right leader today. The metaphor
+  provides no vocabulary for graceful succession or evolving fitness.
+
+## Expressions
+
+- "That project was her Excalibur" -- the challenge that proved someone's
+  exceptional fitness for a role
+- "Pulling the sword from the stone" -- demonstrating legitimacy through a
+  feat that nobody else can replicate
+- "Excalibur product" -- informal startup jargon for a product that both
+  proves the founder's vision and becomes the company's primary weapon
+- "Waiting for Excalibur" -- deferring action until the perfect tool,
+  opportunity, or proof of legitimacy appears
+- "Nobody else could pull it out" -- justifying a monopoly of authority by
+  pointing to a singular demonstration of capability
+
+## Origin Story
+
+The sword-in-the-stone motif first appears in Robert de Boron's *Merlin*
+(c. 1200), though the name Excalibur (from Welsh *Caledfwlch*, possibly
+via Latin *Caliburnus*) traces to Geoffrey of Monmouth's *Historia Regum
+Britanniae* (c. 1136). In Geoffrey's version, the sword is simply Arthur's
+weapon; the test of pulling it from an anvil set in stone is a later
+addition.
+
+The metaphorical use in English -- an object or challenge that reveals the
+true leader -- appears informally in the 20th century and gained traction
+in business and technology writing in the 2000s. Unlike "Holy Grail" (which
+became a dead metaphor for any ultimate goal), "Excalibur" retains its
+mythological resonance: people who use it generally know they are invoking
+King Arthur.


### PR DESCRIPTION
## Summary

- Adds `excalibur` mapping: Arthurian metaphor for legitimacy revealed through demonstration -- the tool that selects its wielder
- Source frame: mythology, Target frame: social-behavior
- Kind: conceptual-metaphor (source domain remains recognizable in usage)
- All required frames already exist in catalog

Closes #1097

## Validator output

```
All content valid.
```

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)