### PR TITLE
Add mapping: palantir

### DIFF
--- a/catalog/mappings/palantir.md
+++ b/catalog/mappings/palantir.md
@@ -1,0 +1,112 @@
+---
+slug: palantir
+name: "Palantir"
+kind: conceptual-metaphor
+source_frame: mythology
+target_frame: surveillance
+categories:
+  - mythology-and-religion
+  - security
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - one-ring
+---
+
+## What It Brings
+
+Tolkien's palantiri are seeing-stones that let the user observe distant
+events -- but the connection is bidirectional. Sauron does not merely
+watch through the palantir; he shapes what the watcher sees. Denethor
+uses one and is driven to despair not because the stone lies but because
+Sauron controls which truths it reveals. The metaphor maps onto
+surveillance technology with a precision that the company Palantir
+Technologies made explicit by adopting the name in 2003.
+
+Key structural parallels:
+
+- **Surveillance is bidirectional** -- looking through the palantir
+  exposes the looker. In information security, every query reveals
+  something about the querier's interests, capabilities, and blind
+  spots. Intelligence agencies that monitor communications generate
+  metadata about their own priorities. The watcher is always also
+  being watched.
+- **The stronger mind dominates the channel** -- Sauron controls what
+  Denethor sees because Sauron is more powerful. The metaphor captures
+  how surveillance asymmetries work in practice: the party with greater
+  resources, processing power, or institutional leverage shapes the
+  information flow regardless of who initiated the observation.
+- **Partial truth is more dangerous than lies** -- the palantir shows
+  real events, selectively. Denethor sees Gondor's defeats but not its
+  allies' victories. This maps to algorithmic feeds, intelligence
+  briefings, and analytics dashboards that present accurate data in
+  misleading contexts -- the system does not fabricate, but it curates.
+- **The stones are networked** -- the seven palantiri form a network;
+  each can communicate with any other, but the master-stone at
+  Osgiliath (now lost) once coordinated them all. The metaphor
+  captures how surveillance infrastructure operates as a system:
+  individual cameras, databases, and sensors are limited, but the
+  network is totalizing.
+
+## Where It Breaks
+
+- **The palantiri are rare and precious; surveillance is cheap and
+  ubiquitous.** Tolkien's stones are artifacts of a lost civilization,
+  closely guarded. Real surveillance technology is commodity hardware
+  running commodity software. The metaphor imports an aura of rarity
+  and elite access that obscures how surveillance has become banal --
+  every smartphone is a palantir, and no one guards it like one.
+- **Tolkien's users choose to look; modern subjects don't choose to be
+  seen.** Denethor picks up the stone. Citizens captured by CCTV,
+  browser fingerprinting, or location tracking have made no
+  corresponding choice. The metaphor centers the watcher's experience
+  and decision, making it easy to ignore the watched.
+- **The bidirectionality is asymmetric in the wrong direction.** In
+  Tolkien, the weaker party (Denethor) is endangered by looking. In
+  real surveillance, the weaker party (the subject) is endangered by
+  being looked at. The metaphor can accidentally reassure: "surveillance
+  hurts the watchers too" is true but secondary.
+- **Palantir Technologies adopted the name approvingly.** The company
+  chose the name to evoke far-seeing clarity, not Denethor's madness.
+  This inverted reading -- the palantir as a tool of justified
+  vigilance rather than corrupting oversight -- demonstrates how
+  literary metaphors can be repurposed to mean the opposite of their
+  source text.
+
+## Expressions
+
+- "Palantir" (the company) -- the most literal adoption of the metaphor,
+  naming a surveillance analytics firm after Tolkien's seeing-stones
+- "Looking into the palantir" -- consulting a surveillance or intelligence
+  system with the implication that doing so exposes the querier
+- "Denethor's mistake" -- trusting a surveillance feed without accounting
+  for who controls what it shows, used in intelligence analysis and
+  information security
+- "The stone shows only what Sauron wants you to see" -- critique of
+  algorithmically curated information that is technically accurate but
+  strategically misleading
+- "Who holds the master-stone?" -- asking who controls the central node
+  in a surveillance or information network
+
+## Origin Story
+
+Tolkien's palantiri first appear in *The Two Towers* (1954), where
+Pippin looks into the stone recovered from Isengard and is briefly
+interrogated by Sauron. The metaphor's modern career began when Peter
+Thiel, Alex Karp, and others founded Palantir Technologies in 2003
+to build data analytics for intelligence agencies. The company's
+explicit adoption of the Tolkien reference invited exactly the double
+reading the source text supports: are they providing clear sight to
+the defenders of Gondor, or are they building a system that will
+corrupt its users? The debate around Palantir Technologies
+recapitulates the literary debate about Denethor's use of the stone.
+
+## References
+
+- Tolkien, J. R. R. *The Lord of the Rings* (1954-55), especially
+  "The Palantir" and "The Siege of Gondor"
+- Tolkien, J. R. R. *Unfinished Tales* (1980), "The Palantiri" --
+  the fullest technical description of how the stones work
+- Zuboff, S. *The Age of Surveillance Capitalism* (2019) -- the
+  structural argument about bidirectional data flows that the palantir
+  metaphor anticipates


### PR DESCRIPTION
## Summary
- Adds `palantir` mapping: Tolkien's seeing-stones as metaphor for bidirectional surveillance
- Source: mythology, Target: surveillance (existing frame)

Closes #1113

## Validator output
All content valid (0 errors).

## Test plan
- [x] `uv run scripts/validate.py validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)