### PR TITLE
Add mapping: koan

### DIFF
--- a/catalog/mappings/koan.md
+++ b/catalog/mappings/koan.md
@@ -1,0 +1,126 @@
+---
+slug: koan
+name: "Koan"
+kind: archetype
+source_frame: mythology
+target_frame: mental-experience
+categories:
+  - mythology-and-religion
+  - philosophy
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - labyrinth
+  - holy-grail
+---
+
+## What It Brings
+
+A koan is a paradoxical statement or question used in Zen Buddhist practice
+to provoke insight by exhausting the rational mind. "What is the sound of
+one hand clapping?" is not a riddle with a clever answer -- it is a device
+for breaking the habit of treating all questions as problems with solutions.
+When speakers outside Zen call something "a koan," they import this specific
+structure: a question that resists logical resolution but produces
+understanding through the act of wrestling with it.
+
+Key structural parallels:
+
+- **The productive impasse** -- a koan works by generating a mental state
+  where ordinary reasoning stalls. In software design, architecture, and
+  management, "koan" labels problems that cannot be resolved by applying
+  existing frameworks but whose contemplation reveals something about the
+  frameworks themselves. "How do you build a system that is both fully
+  consistent and fully available?" is a distributed systems koan (the
+  CAP theorem), and its value lies not in the answer but in what the
+  impossibility teaches you about your assumptions.
+- **The master-student relationship** -- koans are assigned by a teacher
+  who already understands what the student will discover. The metaphor
+  carries this asymmetry: calling something "a koan" implies that someone
+  further along knows why the question matters, even if the person
+  struggling with it does not yet see. This creates a pedagogical frame
+  around what might otherwise be dismissed as a contradiction or a bug.
+- **Insight as discontinuity** -- the Zen tradition holds that koan
+  practice produces satori, a sudden flash of understanding that is
+  qualitatively different from incremental reasoning. The metaphor
+  imports this expectation: the answer, when it comes, will not be a
+  logical next step but a reframing of the entire question. This is why
+  "koan" feels right for paradigm shifts and why it feels wrong for
+  problems that yield to patient analysis.
+- **The answer cannot be communicated** -- in Zen, demonstrating
+  understanding of a koan requires a response that the master
+  recognizes, not a propositional statement. The metaphor preserves
+  this incommunicability: the insight gained from a koan-like problem
+  is often difficult to transfer to someone who has not themselves
+  struggled with it.
+
+## Where It Breaks
+
+- **Most things called "koans" are just hard problems.** The term gets
+  applied loosely to any question that is difficult or counterintuitive,
+  but a genuine koan is not merely difficult -- it is structurally
+  designed to defeat logical reasoning. A hard engineering problem that
+  yields to better data, more compute, or a cleverer algorithm is not a
+  koan; it is a problem. The metaphor flatters ordinary difficulty by
+  dressing it in spiritual clothing.
+- **Koans have no practical urgency; real problems do.** A Zen student
+  can sit with a koan for years. A software architect facing a design
+  contradiction has a deadline. The metaphor imports a contemplative
+  temporal frame that is incompatible with the urgency of most contexts
+  where it gets used. Calling a production outage "a koan" does not
+  make patience a virtue -- it makes inaction sound wise.
+- **The authority structure is absent.** Zen koans function within a
+  lineage where the master's judgment is authoritative. In secular
+  usage, there is no master -- just people who find a question
+  interesting. Without the authority structure, "koan" becomes a way
+  of saying "I don't know the answer and I'm choosing to frame that
+  ignorance as depth." The metaphor can disguise intellectual laziness
+  as spiritual sophistication.
+- **Cultural flattening.** Using "koan" as a generic label for
+  paradoxes strips the term of its specific Zen Buddhist context --
+  the meditation practice, the student-master relationship, the
+  tradition of recorded koan collections (the Mumonkan, the Blue Cliff
+  Record). What remains is a vague gesture toward Eastern mysticism,
+  which can function as orientalism dressed up as intellectual humility.
+
+## Expressions
+
+- "That's a real koan" -- a problem whose value lies in the
+  contemplation rather than the solution, used in design and
+  engineering discussions
+- "Unix koans" -- a genre of programming humor (the Rootless Root,
+  the Jargon File) that casts system administration wisdom in
+  master-student dialogue form
+- "A management koan" -- a leadership dilemma with no clean resolution,
+  used in business writing
+- "Design koan" -- an architectural question that reveals fundamental
+  trade-offs when you sit with it long enough
+- "The koan of testing" -- informal expression for the paradox that
+  you cannot fully test software without knowing all possible inputs,
+  but you cannot know all possible inputs without already understanding
+  the software
+
+## Origin Story
+
+Koans originated in Chinese Chan Buddhism (gong'an, literally "public
+case") as records of exchanges between masters and students. They were
+systematized in Song Dynasty collections, most famously the Wumenguan
+(Gateless Gate, 1228) and the Biyan Lu (Blue Cliff Record, ca. 1125).
+Japanese Zen adopted and formalized the practice, and it entered English
+through D.T. Suzuki's influential mid-twentieth-century translations.
+
+The word entered technical and business English primarily through the
+hacker culture of the 1970s and 1980s. The Jargon File included
+"AI koans" -- short dialogues between a master and a student about
+computing. The format proved durable because it captured something
+real about programming: that certain insights about system design
+cannot be taught propositionally but must be discovered through
+confrontation with a carefully chosen problem.
+
+## References
+
+- Aitken, R. *The Gateless Barrier: The Wu-men Kuan* (1991)
+- Cleary, T. and Cleary, J. C. *The Blue Cliff Record* (1977)
+- Raymond, E. S. *The Jargon File* (various editions) -- "AI Koans"
+- *The Rootless Root: Unix Koans of Master Foo* -- hacker folklore
+  applying koan structure to system administration wisdom


### PR DESCRIPTION
## Summary
- Adds `koan` mapping as archetype (Zen paradox pattern recurs across engineering, design, management, pedagogy)
- source_frame: mythology, target_frame: mental-experience
- All required frames already exist

Closes #1102

## Validator output
All content valid. No new warnings introduced.

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [x] Required body sections present (What It Brings, Where It Breaks, Expressions)
- [x] Frames exist for source and target

Generated with Claude Code