### PR TITLE
Add mapping: shire

### DIFF
--- a/catalog/frames/technology-risk.md
+++ b/catalog/frames/technology-risk.md
@@ -1,0 +1,21 @@
+---
+slug: technology-risk
+name: "Technology Risk"
+related:
+  - ethics-and-morality
+  - governance
+roles:
+  - capability
+  - threat
+  - safeguard
+  - unintended-consequence
+  - wielder
+  - vulnerability
+---
+
+The dangers that emerge from creating, deploying, or relying on powerful
+technologies. This frame centers on the gap between a technology's intended
+use and its actual consequences -- the idea that capabilities carry inherent
+risks that cannot be fully separated from the benefits. Key dynamics include
+concentration of power, irreversibility, dual-use potential, and the
+temptation to believe one can control what one has merely unleashed.

--- a/catalog/mappings/shire.md
+++ b/catalog/mappings/shire.md
@@ -1,0 +1,120 @@
+---
+slug: shire
+name: "The Shire"
+kind: conceptual-metaphor
+source_frame: mythology
+target_frame: technology-risk
+categories:
+  - mythology-and-religion
+  - social-dynamics
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - mordor
+  - one-ring
+---
+
+## What It Brings
+
+The Shire is Tolkien's image of what is worth protecting: a small,
+self-governing, agrarian community where the most important events are
+birthdays, harvests, and the quality of pipe-weed. Its narrative function
+is to establish stakes. The hobbits do not fight because they love war
+but because they love the Shire. In technology discourse, the metaphor
+names the human-scale values -- privacy, autonomy, community, slowness,
+local knowledge -- that are threatened by the systems being built, and
+that motivate the people who resist or regulate those systems.
+
+Key structural parallels:
+
+- **The protected do not understand the threat** -- hobbits are largely
+  unaware of the Rangers who guard their borders and the wars fought to
+  keep Mordor at bay. The metaphor captures how ordinary users of
+  technology are shielded from (and largely ignorant of) the security
+  infrastructure, policy battles, and technical safeguards that protect
+  their digital lives. The Shire's innocence is both its value and its
+  vulnerability.
+- **Protection changes the protector** -- Frodo returns to the Shire
+  but cannot live there. Aragorn guards the Shire but never enters it.
+  The metaphor maps onto the experience of security researchers, policy
+  advocates, and engineers who work to protect user privacy or safety:
+  the knowledge required to protect innocence is itself a loss of
+  innocence. You cannot unsee Mordor.
+- **The Scouring makes the threat concrete** -- Tolkien's most
+  controversial chapter shows Saruman industrializing the Shire: felling
+  trees, building factories, replacing local governance with
+  bureaucratic control. The metaphor maps onto platform colonization of
+  local communities, algorithmic replacement of human judgment, and the
+  creep of optimization logic into domains that were previously governed
+  by custom and relationship.
+- **You cannot go home again** -- even after the Scouring is reversed,
+  the Shire is changed. Sam plants a new tree, but the old one is gone.
+  The metaphor captures the irreversibility of technological disruption:
+  you can regulate social media, but you cannot restore the pre-social-
+  media public sphere. What is rebuilt is different from what was lost.
+
+## Where It Breaks
+
+- **The Shire never actually existed.** Tolkien's pastoral England is a
+  nostalgic construction -- rural England in the 1890s was not a hobbit
+  paradise but a place of agricultural poverty, rigid class hierarchy,
+  and child labor. The metaphor can smuggle in golden-age thinking: the
+  assumption that there was a pre-technological Eden to return to, when
+  the historical record shows no such place. "Protecting the Shire"
+  can mean protecting a fantasy rather than a reality.
+- **The metaphor romanticizes smallness and insularity.** Hobbits are
+  proudly provincial. They distrust outsiders, have no interest in the
+  wider world, and would have been overrun without the Rangers they
+  never thanked. Applied to technology, this maps to a localism that
+  ignores the benefits of scale, connection, and coordination -- the
+  same internet that threatens privacy also enables solidarity.
+- **The Shire's self-governance works because it is fictional.** Hobbit
+  society has almost no government, no police, and no crime. This is
+  not a political model; it is a literary convenience. Using the Shire
+  as an argument for small-scale, low-tech governance ignores that
+  real communities at that scale have real conflicts that require real
+  institutions.
+- **The protector/protected binary is patronizing.** The metaphor casts
+  ordinary users as innocent hobbits who need Rangers (security experts,
+  regulators, ethicists) to protect them. This recapitulates the
+  paternalism that technology critics often rightly object to in
+  technology companies themselves. The users-as-hobbits frame denies
+  agency to the people it claims to serve.
+
+## Expressions
+
+- "Protecting the Shire" -- used in AI safety, privacy advocacy, and
+  technology ethics to name the human values that motivate resistance
+  to unconstrained technological development
+- "Shire-posting" -- online content that celebrates small, local,
+  low-tech ways of life as an alternative to platform culture
+- "The Scouring of the Shire" -- applied to platform colonization of
+  local communities, enshittification of previously functional systems,
+  or corporate capture of public goods
+- "You can't go back to the Shire" -- the irreversibility of
+  technological change, used to argue against nostalgia-based policy
+- "Hobbit life" -- the aspiration to live simply and locally in a world
+  optimized for scale and speed, sometimes sincere, sometimes ironic
+
+## Origin Story
+
+Tolkien modeled the Shire on the rural Warwickshire of his childhood,
+particularly the village of Sarehole where he lived from 1896 to 1900.
+The encroachment of Birmingham's industrial sprawl -- which literally
+consumed Sarehole during his lifetime -- gave the Scouring of the Shire
+its emotional force. The chapter was cut from Peter Jackson's film
+adaptations, which means the metaphor's cinematic audience knows the
+Shire only as a place of departure and return, not as a place that was
+itself colonized. The full metaphorical power of the Shire requires
+the Scouring, which is why the literary metaphor is richer than the
+cinematic one.
+
+## References
+
+- Tolkien, J. R. R. *The Lord of the Rings* (1954-55), especially
+  "A Long-Expected Party," "The Grey Havens," and "The Scouring of
+  the Shire"
+- Tolkien, J. R. R. *Letters* (1981), #131 on the Shire as "more or
+  less a Warwickshire village"
+- Doctorow, C. "Enshittification" (2023) -- the Scouring of the Shire
+  applied to platform economics


### PR DESCRIPTION
## Summary
- Adds `shire` mapping: Tolkien's pastoral ideal as metaphor for human-scale values threatened by technology
- Includes `technology-risk` frame (new, also in one-ring PR -- whichever merges first provides it)
- Source: mythology, Target: technology-risk

Closes #1115

## Validator output
All content valid (0 errors).

## Test plan
- [x] `uv run scripts/validate.py validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)