### PR TITLE
Add mapping: sorcerer-apprentice

### DIFF
--- a/catalog/frames/social-control.md
+++ b/catalog/frames/social-control.md
@@ -1,0 +1,24 @@
+---
+slug: social-control
+name: "Social Control"
+related:
+  - governance
+  - social-behavior
+roles:
+  - authority
+  - conformity
+  - dissent
+  - surveillance
+  - norm
+  - sanction
+  - compliance
+  - resistance
+---
+
+The mechanisms by which groups enforce behavioral norms, maintain collective
+beliefs, and suppress deviation. Social control operates through formal
+structures (laws, institutions, punishment) and informal ones (shame,
+ostracism, peer pressure). As a target domain it captures situations where
+individual judgment is overridden by group dynamics, where speaking truth
+carries social cost, and where authority depends on collective acquiescence
+rather than on force alone.

--- a/catalog/mappings/sorcerer-apprentice.md
+++ b/catalog/mappings/sorcerer-apprentice.md
@@ -1,0 +1,131 @@
+---
+slug: sorcerer-apprentice
+name: "Sorcerer's Apprentice"
+kind: archetype
+source_frame: mythology
+target_frame: social-control
+categories:
+  - mythology-and-religion
+  - software-engineering
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - frankenstein-is-technology-risk
+  - paperclip-maximizer-is-alignment-failure
+---
+
+## What It Brings
+
+In the tale (Goethe's 1797 poem "Der Zauberlehrling," popularized by
+Disney's 1940 *Fantasia*), a sorcerer's apprentice enchants a broom to
+carry water. The broom obeys perfectly -- too perfectly. It cannot be
+stopped, it floods the workshop, and when the apprentice splits it with
+an axe, both halves continue carrying water. Only the master's return
+restores order. The archetype captures a specific failure mode:
+automation that executes its instructions flawlessly while producing
+catastrophic results because the operator lacked the authority or
+knowledge to constrain it.
+
+Key structural parallels:
+
+- **Correct execution, wrong outcome** -- the broom does exactly what
+  it was told. The disaster is not a malfunction but a specification
+  error. This maps precisely onto runaway automated systems: algorithmic
+  trading that executes its strategy perfectly during a flash crash,
+  CI/CD pipelines that deploy broken code exactly as configured, email
+  marketing systems that send millions of messages because nobody set
+  a rate limit. The archetype insists that the problem is not the tool
+  but the gap between the instruction given and the instruction intended.
+- **The axe makes it worse** -- the apprentice's attempt to fix the
+  problem by destroying the broom doubles the rate of flooding. This
+  captures the real-world phenomenon where emergency interventions in
+  automated systems amplify the original failure. Killing a process
+  that holds a lock, reverting a deployment mid-transaction, manually
+  overriding an autopilot -- the instinct to "just stop it" often
+  creates a second, worse failure mode.
+- **The absent master** -- the disaster happens because the person
+  with full understanding (the sorcerer) is away. The apprentice has
+  enough knowledge to start the process but not enough to stop it.
+  This maps onto organizations where the person who architected a
+  system has left, where operational knowledge is concentrated in one
+  expert, or where the system's complexity exceeds any single
+  operator's comprehension.
+- **Power without understanding** -- the apprentice can invoke the
+  spell but does not understand the forces it commands. This is the
+  core anxiety the archetype expresses: the gap between the ability
+  to deploy a capability and the ability to comprehend its
+  consequences. It applies equally to nuclear energy, genetic
+  engineering, large language models, and financial derivatives.
+
+## Where It Breaks
+
+- **The master exists and returns.** The tale's resolution depends on
+  a higher authority who fully understands the system. In most real
+  scenarios, there is no master -- no one who can simply speak the
+  counterspell. Complex systems exceed the comprehension of any
+  individual. The archetype implies that the solution is to find or
+  become the master, when the actual problem may be that mastery is
+  impossible at the relevant scale. The sorcerer is a comforting
+  fiction.
+- **The broom has no agency.** The enchanted broom is a pure
+  executor -- it has no goals, no learning, no adaptation. Modern AI
+  systems, autonomous vehicles, and adaptive algorithms do not merely
+  execute instructions; they optimize, learn, and generalize. The
+  archetype's model of automation as "dumb obedience" understates the
+  challenge posed by systems that are not just uncontrollable but
+  unpredictable in their behavior.
+- **The apprentice is merely incompetent.** In the tale, the
+  apprentice's flaw is simple: he used a tool he was not qualified to
+  use. The moral is "stay within your competence" or "wait for the
+  master." But many real automation disasters involve competent
+  operators facing genuinely novel situations. The Three Mile Island
+  operators were trained; the Knight Capital engineers were experienced.
+  The archetype's framing as an apprentice problem can deflect
+  attention from systemic issues (poor design, missing safeguards,
+  organizational pressure) by blaming the individual.
+- **The tale treats automation as optional.** The apprentice could
+  have carried the water himself. In many modern contexts, automation
+  is not a convenience but a necessity -- no human can trade at
+  microsecond speeds, monitor millions of network packets, or
+  process genomic data manually. The archetype's implicit suggestion
+  that one should "just do it by hand" is not available.
+
+## Expressions
+
+- "Sorcerer's apprentice problem" -- any situation where an automated
+  process exceeds its operator's ability to control it
+- "The brooms are still carrying water" -- a system is still executing
+  a task that should have been stopped long ago
+- "We split the broom" -- an emergency fix that doubled the problem
+- "Who's the sorcerer?" -- asking who in the organization has the
+  authority and knowledge to stop a runaway process
+- "Mickey Mouse operation" -- pejorative for an amateurish or
+  poorly controlled operation, partly derived from the Fantasia
+  sequence though the phrase predates it
+
+## Origin Story
+
+The tale originates with Lucian of Samosata's *Philopseudes* (second
+century CE), where a character named Eucrates describes an Egyptian
+sorcerer's servant animating a pestle to carry water. Goethe adapted
+it as the ballad "Der Zauberlehrling" (1797), which became the
+definitive literary version. Paul Dukas composed the orchestral
+scherzo *L'apprenti sorcier* (1897), and Disney's *Fantasia* (1940)
+cemented the image of Mickey Mouse battling multiplying brooms in
+popular culture.
+
+The metaphor gained particular currency in technology discourse from
+the 1980s onward, as automation systems became powerful enough to
+cause large-scale failures without human intervention. It is now a
+standard reference in discussions of AI safety, algorithmic trading
+regulation, and autonomous weapons policy.
+
+## References
+
+- Goethe, J. W. von. "Der Zauberlehrling" (1797)
+- Lucian of Samosata. *Philopseudes* (c. 150 CE)
+- Perrow, C. *Normal Accidents: Living with High-Risk Technologies*
+  (1984) -- formalizes the "system beyond operator comprehension"
+  problem the archetype dramatizes
+- Leveson, N. *Engineering a Safer World* (2011) -- systems-theoretic
+  approach to automation safety


### PR DESCRIPTION
## Summary
- Adds `sorcerer-apprentice` mapping as archetype (runaway automation pattern across AI, finance, nuclear, biotech)
- source_frame: mythology, target_frame: social-control
- Creates new `social-control` frame (same as emperor-new-clothes PR; whichever merges first creates it)

Closes #1104

## Validator output
All content valid. No new errors introduced.

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [x] Required body sections present
- [x] New frame included in PR

Generated with Claude Code