### PR TITLE
Add mapping: emperor-new-clothes

### DIFF
--- a/catalog/frames/social-control.md
+++ b/catalog/frames/social-control.md
@@ -1,0 +1,24 @@
+---
+slug: social-control
+name: "Social Control"
+related:
+  - governance
+  - social-behavior
+roles:
+  - authority
+  - conformity
+  - dissent
+  - surveillance
+  - norm
+  - sanction
+  - compliance
+  - resistance
+---
+
+The mechanisms by which groups enforce behavioral norms, maintain collective
+beliefs, and suppress deviation. Social control operates through formal
+structures (laws, institutions, punishment) and informal ones (shame,
+ostracism, peer pressure). As a target domain it captures situations where
+individual judgment is overridden by group dynamics, where speaking truth
+carries social cost, and where authority depends on collective acquiescence
+rather than on force alone.

--- a/catalog/mappings/emperor-new-clothes.md
+++ b/catalog/mappings/emperor-new-clothes.md
@@ -1,0 +1,125 @@
+---
+slug: emperor-new-clothes
+name: "Emperor's New Clothes"
+kind: archetype
+source_frame: mythology
+target_frame: social-control
+categories:
+  - mythology-and-religion
+  - social-dynamics
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - cassandra
+  - big-brother-is-surveillance
+---
+
+## What It Brings
+
+In Andersen's 1837 tale, two swindlers convince an emperor that they have
+woven him a magnificent suit visible only to the wise and competent. The
+entire court praises the nonexistent garment because admitting they see
+nothing would mark them as fools. Only a child, unburdened by social
+stakes, states the obvious: the emperor is naked. When someone invokes
+"the emperor's new clothes," they import this entire social machinery --
+not just the lie but the structure that sustains it.
+
+Key structural parallels:
+
+- **The self-enforcing delusion** -- the swindlers' genius is not the
+  lie itself but the mechanism they attach to it: anyone who cannot see
+  the clothes is unfit for their position. This transforms a simple
+  fraud into a loyalty test. In organizations, the equivalent is any
+  initiative where questioning it signals disloyalty, incompetence, or
+  insufficient vision. "If you don't see the value of this strategy,
+  maybe you're not strategic enough to be here."
+- **Cascading conformity** -- each courtier who praises the clothes
+  makes it harder for the next one to dissent. The cost of truth-telling
+  rises with each person who has already committed to the fiction. This
+  maps precisely onto groupthink in corporate strategy, academic
+  consensus, and political movements: the later you speak, the more
+  people you implicitly accuse of being fools or liars.
+- **The child as structural outsider** -- the truth-teller in the tale
+  is someone with nothing to lose. The child has no position, no
+  reputation, no investment in the court hierarchy. The archetype
+  predicts that dissent in organizations will come from outsiders,
+  newcomers, or people about to leave -- those whose social capital
+  is not at stake.
+- **The emperor's complicity** -- the emperor himself suspects the
+  truth but proceeds with the procession. He is not merely deceived;
+  he is a participant in his own deception. The archetype captures
+  cases where leaders are not innocent victims of bad advice but
+  active collaborators in maintaining fictions that serve their
+  status.
+
+## Where It Breaks
+
+- **The tale assumes a single, obvious truth.** The emperor is naked --
+  this is a binary, verifiable fact. Most real-world "emperor's new
+  clothes" situations involve genuine ambiguity. Is a corporate strategy
+  visionary or delusional? Is a new technology transformative or overhyped?
+  The archetype smuggles in the assumption that there is a naked emperor
+  to be seen, when often the dispute is about interpretation, not
+  perception. Invoking the metaphor lets the dissenter claim the moral
+  authority of the child while skipping the burden of proof.
+- **Dissent is not always correct.** The archetype privileges the
+  contrarian: if everyone agrees and you disagree, you must be the
+  child who sees the truth. But scientific consensus, engineering best
+  practices, and institutional knowledge exist for reasons. The
+  archetype provides no way to distinguish between courageous
+  truth-telling and ignorant contrarianism. Every crank who rejects
+  evolution or climate science casts themselves as the child in this
+  story.
+- **The swindlers are external.** In the tale, the delusion is
+  introduced by outsiders with fraudulent intent. In most real
+  organizations, collective delusions emerge endogenously -- through
+  optimism bias, sunk cost effects, and incremental commitment. There
+  are no swindlers to unmask, which makes the archetype's implied
+  solution (identify the fraud, expose it) inapplicable.
+- **The aftermath is missing.** The tale ends with the procession.
+  It does not address what happens next: does the emperor punish the
+  child? Fire the courtiers? Reform the court? The archetype is
+  useful for diagnosing the problem but silent on what follows
+  exposure. In practice, the person who points out the emperor's
+  nakedness is often punished -- the archetype's feel-good ending
+  obscures this reality.
+
+## Expressions
+
+- "The emperor has no clothes" -- direct invocation to call out a
+  collective delusion, used in politics, business, and technology
+  criticism
+- "Who will be the child?" -- asking who in a group has the standing
+  or courage to state an obvious but unspeakable truth
+- "Drinking the Kool-Aid" -- a darker American variant of the same
+  conformity dynamic, though with different source material
+- "The elephant in the room" -- related idiom for an obvious truth
+  that everyone avoids mentioning, though without the fairy tale's
+  specific mechanism of status-linked self-censorship
+- "Saying the quiet part out loud" -- contemporary expression for
+  breaking the collective agreement to maintain a fiction
+
+## Origin Story
+
+Hans Christian Andersen published "Kejserens nye Klaeder" in 1837,
+drawing on a medieval Spanish source -- a tale in Don Juan Manuel's
+*El Conde Lucanor* (1335), where the cloth is invisible not to fools
+but to those of impure blood (conversos, in the context of
+Reconquista Spain). Andersen replaced the blood-purity test with a
+competence test, which made the story more universally applicable
+but also less politically specific.
+
+The tale entered management and organizational theory through
+Irving Janis's work on groupthink (1972), which describes exactly
+the cascading conformity mechanism the story dramatizes. It has
+since become one of the most frequently invoked narrative metaphors
+in English, deployed in contexts ranging from financial bubbles to
+technology hype cycles to political rhetoric.
+
+## References
+
+- Andersen, H. C. "Kejserens nye Klaeder" (1837)
+- Don Juan Manuel, *El Conde Lucanor* (1335), Exemplo XXXII
+- Janis, I. L. *Victims of Groupthink* (1972)
+- Noelle-Neumann, E. *The Spiral of Silence* (1974) -- the
+  communication theory that formalizes the cascade mechanism


### PR DESCRIPTION
## Summary
- Adds `emperor-new-clothes` mapping as archetype (collective delusion pattern recurs across politics, business, tech, academia)
- source_frame: mythology, target_frame: social-control
- Creates new `social-control` frame

Closes #1103

## Validator output
All content valid. No new errors introduced.

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [x] Required body sections present
- [x] New frame included in PR

Generated with Claude Code