### PR TITLE
Add mapping: alchemy

### DIFF
--- a/catalog/frames/transformation.md
+++ b/catalog/frames/transformation.md
@@ -1,0 +1,23 @@
+---
+slug: transformation
+name: "Transformation"
+related:
+  - event-structure
+  - creative-process
+roles:
+  - input
+  - output
+  - process
+  - catalyst
+  - waste
+  - refinement
+  - transmutation
+---
+
+The process of changing something from one state, form, or substance into
+another. Transformation implies that the output is qualitatively different
+from the input -- not merely modified but fundamentally altered. As a target
+domain it covers any process where raw material becomes finished product,
+data becomes insight, or base inputs become valuable outputs. The frame
+carries implicit questions about what is preserved through the change, what
+is lost, and whether the transformation is genuine or illusory.

--- a/catalog/mappings/alchemy.md
+++ b/catalog/mappings/alchemy.md
@@ -1,0 +1,142 @@
+---
+slug: alchemy
+name: "Alchemy"
+kind: dead-metaphor
+source_frame: mythology
+target_frame: transformation
+categories:
+  - mythology-and-religion
+  - economics-and-finance
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - midas-touch
+  - phoenix
+---
+
+## What It Brings
+
+Alchemy was the medieval and early modern practice of attempting to
+transmute base metals into gold, discover a universal solvent, and
+create the elixir of life. When modern speakers say "financial alchemy,"
+"data alchemy," or "algorithmic alchemy," they almost never mean to
+invoke the historical practice -- the word has become a dead metaphor
+for any process that transforms something common into something
+valuable, with an undercurrent of suspicion that the transformation
+may be illusory.
+
+Key structural parallels:
+
+- **Base material becomes precious** -- the alchemist's core promise
+  was transmutation: lead into gold, the ordinary into the extraordinary.
+  When a startup claims to turn "data exhaust" into actionable
+  intelligence, or a financial engineer packages subprime mortgages
+  into AAA-rated securities, the alchemical structure is present even
+  if the word is not used. The metaphor carries the promise of
+  value creation from apparently worthless inputs.
+- **The secret process** -- alchemists worked in private, using
+  coded language and obscure symbolism. Their methods were
+  deliberately opaque. This maps onto proprietary algorithms,
+  trade secrets, and any "black box" process where the
+  transformation is visible but the mechanism is hidden. "Data
+  alchemy" implies that the data scientist's methods are as
+  incomprehensible to outsiders as an alchemist's furnace.
+- **The philosopher's stone** -- alchemy's central quest was for a
+  catalyst that would enable transmutation. The philosopher's stone
+  was not a tool but a universal enabler. This maps onto platform
+  thinking, foundation models, and any technology marketed as the
+  key that unlocks all transformations. Every decade produces its
+  philosopher's stone: the internet, big data, blockchain, AI.
+- **The charlatan suspicion** -- alchemy carries a permanent taint
+  of fraud. Real alchemists were intermingled with con artists, and
+  the distinction was often unclear even to contemporaries. When
+  someone calls a process "alchemy," they may be praising its
+  transformative power or questioning its legitimacy -- the word
+  holds both meanings simultaneously.
+
+## Where It Breaks
+
+- **Alchemy failed.** The central project of alchemy -- transmuting
+  base metals into gold -- was impossible with pre-modern chemistry.
+  The metaphor inherits this failure as an undercurrent: calling
+  something "alchemy" always carries the implication that the
+  transformation might not be real. But many modern processes that
+  get called "alchemical" actually work. Machine learning genuinely
+  does extract patterns from noise. Financial engineering genuinely
+  does create new instruments. The dead metaphor's residual
+  skepticism can be unearned.
+- **Alchemy was proto-science, not magic.** Popular usage treats
+  alchemy as mysticism, but historical alchemists developed
+  laboratory techniques, chemical knowledge, and experimental
+  methods that fed directly into modern chemistry. Boyle, Newton,
+  and Lavoisier all engaged with alchemical traditions. The dead
+  metaphor flattens a complex intellectual tradition into a
+  shorthand for "fake transformation," which is historically
+  inaccurate and intellectually lazy.
+- **The transformation metaphor obscures destruction.** Alchemical
+  processes involved heating, dissolving, calcinating, and
+  otherwise destroying the original substance. The modern metaphor
+  focuses on what emerges (gold) and ignores what is consumed. When
+  "data alchemy" transforms personal information into targeted
+  advertising, the "base material" includes people's privacy. The
+  metaphor's emphasis on the output conceals the cost of the input.
+- **Not all value creation is transmutation.** The alchemical frame
+  implies that the valuable output is a different substance from the
+  worthless input. But in many modern "alchemical" processes, the
+  value was always present -- it just needed to be recognized,
+  organized, or made accessible. A search engine does not transmute
+  web pages into knowledge; it indexes what was already there. The
+  alchemy metaphor overstates the degree of transformation and
+  understates the degree of curation.
+
+## Expressions
+
+- "Financial alchemy" -- creating complex financial instruments that
+  appear to generate value from nothing, used both approvingly (by
+  practitioners) and pejoratively (by critics, especially after 2008)
+- "Data alchemy" -- transforming raw data into actionable insight,
+  common in data science marketing
+- "Algorithmic alchemy" -- the process by which machine learning
+  models extract patterns from noise, with an implied question about
+  whether the patterns are real
+- "The philosopher's stone of X" -- the single breakthrough that
+  would solve all problems in a domain, always sought, never found
+- "Turning lead into gold" -- the generic expression for any
+  improbable value transformation, used with no awareness of its
+  alchemical origin by most speakers
+- "It's not alchemy" -- defensive reassurance that a process is
+  legitimate and reproducible, not magical or fraudulent
+
+## Origin Story
+
+The word "alchemy" derives from Arabic al-kimiya, possibly from
+the Greek chymeia (pouring, infusion) or the Egyptian keme (black
+earth, referring to the Nile delta soil). The practice emerged in
+Hellenistic Egypt, flourished in the Islamic Golden Age, and entered
+medieval Europe through Arabic texts translated in Toledo and Sicily.
+
+Alchemy's metaphorical afterlife began almost as soon as the literal
+practice declined. By the eighteenth century, "alchemy" was already
+being used figuratively to mean any mysterious or dubious
+transformation. Adam Smith used alchemical language to describe the
+operations of banks and credit. The word entered financial vocabulary
+permanently through this route and has since spread to technology,
+data science, and organizational theory.
+
+The metaphor is now so dead that most speakers using "data alchemy"
+or "financial alchemy" would not recognize the historical practice
+as the source. The word functions as a simple intensifier meaning
+"impressive transformation" -- the medieval laboratory, the coded
+symbols, the philosophical framework have all been stripped away,
+leaving only the gold.
+
+## References
+
+- Principe, L. M. *The Secrets of Alchemy* (2013) -- authoritative
+  history that recovers alchemy as serious intellectual practice
+- Newman, W. R. *Atoms and Alchemy* (2006) -- alchemy's contribution
+  to the development of modern chemistry
+- Taussig, M. *The Devil and Commodity Fetishism in South America*
+  (1980) -- explores alchemical metaphors in economic thinking
+- Das, S. *Traders, Guns & Money* (2006) -- "financial alchemy" in
+  derivatives markets


### PR DESCRIPTION
## Summary
- Adds `alchemy` mapping as dead-metaphor (speakers use "financial alchemy" / "data alchemy" with no awareness of medieval proto-chemistry source)
- source_frame: mythology, target_frame: transformation (per advisory, NOT destruction)
- Creates new `transformation` frame

Closes #1106

## Validator output
All content valid. No new errors introduced.

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [x] Required body sections present
- [x] New frame included in PR

Generated with Claude Code