### PR TITLE
Add mapping: gordian-knot

### DIFF
--- a/catalog/mappings/gordian-knot.md
+++ b/catalog/mappings/gordian-knot.md
@@ -1,0 +1,135 @@
+---
+slug: gordian-knot
+name: "Gordian Knot"
+kind: dead-metaphor
+source_frame: mythology
+target_frame: puzzles-and-games
+categories:
+  - mythology-and-religion
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - damocles-sword
+---
+
+## What It Brings
+
+An oracle declared that whoever could untie the impossibly complex knot
+on the ox-cart in Gordium would rule all of Asia. Nobody could. Alexander
+the Great drew his sword and cut it. The structural insight: some problems
+resist analysis because they were never meant to be analyzed -- they were
+meant to be dissolved. The knot is a test of approach, not of dexterity.
+
+- **Intractability as a misidentified problem type** -- the Gordian knot
+  looks like a puzzle (find the end of the rope, trace the path, untie
+  the sequence). But it is not a puzzle; it is a challenge. The people
+  who failed were solving the wrong kind of problem. The metaphor maps
+  onto situations where the difficulty is not in the execution but in
+  the framing: regulatory tangles that require legislative bypass rather
+  than compliance, legacy codebases that should be rewritten rather than
+  refactored, negotiations that need to be abandoned rather than
+  continued.
+- **Boldness as a method** -- Alexander's solution is not clever; it is
+  bold. He does not find a hidden trick. He changes the rules of
+  engagement. The metaphor imports the idea that some problems require
+  not more skill but more willingness to act outside the expected
+  constraints. In business strategy, this maps onto disruptive moves:
+  the company that stops competing in a crowded market and creates a
+  new one, the founder who eliminates the problem rather than solving it.
+- **The knot validates the cutter** -- the oracle did not specify how the
+  knot should be untied. Everyone assumed it had to be untied, but the
+  prophecy was about freeing the yoke, not about method. Alexander's
+  willingness to reinterpret the constraint was itself the qualification
+  for rulership. The metaphor maps onto leadership tests where the
+  ability to reframe the question is more important than the ability to
+  answer it as stated.
+
+## Where It Breaks
+
+- **Most problems are not knots** -- the Gordian knot metaphor flatters
+  the person who cuts through complexity by implying that the complexity
+  was artificial. But many complex problems are genuinely complex:
+  cutting through them destroys necessary structure. A healthcare system
+  is not a knot to be cut; it is a network of interdependencies. The
+  metaphor can license reckless simplification by framing nuance as
+  obstruction.
+- **Cutting is destructive** -- Alexander destroyed the knot. In the
+  story, that is fine because the knot had no purpose beyond being a
+  test. But most real "Gordian knots" are working systems. Cutting a
+  regulatory tangle may also cut the protections the regulations
+  provide. Rewriting a legacy codebase from scratch destroys
+  institutional knowledge embedded in the old code. The metaphor
+  celebrates the cut and ignores the cost.
+- **The metaphor privileges action over understanding** -- people who
+  tried to untie the knot were doing intellectual work: tracing
+  structure, understanding relationships, building mental models.
+  Alexander skipped all of that. The metaphor implicitly ranks decisive
+  action above careful analysis, which is a dangerous preference in
+  domains where understanding the system matters more than eliminating
+  it -- medicine, diplomacy, infrastructure engineering.
+- **The historical basis is thin** -- the primary source is Arrian's
+  *Anabasis* (2nd century CE), written over 400 years after Alexander's
+  campaign. Arrian himself notes multiple versions of the story,
+  including one where Alexander pulled out the linchpin rather than
+  cutting. The story may be propaganda designed to legitimize
+  Alexander's conquest. Using it as a model for problem-solving
+  inherits the legitimation function of the original narrative.
+- **"Cut the Gordian knot" now just means "solve a hard problem"** --
+  the expression has drifted so far from its source that it no longer
+  carries the specific insight about changing approach. Many speakers
+  use it interchangeably with "crack a tough nut" or "break through,"
+  losing the distinction between solving within constraints and
+  abolishing the constraints.
+
+## Expressions
+
+- "Cut the Gordian knot" -- the standard expression, now largely dead:
+  used to mean solving a seemingly intractable problem, usually through
+  bold or unconventional action
+- "A Gordian knot" -- used as a noun for any intractable tangle of
+  interconnected problems, especially in policy and law
+- "Gordian" -- the rare adjective form, used in academic writing for
+  problems characterized by irreducible complexity (e.g., "a Gordian
+  regulatory environment")
+- "Alexander's solution" -- occasional allusion to the cutting approach,
+  used when recommending radical simplification over incremental reform
+- "Untangling the knot" -- the cautious version, implying patient
+  analysis rather than cutting, used by people who prefer the
+  opposite moral from the story
+
+## Origin Story
+
+The knot was tied by Gordius, a peasant who became king of Phrygia
+after an eagle landed on his ox-cart (fulfilling an oracle). He
+dedicated the cart to Zeus and tied the yoke with a knot of cornel bark
+so complex that no one could find the ends. The oracle at Gordium then
+declared that whoever loosed the knot would rule Asia.
+
+Alexander arrived at Gordium in 333 BCE during his campaign against
+Persia. Arrian, writing in the 2nd century CE based on lost accounts
+by Ptolemy and Aristobulus, records that Alexander either cut the knot
+with his sword or pulled out the linchpin of the yoke. Plutarch
+(*Life of Alexander*) gives the cutting version. The story circulated
+widely in the ancient world as a demonstration of Alexander's
+character: his refusal to accept the problem as stated.
+
+The metaphor entered English by the 16th century. Shakespeare uses
+"Gordian knot" in *Henry V* (Act I, Scene 1). By the 19th century,
+"cutting the Gordian knot" was a common political and editorial
+expression for bold, simplifying action. In modern usage, most
+speakers know the phrase but not the story behind it -- a classic
+sign of a dead metaphor.
+
+## References
+
+- Arrian. *Anabasis of Alexander*, Book II (c. 150 CE) -- the most
+  detailed ancient account, noting variant traditions about the
+  cutting versus linchpin removal
+- Plutarch. *Life of Alexander* (c. 100 CE) -- the cutting version,
+  more dramatically told
+- Shakespeare, W. *Henry V*, Act I, Scene 1 (1599) -- early English
+  literary use of the metaphor
+- Christensen, C. *The Innovator's Dilemma* (1997) -- though not
+  referencing the metaphor directly, describes the structural logic
+  of disruptive innovation that "cutting the knot" maps onto


### PR DESCRIPTION
## Summary

- Adds `gordian-knot` mapping: dead metaphor from Greek mythology for intractable problems solved by reframing
- Source frame: mythology, Target frame: puzzles-and-games
- Categories: mythology-and-religion

Closes #1118

## Validator output

All content valid. Zero errors.

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors
- [x] All referenced frames and categories exist

Generated with [Claude Code](https://claude.com/claude-code)