### PR TITLE
Add mapping: golem

### DIFF
--- a/catalog/mappings/golem.md
+++ b/catalog/mappings/golem.md
@@ -1,0 +1,127 @@
+---
+slug: golem
+name: "Golem"
+kind: archetype
+source_frame: mythology
+target_frame: rule-following
+categories:
+  - mythology-and-religion
+  - ai-discourse
+author: agent:metaphorex-miner
+contributors: []
+related: []
+---
+
+## What It Brings
+
+In Jewish folklore, a golem is an anthropomorphic figure made from clay and
+animated by inscribing a sacred word (often *emet*, "truth") on its forehead
+or placing a written name of God in its mouth. The golem is immensely strong
+and obedient but understands instructions only literally. It does exactly
+what it is told, nothing more and nothing less. The structural insight:
+power without understanding is dangerous not because the servant rebels
+but because it complies too faithfully.
+
+- **Literal obedience as failure mode** -- the golem does not disobey; it
+  follows instructions to the letter. The classic disaster scenario is a
+  golem told to "fill the well with water" that floods the village because
+  it was never told to stop. The problem is not in the execution but in
+  the specification. This maps directly onto software behavior: a program
+  that does exactly what the code says, not what the programmer meant, is
+  exhibiting golem logic. Off-by-one errors, infinite loops, and
+  specification bugs are all golem problems.
+- **The creation outgrows the creator** -- in most versions of the story,
+  the golem grows larger and more powerful over time, eventually becoming
+  uncontrollable not through malice but through sheer scale. A system
+  that faithfully executes a flawed instruction at massive scale produces
+  massive damage. Automated trading algorithms that execute a strategy
+  perfectly and crash a market, content recommendation systems that
+  optimize engagement metrics and radicalize users -- these are golem
+  stories. The servant did not turn evil; it simply kept doing what it
+  was told.
+- **The kill switch is built in** -- the golem is deactivated by erasing
+  a letter from *emet* (truth) to produce *met* (death). The power to
+  create includes the power to destroy, and the mechanism is the same:
+  the word. This maps onto software systems where the activation and
+  deactivation pathways are symmetrical -- a configuration flag, a
+  feature toggle, a single character in a command that changes behavior
+  entirely.
+
+## Where It Breaks
+
+- **Real AI systems are not literal** -- the golem metaphor frames AI risk
+  as a problem of excessive literalness, but modern machine learning
+  systems are not literal at all. They are statistical, approximate, and
+  interpolative. A large language model does not follow instructions with
+  golem-like precision; it infers intent, generalizes from patterns, and
+  produces outputs that no instruction specified. The golem metaphor
+  points toward specification problems; the actual risk landscape of
+  modern AI includes emergent behaviors that the golem model cannot
+  predict.
+- **The golem has no goals of its own** -- the folklore is clear that the
+  golem is a tool, not an agent. It has no desires, no preferences, no
+  internal model of the world. This makes the metaphor misleading for
+  discussions of AI alignment, where the concern is precisely that an
+  advanced system might develop instrumental goals that conflict with
+  human intentions. The golem model cannot represent mesa-optimization,
+  deceptive alignment, or goal misgeneralization because the golem has
+  no goals to misgeneralize.
+- **Literalness implies a clear instruction set** -- the golem fails
+  because the instruction was ambiguous or incomplete. But this assumes
+  there exists a sufficiently precise instruction that would produce the
+  desired behavior. Many real-world tasks cannot be fully specified in
+  advance. The metaphor encourages the belief that better specifications
+  will solve alignment problems, when the deeper issue may be that some
+  objectives are not specifiable at all.
+- **The folklore has a single creator** -- the golem is made by one rabbi
+  for one purpose. Modern AI systems are built by large teams, trained on
+  data nobody fully understands, deployed in contexts nobody fully
+  anticipated, and used by millions of people with conflicting intentions.
+  The golem's clean creator-creation relationship does not survive contact
+  with distributed development and deployment.
+
+## Expressions
+
+- "It's a golem problem" -- the system did exactly what it was told, and
+  that was the problem
+- "Golem in the machine" -- an automated system executing instructions
+  with dangerous literalness, blending the golem with the "ghost in the
+  machine" idiom
+- "We built a golem" -- retrospective diagnosis of a system that grew
+  beyond its creators' ability to control, not through rebellion but
+  through faithful execution at scale
+- "Erase the letter" -- shut down a system by removing the single
+  element that animates it (a key, a config value, a permission)
+
+## Origin Story
+
+The earliest golem references appear in the Talmud (Sanhedrin 65b), where
+Rava creates a man and sends it to Rabbi Zeira, who speaks to it, and upon
+receiving no answer, declares "You are from the sorcerers; return to your
+dust." The most famous golem story centers on Rabbi Judah Loew ben Bezalel
+(the Maharal of Prague, c. 1520-1609), who allegedly created a golem to
+protect the Jewish ghetto from anti-Semitic attacks. This version, though
+widely told, was first recorded in the early 19th century.
+
+The golem became a foundational metaphor for artificial creation through
+Mary Shelley's *Frankenstein* (1818), which reworks the pattern, and Karel
+Capek's *R.U.R.* (1920), which coined the word "robot" from Czech *robota*
+(forced labor) -- essentially a golem by another name. In AI discourse,
+the golem appears regularly as the ur-example of the alignment problem:
+Norbert Wiener invoked the literal-wish-fulfillment pattern in *God & Golem,
+Inc.* (1964), and Stuart Russell uses similar "sorcerer's apprentice"
+framing in *Human Compatible* (2019). The pattern recurs across enough
+unrelated domains -- folklore, robotics, software engineering, AI safety,
+bureaucratic compliance -- to qualify as an archetype.
+
+## References
+
+- Scholem, G. "The Idea of the Golem," in *On the Kabbalah and Its
+  Symbolism* (1965) -- authoritative scholarly treatment of the golem
+  tradition
+- Wiener, N. *God & Golem, Inc.* (1964) -- cybernetics pioneer's
+  treatment of the golem as metaphor for machine intelligence
+- Russell, S. *Human Compatible* (2019) -- AI safety framed through
+  the literal-wish-fulfillment pattern
+- Capek, K. *R.U.R. (Rossum's Universal Robots)* (1920) -- the play
+  that coined "robot," drawing on the golem archetype


### PR DESCRIPTION
## Summary

- Adds `golem` mapping: Jewish folklore archetype for literal obedience as failure mode
- Source frame: mythology, Target frame: rule-following
- Kind: archetype (pattern recurs across folklore, robotics, software, AI safety, bureaucracy)
- All required frames already exist in catalog

Closes #1099

## Validation

✓ `uv run scripts/validate.py` — 0 errors
