### PR TITLE
Add mapping: trickster

### DIFF
--- a/catalog/mappings/trickster.md
+++ b/catalog/mappings/trickster.md
@@ -1,0 +1,139 @@
+---
+slug: trickster
+name: "Trickster"
+kind: archetype
+source_frame: mythology
+target_frame: social-behavior
+categories:
+  - mythology-and-religion
+  - social-dynamics
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - the-shadow
+  - chosen-one
+---
+
+## What It Brings
+
+The trickster is the figure who disrupts established order through
+cunning, deception, and boundary violation. Loki in Norse mythology,
+Anansi in West African tradition, Coyote in Indigenous North American
+stories, Hermes in Greek myth, Sun Wukong in Chinese legend. The
+trickster appears in every culture because every culture needs a
+narrative container for the force that breaks rules and, in breaking
+them, reveals what the rules actually are.
+
+The archetype recurs across domains well beyond mythology:
+
+- **Creative disruption** -- the trickster does not fight the existing
+  order on its own terms; they redefine the game. This maps onto
+  innovation strategy: Napster did not compete with record labels, it
+  made the distribution model irrelevant. Airbnb did not build hotels,
+  it redefined what accommodation means. The trickster's method is not
+  superior force but lateral thinking -- finding the loophole, the
+  unguarded border, the assumption nobody examined.
+- **Hacking as trickster practice** -- the hacker ethos is structurally
+  trickster behavior. Finding unintended uses for systems, exploiting
+  gaps between what a system is designed to do and what it can be made
+  to do, treating security boundaries as puzzles rather than walls.
+  Kevin Mitnick's social engineering, Aaron Swartz's JSTOR download,
+  jailbreaking consumer devices -- all follow the trickster pattern of
+  accomplishing goals through cleverness rather than authority.
+- **The provocateur's social function** -- the trickster exposes
+  hypocrisy by performing it. Court jesters could say what courtiers
+  could not. Satirists from Aristophanes to Jon Stewart occupy the
+  trickster role: they break norms in a controlled way that reveals
+  the norms' absurdities. The archetype insists that some truths can
+  only be spoken by figures who are not bound by the conventions that
+  suppress them.
+- **Boundary violation as creation** -- many trickster myths are origin
+  stories. Prometheus steals fire. Coyote steals the sun. Anansi
+  captures all the world's stories. The trickster creates by
+  transgressing, suggesting that genuine novelty requires rule-breaking
+  -- that innovation and obedience are structurally incompatible.
+
+## Where It Breaks
+
+- **The archetype romanticizes rule-breaking** -- not all boundary
+  violation is creative. Fraud is trickster behavior. Market
+  manipulation is trickster behavior. Elizabeth Holmes was a trickster.
+  The archetype provides no internal criterion for distinguishing
+  productive disruption from destructive deception. When Silicon Valley
+  celebrates "move fast and break things," it is invoking the trickster
+  without acknowledging that what gets broken may be other people's
+  lives, savings, or safety.
+- **Trickster narratives obscure structural power** -- the mythological
+  trickster is typically a marginal figure: small, weak, low-status.
+  But when a billion-dollar company calls itself a "disruptor," it is
+  a giant wearing the trickster's mask. Uber did not hack the taxi
+  industry from a position of marginality; it deployed massive capital
+  to overwhelm regulations designed to protect drivers and passengers.
+  The trickster archetype lets powerful actors perform powerlessness.
+- **The archetype has no theory of responsibility** -- trickster stories
+  often end in chaos. Loki's tricks lead to Ragnarok. Coyote's
+  schemes frequently backfire catastrophically. The myths encode the
+  consequences of trickster behavior, but modern applications tend to
+  invoke only the cleverness, not the collateral damage. "Move fast
+  and break things" is a trickster motto that edited out the part
+  where everything burns.
+- **Cultural flattening** -- calling Loki, Anansi, and Coyote
+  "tricksters" imposes a single Western analytical category on
+  figures that serve radically different functions in their home
+  cultures. Anansi is a wisdom figure and cultural hero. Coyote is
+  a creator deity in some traditions. Reducing them to a behavioral
+  archetype erases the specific cultural meanings they carry.
+
+## Expressions
+
+- "Hack" -- originally a trickster verb: to find an unintended path
+  through a system, now so ubiquitous ("life hack," "growth hack")
+  that the transgressive connotation has faded
+- "Disruptor" -- Clayton Christensen's economic term, now functioning as
+  the trickster's business card
+- "Move fast and break things" -- Facebook's early motto, the trickster
+  creed stripped of consequences
+- "Thinking outside the box" -- the trickster's spatial metaphor:
+  solving problems by leaving the defined space
+- "Social engineering" -- the security term for trickster methods
+  applied to human systems rather than technical ones
+- "Gray hat" -- the hacker who is neither hero nor villain, the
+  trickster's native moral position
+- "Trojan horse" -- the trickster's signature tactical pattern: gaining
+  entry by appearing to be something else
+- "Gaming the system" -- trickster behavior described from the
+  perspective of the system being tricked
+
+## Origin Story
+
+The trickster is arguably the most universal character type in world
+mythology. Lewis Hyde's *Trickster Makes This World* (1998) traces the
+archetype across cultures and argues that the trickster occupies the
+boundary between order and chaos -- not destroying order but keeping it
+from becoming rigid. The trickster is the cultural immune system's
+stress test: by breaking rules in narrative, the culture discovers
+which rules are load-bearing and which are arbitrary.
+
+Carl Jung identified the trickster as an archetypal figure connected to
+the shadow: the repository of traits the conscious personality rejects.
+Paul Radin's earlier *The Trickster* (1956) documented the archetype
+in Winnebago, Greek, and Chinese traditions, establishing it as a
+cross-cultural constant.
+
+The archetype's migration into technology and business discourse
+accelerated with the hacker culture of the 1980s and the startup
+culture of the 2000s, which explicitly celebrated rule-breaking,
+unconventional thinking, and contempt for established institutions.
+
+## References
+
+- Hyde, L. *Trickster Makes This World: Mischief, Myth, and Art*
+  (1998) -- the definitive cross-cultural analysis of trickster figures
+- Radin, P. *The Trickster: A Study in American Indian Mythology*
+  (1956) -- foundational anthropological study
+- Jung, C. G. "On the Psychology of the Trickster Figure" (1954) --
+  the archetypal psychology reading
+- Christensen, C. *The Innovator's Dilemma* (1997) -- disruption theory
+  as formalized trickster economics
+- Mitnick, K. *The Art of Deception* (2002) -- social engineering as
+  explicit trickster practice


### PR DESCRIPTION
## Summary
- Adds `trickster` archetype mapping (mythology -> social-behavior)
- Creative disruption, hacking social systems, the role of the provocateur
- Cross-cultural: Loki, Anansi, Coyote, Hermes, Sun Wukong

Closes #1110
Sub-issue of #219

## Validator
All content valid (0 errors, pre-existing warnings only).

## Test plan
- [x] `uv run scripts/validate.py validate` passes
- [ ] Review body sections for accuracy and tone

Generated with [Claude Code](https://claude.com/claude-code)