### PR TITLE
Add mapping: rumpelstiltskin

### DIFF
--- a/catalog/mappings/rumpelstiltskin.md
+++ b/catalog/mappings/rumpelstiltskin.md
@@ -1,0 +1,138 @@
+---
+slug: rumpelstiltskin
+name: "Rumpelstiltskin"
+kind: archetype
+source_frame: mythology
+target_frame: language
+categories:
+  - mythology-and-religion
+  - linguistics
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - nemesis
+---
+
+## What It Brings
+
+In the Grimm brothers' tale (1812), a mysterious creature spins straw
+into gold for a miller's daughter but demands her firstborn child in
+return. She can escape the bargain only by discovering his name. When
+she does -- Rumpelstiltskin -- his power over her collapses. The
+archetype captures a deep and ancient intuition: that to name something
+is to gain power over it, and that the unnamed exerts a terrifying
+authority precisely because it cannot be identified, classified, or
+controlled.
+
+Key structural parallels:
+
+- **Naming as mastery** -- across cultures, knowing the true name of a
+  being confers control over it. Egyptian magicians commanded gods by
+  name. Jewish mysticism restricts the pronunciation of the divine
+  name. In the tale, the name is not a label but a key -- it unlocks
+  power over the named. This maps onto debugging (naming the bug is
+  half the fix), medical diagnosis (the named condition becomes
+  treatable), and psychology (naming an emotion reduces its grip).
+  The act of classification is not merely descriptive; it is an
+  assertion of cognitive control.
+- **The unnamed is dangerous** -- before the miller's daughter knows
+  Rumpelstiltskin's name, she is helpless. The unnamed creature
+  operates outside her categories, beyond her ability to predict or
+  resist. This parallels the anxiety of facing an undiagnosed illness,
+  an uncharacterized software bug, or an unnamed organizational
+  dysfunction. The thing without a name occupies a zone of maximum
+  uncertainty -- it could be anything, and therefore it is more
+  frightening than any specific threat.
+- **The bargain you cannot refuse** -- Rumpelstiltskin offers something
+  genuinely valuable (gold, survival) in exchange for something whose
+  cost is not yet felt (a future child). This maps onto technical debt,
+  Faustian bargains with investors, and any situation where present
+  benefit is purchased with deferred, poorly understood cost. The
+  archetype insists that the benefactor whose name you do not know is
+  the most dangerous kind.
+- **Discovery through investigation, not combat** -- the miller's
+  daughter defeats Rumpelstiltskin not through force but through
+  research. She sends messengers across the kingdom to collect names.
+  The archetype privileges intellectual labor over physical power:
+  the solution to the problem is knowledge, specifically taxonomic
+  knowledge -- placing the unknown into a known category.
+
+## Where It Breaks
+
+- **Naming is not always control.** The archetype assumes that
+  classification confers power, but many named things remain
+  intractable. We can name cancer, climate change, and systemic
+  racism without gaining meaningful control over them. Diagnosis is
+  not cure. The archetype can create a false sense of progress:
+  "We've named the problem" becomes a substitute for solving it,
+  and the naming ceremony becomes its own form of magical thinking.
+- **Names can be wrong.** The archetype treats the true name as a
+  fixed, discoverable fact. In practice, naming is a human act of
+  categorization that can be mistaken, misleading, or politically
+  motivated. A psychiatric diagnosis, a software architecture label,
+  or a geopolitical category ("axis of evil," "failed state") shapes
+  perception as much as it describes reality. The Rumpelstiltskin
+  archetype has no room for the possibility that the name is a tool
+  of power wielded by the namer, not a neutral discovery.
+- **The creature cooperates in its own defeat.** Rumpelstiltskin
+  dances around a fire singing his own name. This is a narrative
+  convenience, not a structural parallel. Real unnamed threats do
+  not advertise their identities. The archetype can encourage the
+  belief that sufficient investigation will always yield the key
+  piece of information, when many problems resist categorization
+  not because we have not searched hard enough but because they are
+  genuinely novel or ambiguous.
+- **The tale privileges the individual identifier over systemic
+  understanding.** Knowing Rumpelstiltskin's name tells you nothing
+  about what he is, where he came from, or why he spins straw into
+  gold. The name is a point solution to a specific threat, not
+  comprehension. The archetype can encourage a reductive approach to
+  complex problems: find the name, solve the case, move on -- without
+  understanding the system that produced the threat in the first place.
+
+## Expressions
+
+- "The Rumpelstiltskin principle" -- the idea that naming a problem
+  is the first step toward solving it, used in psychology and
+  organizational theory
+- "Name it to tame it" -- clinical psychology phrase (Dan Siegel) for
+  the practice of labeling emotions to reduce their intensity, a
+  direct application of the archetype
+- "Knowing the true name" -- in programming and security, the idea
+  that identifying the exact class of bug, vulnerability, or failure
+  mode is the prerequisite for addressing it
+- "Spinning straw into gold" -- the other half of the tale, used
+  independently to describe transforming worthless inputs into
+  valuable outputs (often with an implication of fraudulence)
+- "What do you call it?" -- the diagnostic question in medicine,
+  therapy, and engineering that signals the transition from confusion
+  to categorization
+
+## Origin Story
+
+The Rumpelstiltskin tale belongs to the Aarne-Thompson type 500
+("The Name of the Supernatural Helper"), a story pattern found across
+European, Middle Eastern, and Asian folklore traditions. The Grimm
+brothers published their version in 1812. Variants include the English
+Tom Tit Tot, the Cornish Duffy and the Devil, and the Jewish story of
+the demon Ashmodai.
+
+The "true name" motif is far older than any single tale. Egyptian
+mythology holds that Ra's secret name was the source of his power.
+The Sumerian me -- divine decrees that governed civilization -- were
+essentially names that conferred authority. The archetype taps into a
+preliterate intuition about language: that words are not arbitrary
+labels but have intrinsic connection to the things they designate.
+Modern linguistics (Saussure's arbitrariness principle) rejects this,
+but the cognitive and emotional force of the archetype persists.
+
+## References
+
+- Grimm, J. and Grimm, W. *Kinder- und Hausmarchen* (1812),
+  "Rumpelstilzchen"
+- Aarne, A. and Thompson, S. *The Types of the Folktale* (1961),
+  Type 500
+- Siegel, D. J. *Mindsight* (2010) -- "name it to tame it" in
+  clinical neuroscience
+- Frazer, J. G. *The Golden Bough* (1890) -- naming taboos and the
+  power of true names across cultures


### PR DESCRIPTION
## Summary
- Adds `rumpelstiltskin` mapping as archetype (naming-as-power pattern across debugging, medicine, psychology, theology, security)
- source_frame: mythology, target_frame: language
- All required frames already exist

Closes #1105

## Validator output
All content valid. No new errors introduced.

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [x] Required body sections present
- [x] Frames exist for source and target

Generated with Claude Code