### PR TITLE
Add mapping: chosen-one

### DIFF
--- a/catalog/mappings/chosen-one.md
+++ b/catalog/mappings/chosen-one.md
@@ -1,0 +1,134 @@
+---
+slug: chosen-one
+name: "Chosen One"
+kind: archetype
+source_frame: mythology
+target_frame: governance
+categories:
+  - mythology-and-religion
+  - social-dynamics
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - the-hero
+  - prometheus
+---
+
+## What It Brings
+
+The Chosen One is the figure marked by destiny, prophecy, or divine
+selection to accomplish what no ordinary person can. Moses receives
+the tablets; Arthur pulls the sword; Neo is told he is The One. The
+pattern recurs across cultures because it solves a narrative problem:
+how to justify extraordinary authority without democratic consent. The
+chosen one does not campaign, negotiate, or earn credentials. They are
+simply recognized -- and that recognition is sufficient.
+
+The archetype maps onto leadership narratives across multiple domains:
+
+- **Founder mythology in technology** -- the tech industry's preferred
+  origin story is a chosen-one narrative. Jobs in the garage, Zuckerberg
+  in the dorm room, Musk as the polymath savior. These figures are not
+  presented as skilled managers who built effective organizations; they
+  are presented as visionaries whose singular insight changed everything.
+  The narrative structure is identical to the prophecy: this person was
+  destined to build this thing. The board, the engineers, the market
+  conditions are background characters in someone else's destiny.
+- **Messianic leadership in politics** -- political movements regularly
+  produce chosen-one narratives. The leader is not merely competent but
+  uniquely capable of saving the nation. This pattern appears across the
+  political spectrum: Obama's "the one we've been waiting for," Trump's
+  "I alone can fix it," Chavez's Bolivarian destiny. The archetype
+  provides emotional fuel that policy platforms cannot: the feeling that
+  history has selected this moment and this person.
+- **The bypass of institutional legitimacy** -- the chosen one does not
+  derive authority from institutions. Arthur does not inherit the throne
+  through primogeniture; he pulls a sword from a stone. This structural
+  feature maps onto disruption narratives: the founder who drops out of
+  college, the outsider candidate who has never held office, the
+  whistleblower who breaks ranks. The archetype validates authority that
+  comes from outside established channels.
+- **The prophecy as self-fulfilling mechanism** -- once someone is
+  identified as the chosen one, resources, attention, and loyalty flow
+  toward them, making their success more likely. Venture capital operates
+  on this logic: the anointed founder receives funding that enables the
+  outcome the funding was predicated on. The prophecy does not predict
+  the future; it creates it.
+
+## Where It Breaks
+
+- **The archetype erases collective action** -- real change is almost
+  always the product of teams, movements, and institutions. The chosen-one
+  narrative compresses this into a single protagonist, making the
+  contributions of thousands of people invisible. Apple had Wozniak,
+  Ive, Cook, and tens of thousands of engineers. The chosen-one frame
+  makes it structurally impossible to see them. This is not a minor
+  distortion; it is a systematic misrepresentation of how complex
+  achievements happen.
+- **Succession becomes a crisis** -- if authority derives from personal
+  destiny rather than institutional role, there is no mechanism for
+  transfer. When the chosen one leaves, retires, or dies, the
+  organization faces an existential question that institutions with
+  distributed authority do not. Apple after Jobs, Tesla's dependence on
+  Musk, any political movement built around a single charismatic leader
+  -- the chosen-one structure creates organizations that cannot outlive
+  their founders.
+- **Failure is inexplicable within the frame** -- if the leader was
+  chosen by destiny, failure implies either that the prophecy was wrong
+  (unacceptable to believers) or that dark forces intervened (conspiracy
+  thinking). The archetype has no vocabulary for ordinary incompetence,
+  bad luck, or changed circumstances. When a chosen-one narrative
+  encounters failure, it does not update; it radicalizes.
+- **The archetype is inherently anti-democratic** -- democracy's premise
+  is that authority derives from the consent of the governed, not from
+  destiny, divine selection, or singular genius. The chosen-one archetype
+  is structurally monarchist. Every time it is applied to a democratic
+  context -- "only this candidate can save us" -- it undermines the
+  institutional foundations it claims to serve.
+
+## Expressions
+
+- "Visionary founder" -- the tech industry's standard chosen-one epithet,
+  applied so routinely it has become a job description
+- "The one we've been waiting for" -- explicit prophecy language in
+  political campaigns
+- "I alone can fix it" -- the chosen-one claim stated without metaphorical
+  softening
+- "Born to lead" -- destiny language applied to leadership, treating
+  political skill as innate rather than learned
+- "Steve would have..." -- the departed chosen one invoked as an
+  authority that no living person can challenge
+- "10x engineer" -- the chosen-one archetype scaled down to the team
+  level: one person who is not merely better but categorically different
+- "Founder mode" -- Paul Graham's 2024 coinage, explicitly arguing that
+  founders possess qualities that professional managers do not and
+  cannot acquire
+
+## Origin Story
+
+The chosen-one archetype is among the oldest narrative structures in
+human culture. Joseph Campbell identified it as central to the monomyth
+in *The Hero with a Thousand Faces* (1949), though Campbell's hero
+undergoes transformation through trial, while the modern chosen one is
+often presented as already complete -- merely awaiting recognition.
+
+The archetype's migration into business and technology discourse
+accelerated in the 1980s and 1990s with the rise of celebrity CEO
+culture. The Harvard Business Review and business press shifted from
+covering companies to covering leaders, creating a media ecosystem
+that demanded chosen-one narratives. Silicon Valley intensified this
+with its venture capital model, which explicitly bets on founders
+rather than businesses, and its mythology of the college dropout who
+sees what the establishment cannot.
+
+## References
+
+- Campbell, J. *The Hero with a Thousand Faces* (1949) -- the monomyth
+  framework that systematized the chosen-one pattern across cultures
+- Khurana, R. *Searching for a Corporate Savior* (2002) -- documents
+  how the CEO labor market creates and depends on chosen-one narratives
+- Isaacson, W. *Steve Jobs* (2011) -- the canonical modern chosen-one
+  biography, which reinforced the archetype it documented
+- Graham, P. "Founder Mode" (2024) -- explicit argument that founders
+  possess irreplaceable qualities, the chosen-one archetype as
+  management theory


### PR DESCRIPTION
## Summary
- Adds `chosen-one` archetype mapping (mythology -> governance)
- Founder mythology, messianic leadership, the bypass of institutional legitimacy
- Cross-cultural monomyth pattern recurring across tech, politics, religion

Closes #1108
Sub-issue of #219

## Validator
All content valid (0 errors, pre-existing warnings only).

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [ ] Review body sections for accuracy and tone

Generated with [Claude Code](https://claude.com/claude-code)