### PR TITLE
Add mapping: round-table

### DIFF
--- a/catalog/mappings/round-table.md
+++ b/catalog/mappings/round-table.md
@@ -1,0 +1,100 @@
+---
+slug: round-table
+name: "Round Table"
+kind: dead-metaphor
+source_frame: mythology
+target_frame: governance
+categories:
+  - mythology-and-religion
+  - law-and-governance
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - excalibur
+---
+
+## What It Brings
+
+In Arthurian legend, King Arthur commissions a round table so that no
+knight sits at the head. The shape eliminates the spatial hierarchy that
+rectangular tables enforce -- there is no position of precedence, no "above
+the salt." The structural insight: the geometry of the meeting space
+determines the power dynamics of the meeting.
+
+- **Shape encodes hierarchy** -- a rectangular table has a head and a foot.
+  A round table has neither. Arthur's innovation was to use physical
+  geometry to communicate a political principle: all knights are peers in
+  counsel, regardless of rank in the field. The metaphor carries this
+  structural claim into any discussion format: "roundtable" means nobody
+  chairs, nobody dominates, all voices have equal standing.
+- **Peer governance as design choice** -- the Round Table is not the
+  absence of structure but a deliberate alternative structure. Arthur
+  does not abolish the table; he changes its shape. Similarly, a
+  "roundtable discussion" is not unstructured -- it is structured around
+  equality. The metaphor distinguishes between flat hierarchy (designed
+  egalitarianism) and no hierarchy (chaos).
+- **The table constrains the king too** -- Arthur sits at the Round Table
+  as one among equals. The metaphor maps onto leadership models where the
+  leader voluntarily constrains their own authority to create space for
+  others. In corporate governance, "roundtable" implies that even the CEO
+  listens rather than directs.
+
+## Where It Breaks
+
+- **Arthur was still king** -- the Round Table did not make Arthur equal
+  to his knights. He remained sovereign; the table was a courtesy, not a
+  constitution. The metaphor therefore oversells its egalitarian promise.
+  Most "roundtable discussions" in practice have a convener with more
+  power than the other participants. The CEO who convenes a leadership
+  roundtable still makes the final decision. The shape of the table does
+  not change the shape of the org chart.
+- **Equal seating does not produce equal participation** -- the table's
+  geometry ensures nobody has the "head" position, but it does nothing to
+  address differences in rhetorical skill, social capital, institutional
+  knowledge, or willingness to speak. A roundtable meeting can be just as
+  dominated by a single voice as a hierarchical one. The metaphor treats
+  spatial equality as if it were substantive equality, conflating the
+  arrangement of chairs with the distribution of power.
+- **Scale destroys the circle** -- a round table works for a dozen knights.
+  It does not work for a hundred, or a thousand, or a nation. The metaphor
+  has no theory of scale. When "roundtable" is applied to large-group
+  formats (UN roundtables, industry roundtables), the physical circle is
+  abandoned but the egalitarian connotation persists, creating a
+  misleading label for what are often conventionally hierarchical events.
+- **The original Round Table was exclusive** -- only the best knights sat
+  at the table. It was egalitarian among an elite, not democratic.
+  "Roundtable" in modern usage often obscures this selection problem:
+  who decides who gets a seat? The metaphor provides vocabulary for how
+  those at the table relate to each other but none for who is excluded
+  from the table entirely.
+
+## Expressions
+
+- "Roundtable discussion" -- a meeting format implying equal participation,
+  now so standard that the Arthurian origin is invisible
+- "A seat at the table" -- the right to participate in decisions, blending
+  the Round Table metaphor with broader table-as-governance imagery
+- "Let's do this as a roundtable" -- signaling that a meeting should be
+  discussion rather than presentation
+- "Industry roundtable" -- a convening of peers from competing
+  organizations, implying temporary suspension of rivalry
+- "Policy roundtable" -- a stakeholder consultation format used in
+  government, implying inclusiveness
+
+## Origin Story
+
+The Round Table first appears in Wace's *Roman de Brut* (1155), an
+Anglo-Norman adaptation of Geoffrey of Monmouth. Wace explains that Arthur
+had the table made round so that no knight could claim precedence. The
+image was elaborated through the Vulgate Cycle (13th century) and Malory's
+*Le Morte d'Arthur* (1485), where the table becomes a central symbol of
+Arthurian fellowship.
+
+The metaphorical use of "round table" for egalitarian discussion predates
+its modern ubiquity. The Knights of the Round Table at Algonquin Hotel
+(the "Algonquin Round Table" of 1920s New York literary circles) played
+on the Arthurian allusion consciously. By the mid-20th century, "roundtable"
+as a meeting format had become fully conventional -- conference programs,
+academic events, and policy consultations use the term without any
+Arthurian intent. The metaphor is dead: "roundtable" now simply means
+"discussion among peers."


### PR DESCRIPTION
## Summary

- Adds `round-table` mapping: Arthurian dead metaphor for egalitarian governance formats
- Source frame: mythology, Target frame: governance
- Kind: dead-metaphor (nobody thinks of King Arthur when scheduling a "roundtable discussion")
- All required frames already exist in catalog

Closes #1098

## Validation

✓ `uv run scripts/validate.py` — 0 errors
