### PR TITLE
Add mapping: damocles-sword

### DIFF
--- a/catalog/mappings/damocles-sword.md
+++ b/catalog/mappings/damocles-sword.md
@@ -1,0 +1,131 @@
+---
+slug: damocles-sword
+name: "Damocles' Sword"
+kind: dead-metaphor
+source_frame: mythology
+target_frame: governance
+categories:
+  - mythology-and-religion
+  - law-and-governance
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - excalibur
+---
+
+## What It Brings
+
+Damocles, a courtier of the tyrant Dionysius II of Syracuse, envied the
+king's power and luxury. Dionysius offered to let him sit on the throne
+for a day -- but suspended a sword above it, held by a single horsehair.
+The structural insight: power and existential threat are not separate
+conditions but the same condition viewed from different angles. The sword
+does not arrive later; it was always there. Privilege is the seat;
+precarity is the horsehair.
+
+- **Threat as a structural feature, not an event** -- the sword of
+  Damocles is not an attack. Nobody swings it. It hangs. The metaphor
+  maps threat-as-permanent-condition onto positions of power: the CEO
+  who can be fired by the board at any time, the nuclear state that
+  lives under mutually assured destruction, the tech company whose
+  entire business depends on a platform owner's policy decisions. The
+  danger is not that something might happen but that something is
+  always about to happen.
+- **Awareness transforms the experience of power** -- Damocles could
+  not enjoy the feast once he saw the sword. The metaphor captures how
+  knowledge of risk changes the subjective experience of privilege.
+  A founder who has raised venture capital has money and resources, but
+  also a board, a burn rate, and a clock. The sword is the awareness
+  that the horsehair could snap at any moment. Without that awareness,
+  there is no Damocles metaphor -- just a person at a feast.
+- **The horsehair is the critical detail** -- a sword held by a steel
+  chain would not produce the same metaphor. The horsehair imports
+  fragility: the thing that suspends the threat is disproportionately
+  thin relative to the weight it holds. This maps onto situations where
+  a single point of failure supports an entire system -- a single
+  encryption key, a single regulation, a single treaty, a single
+  relationship with a key client.
+
+## Where It Breaks
+
+- **Damocles chose the seat; most people under threat did not** --
+  Dionysius offered the throne as a lesson, and Damocles accepted
+  voluntarily. The metaphor implies that the person under the sword
+  opted into the risk. But most modern applications describe involuntary
+  exposure: citizens under authoritarian rule, employees in precarious
+  jobs, populations facing climate catastrophe. These people did not
+  ask to sit in the chair. Using the Damocles metaphor for their
+  situation subtly implies they chose their predicament, or at least
+  that the threat is a fair price for something they are receiving.
+- **The original moral is about envy, not risk** -- Cicero, who is our
+  primary source for the story (*Tusculan Disputations*, Book V), tells
+  it to illustrate that the powerful are not to be envied. The lesson
+  is directed at the envious observer, not at the person in power. Modern
+  usage inverts this: "the sword of Damocles" now describes the
+  experience of the threatened person, not the moral correction of the
+  envious one. The metaphor has migrated from a lesson about envy to a
+  label for existential risk, losing its original pedagogical function.
+- **The sword never falls** -- in the story, the horsehair does not
+  break. Damocles asks to leave the throne before anything happens.
+  The metaphor therefore describes anticipated threat, not actual
+  destruction. When people say "the sword of Damocles fell," they are
+  extending the metaphor beyond its source in a way that breaks the
+  original structure. The power of the image depends on the sword
+  staying suspended -- once it falls, it becomes a different metaphor
+  entirely.
+- **Binary framing obscures degrees of risk** -- the sword either hangs
+  or it falls. There is no partial threat, no probability distribution,
+  no risk mitigation. Real-world existential risks exist on a spectrum
+  and can be managed, reduced, insured against, or distributed. The
+  Damocles metaphor makes risk feel absolute and unmanageable, which
+  can induce fatalism rather than rational risk assessment.
+
+## Expressions
+
+- "The sword of Damocles" -- the standard expression for an ever-present
+  threat, so common in English that many speakers do not know the source
+  story
+- "Hanging over someone's head" -- the generic version, fully detached
+  from the myth, used for any looming unresolved threat
+- "Damoclean" -- the adjective form, used in academic and policy writing
+  for threats that are structural rather than episodic (e.g., "Damoclean
+  risk")
+- "A sword hanging by a thread" -- the variant that emphasizes the
+  fragility of the suspension, highlighting the horsehair element
+- "Living under the sword" -- describing the ongoing experience of
+  unresolvable threat, common in geopolitical and nuclear discourse
+
+## Origin Story
+
+The story of Damocles comes from Cicero's *Tusculan Disputations*
+(45 BCE, Book V), where Cicero attributes the anecdote to the historian
+Timaeus. Dionysius II ruled Syracuse from 367 to 357 BCE (and again
+from 346 to 344 BCE), and Damocles was a member of his court. Whether
+Damocles was a historical person or a rhetorical invention of Timaeus
+or Cicero is unknown.
+
+The metaphor entered English in the 18th century and became widely used
+in political rhetoric by the 19th century. It gained particular currency
+during the Cold War, when the nuclear arsenal made the image of a
+civilization-ending threat suspended by fragile deterrence feel
+literally accurate. John F. Kennedy invoked it directly in a 1961
+United Nations address: "Every man, woman, and child lives under a
+nuclear sword of Damocles, hanging by the slenderest of threads."
+
+By the 21st century, "sword of Damocles" is a dead metaphor in most
+contexts. Speakers use it to mean "looming threat" without thinking
+about Dionysius, Damocles, or the horsehair. The phrase "hanging over
+my head" has separated entirely from the myth and functions as a
+standalone idiom.
+
+## References
+
+- Cicero. *Tusculan Disputations*, Book V (45 BCE) -- the primary
+  classical source for the Damocles story
+- Kennedy, J.F. "Address Before the General Assembly of the United
+  Nations" (September 25, 1961) -- the most famous modern invocation
+  of the metaphor, applied to nuclear weapons
+- Westbrook, R. "The Sword of Damocles: Nuclear Proliferation and the
+  Long Shadow of Deterrence" (2007) -- on how the Damocles metaphor
+  shaped Cold War strategic thinking


### PR DESCRIPTION
## Summary

- Adds `damocles-sword` mapping: dead metaphor from Greek mythology for ever-present threat inseparable from power
- Source frame: mythology, Target frame: governance
- Categories: mythology-and-religion, law-and-governance

Closes #1117

## Validator output

All content valid. Zero errors.

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors
- [x] All referenced frames and categories exist

Generated with [Claude Code](https://claude.com/claude-code)