### PR TITLE
Add mapping: dragon-hoard

### DIFF
--- a/catalog/mappings/dragon-hoard.md
+++ b/catalog/mappings/dragon-hoard.md
@@ -1,0 +1,127 @@
+---
+slug: dragon-hoard
+name: "Dragon Hoard"
+kind: conceptual-metaphor
+source_frame: mythology
+target_frame: economics
+categories:
+  - mythology-and-religion
+  - economics-and-finance
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - midas-touch
+  - cornucopia
+---
+
+## What It Brings
+
+In Norse and European folklore, the dragon sits atop a vast pile of gold
+it can neither spend nor use. Fafnir in the Volsunga Saga was once a dwarf
+who murdered his father for cursed treasure, then transformed into a dragon
+to guard it -- becoming the thing his greed demanded. The hoard is not
+wealth in any functional sense; it is wealth removed from circulation,
+defended with lethal force, and rotting its possessor from within.
+
+The metaphor maps onto economic behavior with uncomfortable precision:
+
+- **Accumulation beyond use** -- the dragon does not invest, trade, or
+  consume. It sleeps on gold. The structural parallel is the corporation
+  or individual sitting on liquid reserves far beyond any operational
+  need -- Apple's $200 billion cash pile, sovereign wealth funds with no
+  spending mandate, billionaire fortunes that exceed any possible
+  consumption. The hoard is defined by its inertness: it exists to exist.
+- **Resource capture as territorial defense** -- the dragon's relationship
+  to its hoard is not ownership but occupation. It does not hold title; it
+  holds the cave. This maps onto monopolistic control of scarce resources:
+  patent thickets, spectrum hoarding, domain squatting, land banking.
+  The value comes not from using the resource but from preventing others
+  from using it.
+- **Transformation of the hoarder** -- Fafnir becomes a dragon. The
+  metaphor insists that extreme accumulation changes the accumulator.
+  The miser becomes miserly; the rent-seeker becomes the rent. Corporate
+  culture warps around the imperative to protect the hoard rather than
+  deploy it. This is not a moral judgment bolted on from outside -- it
+  is structural to the source narrative.
+- **The curse** -- dragon gold is typically cursed. Andvari's ring brings
+  destruction to everyone who possesses it. The metaphor suggests that
+  hoarded wealth is not merely unproductive but actively toxic -- to the
+  hoarder, to the economy that lost those resources, and to whoever
+  eventually captures the hoard through violence.
+
+## Where It Breaks
+
+- **Dragons do not earn their hoards** -- Fafnir stole his treasure. Most
+  real-world wealth accumulation, however extreme, involves some productive
+  activity at its origin. Bezos built a logistics network; Smaug just
+  conquered a mountain. The metaphor smuggles in an assumption that all
+  large accumulation is theft, which is a political claim disguised as a
+  narrative parallel. Critics of wealth inequality love the metaphor
+  precisely because it skips the question of how the wealth was created.
+- **Liquid reserves serve a function** -- corporate cash hoards exist
+  partly because capital markets are imperfect. Cash buffers absorb
+  shocks, fund acquisitions, and provide strategic flexibility. A company
+  with zero reserves is not virtuous; it is fragile. The dragon metaphor
+  treats all reserves as pathological, which ignores the difference
+  between precautionary saving and compulsive hoarding.
+- **The metaphor assumes a zero-sum economy** -- the dragon's hoard is
+  finite physical gold. Modern wealth is not a fixed pile that someone
+  sits on while others go without. Stock market valuations, intellectual
+  property, and financial instruments can grow without depleting a
+  common pool. The metaphor imports a medieval understanding of wealth
+  (there is only so much gold) into contexts where it may not apply.
+- **Redistribution is not dragon-slaying** -- in the myths, the hero
+  kills the dragon and takes the gold. This maps poorly onto tax policy,
+  antitrust action, or wealth redistribution, which are bureaucratic
+  processes with tradeoffs, not heroic acts with clear moral valence.
+  The metaphor makes complex policy questions feel simple, which is
+  precisely when metaphors become dangerous.
+
+## Expressions
+
+- "Sitting on a pile of cash" -- the dragon's posture applied to
+  corporate treasury management
+- "Cash hoard" -- direct import of the mythological image into financial
+  journalism, used so routinely that the dragon source is often invisible
+- "War chest" -- related but distinct: a hoard with stated offensive
+  purpose, the dragon planning to use its gold
+- "Rent-seeking" -- the economic term for extracting value without
+  creating it, the dragon's entire business model
+- "Patent troll" -- a creature that hoards intellectual property not to
+  use but to extract tolls from those who would, combining the troll
+  and dragon archetypes
+- "Dead money" -- capital sitting idle, the hoard's defining quality
+  expressed in financial vocabulary
+- "Land banking" -- acquiring land not to develop but to hold,
+  the dragon's cave strategy applied to real estate
+
+## Origin Story
+
+The dragon hoard is one of the oldest metaphorical structures in
+Indo-European mythology. The Rigveda's Vritra hoards waters rather than
+gold -- a serpent lying across rivers, causing drought. The structural
+pattern is identical: a reptilian creature prevents a vital resource
+from flowing to those who need it, and a hero must kill the creature
+to release the flow.
+
+In Norse mythology, the Volsunga Saga and the Nibelungenlied elaborate
+the pattern with the addition of the curse motif: the gold itself is
+poisoned by the act of hoarding it. Tolkien, a philologist steeped in
+these sources, made Smaug's hoard central to *The Hobbit* (1937) and
+through that novel transmitted the archetype to modern popular culture.
+
+The economic application became explicit in the 2010s as "cash hoard"
+entered standard financial journalism vocabulary, particularly in
+coverage of technology companies whose liquid reserves exceeded the
+GDP of small nations.
+
+## References
+
+- *Volsunga Saga* (13th century) -- Fafnir's transformation and the
+  cursed gold of Andvari
+- Tolkien, J. R. R. *The Hobbit* (1937) -- Smaug as the canonical
+  modern dragon hoarder
+- Graeber, D. *Debt: The First 5,000 Years* (2011) -- discusses the
+  mythology of hoarded wealth and its relationship to debt
+- Lazonick, W. "Profits Without Prosperity" *Harvard Business Review*
+  (2014) -- the corporate cash hoard as economic pathology


### PR DESCRIPTION
## Summary
- Adds `dragon-hoard` conceptual-metaphor mapping (mythology -> economics)
- Wealth accumulation beyond use; rent-seeking; monopolistic resource capture
- Source: European/Norse folklore (Fafnir, Smaug)

Closes #1107
Sub-issue of #219

## Validator
All content valid (0 errors, pre-existing warnings only).

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [ ] Review body sections for accuracy and tone

Generated with [Claude Code](https://claude.com/claude-code)