### PR TITLE
Add mapping: one-ring

### DIFF
--- a/catalog/frames/technology-risk.md
+++ b/catalog/frames/technology-risk.md
@@ -1,0 +1,21 @@
+---
+slug: technology-risk
+name: "Technology Risk"
+related:
+  - ethics-and-morality
+  - governance
+roles:
+  - capability
+  - threat
+  - safeguard
+  - unintended-consequence
+  - wielder
+  - vulnerability
+---
+
+The dangers that emerge from creating, deploying, or relying on powerful
+technologies. This frame centers on the gap between a technology's intended
+use and its actual consequences -- the idea that capabilities carry inherent
+risks that cannot be fully separated from the benefits. Key dynamics include
+concentration of power, irreversibility, dual-use potential, and the
+temptation to believe one can control what one has merely unleashed.

--- a/catalog/mappings/one-ring.md
+++ b/catalog/mappings/one-ring.md
@@ -1,0 +1,117 @@
+---
+slug: one-ring
+name: "The One Ring"
+kind: conceptual-metaphor
+source_frame: mythology
+target_frame: technology-risk
+categories:
+  - mythology-and-religion
+  - ethics-and-morality
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - palantir
+  - mordor
+---
+
+## What It Brings
+
+Tolkien's One Ring is the canonical literary argument against capturing
+dangerous capabilities. Sauron forged it to dominate, but the Ring's
+central dramatic function is what it does to everyone else: Boromir
+wants to use it to defend Gondor, Gandalf refuses it because he knows
+he would become another Sauron, and Galadriel passes her "test" by
+declining absolute power. The metaphor maps cleanly onto technology
+policy debates where the question is not whether a capability is
+powerful but whether any wielder can be trusted with it.
+
+Key structural parallels:
+
+- **Corruption is gradual and invisible to the corrupted** -- the Ring
+  does not announce its influence. Gollum does not notice his own
+  degradation. In technology, this maps to the slow normalization of
+  surveillance, data exploitation, or weapons deployment: each
+  incremental use seems reasonable to the wielder.
+- **Good intentions do not protect** -- Boromir's desire to save his
+  people makes him more vulnerable, not less. The metaphor argues that
+  the most dangerous wielders are those who believe their motives
+  justify the risk. In AI safety discourse, this maps directly to the
+  "alignment problem": a system built to help can still cause harm
+  through the very mechanism of its power.
+- **The only safe move is destruction** -- the Council of Elrond's
+  conclusion is that the Ring cannot be used, hidden, or contained; it
+  must be unmade. This maps to arguments for banning entire technology
+  categories (biological weapons, autonomous lethal weapons, certain
+  AI capabilities) rather than regulating their use.
+- **The Ring wants to be found** -- Tolkien gives the Ring agency; it
+  "betrayed" Gollum and "abandoned" him when it sensed Sauron's
+  return. The metaphor captures how powerful technologies create their
+  own demand: once a capability exists, the pressure to deploy it is
+  nearly irresistible regardless of policy.
+
+## Where It Breaks
+
+- **Tolkien's Ring has exactly one right answer; real technology rarely
+  does.** The narrative resolves with a binary choice: destroy or be
+  destroyed. Real capability decisions involve spectrums of regulation,
+  oversight, and graduated deployment. The metaphor biases discourse
+  toward all-or-nothing positions and makes incremental governance
+  sound like compromise with evil.
+- **The Ring has no legitimate use case; most technologies do.** Nuclear
+  fission powers cities and destroys them. CRISPR edits diseases and
+  could edit populations. The One Ring metaphor applies cleanly only to
+  technologies with no constructive application, which is a vanishingly
+  small category. Applying it to dual-use technologies smuggles in the
+  assumption that the destructive use is the "real" one.
+- **The metaphor personalizes systemic risk.** The Ring corrupts
+  individuals. Real technology risk is usually institutional and
+  structural -- regulatory capture, market incentives, organizational
+  drift. Framing AI risk as "the Ring will corrupt whoever holds it"
+  obscures the fact that the problem is usually not individual moral
+  failure but system design.
+- **Tolkien's moral framework is monarchist and essentialist.** Aragorn
+  can resist the Ring because of who he is (lineage, character). The
+  metaphor can import the assumption that the right leader could safely
+  wield dangerous power -- the exact opposite of its intended lesson --
+  when audiences identify with Aragorn rather than Boromir.
+
+## Expressions
+
+- "That's the One Ring of [technology]" -- used in AI safety, biotech,
+  and nuclear policy to argue that a capability is inherently corrupting
+  and should be destroyed rather than regulated
+- "You can't wield it" -- shorthand for the argument that good intentions
+  don't neutralize dangerous capabilities, frequently used in open-source
+  AI debates
+- "It wants to be found" -- describes how powerful technologies generate
+  their own adoption pressure independent of policy decisions
+- "Boromir's fallacy" -- the belief that one's own good motives make
+  wielding a dangerous tool safe, used in security and AI ethics
+- "Throw it in the fire" -- the abolitionist position on a technology
+  category, rejecting all regulatory middle grounds
+- "My precious" -- attachment to a tool or system that has become
+  psychologically indispensable despite being harmful, common in
+  discussions of addictive technology design
+
+## Origin Story
+
+Tolkien began writing *The Lord of the Rings* in 1937, and the Ring's
+symbolic weight deepened as World War II progressed. While Tolkien
+consistently rejected allegorical readings ("I cordially dislike
+allegory in all its manifestations"), the Ring's thematic resonance
+with atomic weapons was immediately noted by readers and critics upon
+publication in 1954-55. The metaphor entered technology discourse most
+forcefully in the 2010s-2020s AI safety movement, where Eliezer
+Yudkowsky and others explicitly invoked the Council of Elrond as a
+model for how to think about superintelligence: a capability so
+dangerous that the only responsible course is to ensure it is never
+created.
+
+## References
+
+- Tolkien, J. R. R. *The Lord of the Rings* (1954-55), especially
+  "The Council of Elrond" and "The Mirror of Galadriel"
+- Yudkowsky, E. Various posts on LessWrong invoking the One Ring in
+  AI safety contexts (2008-2023)
+- Bostrom, N. *Superintelligence* (2014) -- the academic formalization
+  of "some capabilities should not be wielded"


### PR DESCRIPTION
## Summary
- Adds `one-ring` mapping: Tolkien's One Ring as conceptual metaphor for technology capabilities that corrupt any wielder
- Creates `technology-risk` frame (new)
- Source: mythology, Target: technology-risk

Closes #1112

## Validator output
All content valid (0 errors, warnings are pre-existing dangling references only).

## Test plan
- [x] `uv run scripts/validate.py validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)