### PR TITLE
Add mapping: scylla-and-charybdis

### DIFF
--- a/catalog/frames/decision-making.md
+++ b/catalog/frames/decision-making.md
@@ -1,0 +1,24 @@
+---
+slug: decision-making
+name: "Decision-Making"
+related:
+  - causal-reasoning
+  - gambling
+  - competition
+roles:
+  - decision-maker
+  - option
+  - constraint
+  - tradeoff
+  - risk
+  - outcome
+  - deadline
+---
+
+The process of choosing among alternatives under uncertainty. As a
+target domain, decision-making is structured by metaphors of paths
+(choosing a direction), containers (being boxed in), warfare (strategic
+positioning), and gambling (weighing odds). The frame is productive
+because decisions are cognitively invisible -- we experience the
+options and consequences but not the choosing itself -- which makes
+metaphor essential for talking about the process.

--- a/catalog/mappings/scylla-and-charybdis.md
+++ b/catalog/mappings/scylla-and-charybdis.md
@@ -1,0 +1,163 @@
+---
+slug: scylla-and-charybdis
+name: Scylla and Charybdis
+kind: conceptual-metaphor
+source_frame: mythology
+target_frame: decision-making
+categories:
+  - mythology-and-religion
+  - social-dynamics
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - damocles-sword
+  - excalibur
+---
+
+## What It Brings
+
+In Homer's *Odyssey* (Book XII), Odysseus must sail through a narrow
+strait flanked by two monsters. Scylla is a six-headed creature on a
+cliff who snatches and devours sailors; Charybdis is a whirlpool that
+swallows entire ships. The passage is too narrow to avoid both. Circe
+advises Odysseus to steer closer to Scylla and sacrifice six men rather
+than risk the whole ship to Charybdis. The metaphor maps this
+geography of compulsory loss onto any decision where every available
+option entails significant harm.
+
+- **Both options are dangerous; neither is safe** -- the defining
+  structural feature. Unlike a simple risk-reward tradeoff where one
+  option is risky and the other is safe, Scylla and Charybdis present
+  a choice between two distinct modes of destruction. The metaphor
+  applies when the decision-maker cannot escape harm -- only choose
+  its form. Regulatory policy (privacy vs. security), engineering
+  design (performance vs. reliability), and medical treatment
+  (side effects of treatment vs. progression of disease) all exhibit
+  this structure.
+- **The dangers are qualitatively different** -- Scylla is precise,
+  targeted, and partial. She takes six men -- a known, bounded loss.
+  Charybdis is total and indiscriminate -- she swallows the whole
+  ship. The metaphor maps this asymmetry onto decisions where one
+  option produces a definite, limited loss and the other produces a
+  catastrophic but probabilistic one. This is precisely the structure
+  of insurance decisions, hedging strategies, and engineering safety
+  margins: accept a known small cost (Scylla) to avoid a possible
+  total loss (Charybdis).
+- **The strait forces the choice** -- Odysseus cannot turn around,
+  wait, or find another route. The passage must be made now. The
+  metaphor imports this time pressure and spatial constraint: the
+  decision-maker is committed to a path and must choose between the
+  dangers that line it. This maps onto situations where prior
+  commitments (contracts signed, resources spent, deadlines set) have
+  eliminated the option of doing nothing.
+- **Expert advice shapes the framing** -- Circe, who knows the
+  strait, tells Odysseus which danger to prefer. Without her, he
+  might have steered for the middle and lost everything. The metaphor
+  carries this advisory structure: navigating between equally bad
+  options requires someone who knows the terrain and can reframe the
+  choice as "which loss is more survivable" rather than "how do I
+  avoid all loss."
+- **The surviving crew is traumatized** -- Odysseus gets through the
+  strait, but the experience scars his crew and haunts the narrative.
+  The metaphor acknowledges that surviving a forced-loss decision is
+  not the same as emerging unharmed. The leader who chose correctly
+  still bears the weight of what was sacrificed. This maps onto the
+  emotional residue of hard organizational decisions: layoffs, product
+  kills, strategic retreats.
+
+## Where It Breaks
+
+- **Most real decisions have more than two options** -- the narrow
+  strait with exactly two flanking dangers is a geographical
+  convenience. Real decision spaces are multidimensional. A company
+  choosing between two bad strategies could also pivot, merge, pause,
+  or exit the market entirely. The Scylla-Charybdis metaphor
+  artificially constrains the option space to a binary, which can
+  prevent creative problem-solving. The metaphor is most dangerous
+  when it is used to pre-empt the question "is there a third option?"
+- **The metaphor assumes the dangers are fixed** -- Scylla and
+  Charybdis do not negotiate, move, or change their behavior. Real
+  adversaries, market conditions, and regulatory environments are
+  dynamic. The decision that was "steer toward Scylla" yesterday may
+  be wrong today because Scylla has moved. The mythological framing
+  imports a static geometry that real decision-making rarely exhibits.
+- **Circe's advice assumes perfect knowledge** -- she knows exactly
+  what Scylla and Charybdis will do. Real advisors operate under
+  uncertainty. The metaphor suggests that the correct choice between
+  two dangers is knowable in advance if you consult the right expert.
+  But many forced-choice situations involve genuine uncertainty about
+  the magnitude and probability of each danger, and expert opinion
+  may be divided or wrong.
+- **The heroic framing obscures systemic failure** -- "we navigated
+  between Scylla and Charybdis" positions the decision-maker as a
+  brave captain who chose the lesser evil. But it does not ask how
+  the ship ended up in that strait in the first place. In many
+  organizational contexts, the "forced choice between two bad
+  options" is itself a failure of earlier planning, not an act of
+  nature. The mythological framing naturalizes the dilemma and
+  discourages examination of the decisions that created it.
+- **Six men is not an acceptable loss in most ethical frameworks** --
+  Circe's calculus (sacrifice six to save the rest) is consequentialist
+  and treats the six sailors as expendable. Applied to organizational
+  decisions, this structure can rationalize sacrificing individuals or
+  groups for collective benefit without adequate moral scrutiny. "We
+  had to choose Scylla" can become a formula for avoiding
+  accountability for the people who were harmed by the choice.
+
+## Expressions
+
+- "Between Scylla and Charybdis" -- the classical idiom for being
+  forced to choose between two dangers, understood by educated
+  speakers as a Homeric reference
+- "Between a rock and a hard place" -- the vernacular English
+  equivalent, fully detached from the myth, used for any no-win
+  choice
+- "Navigating the strait" -- the softened version, emphasizing the
+  skill required to pass through rather than the dangers that line
+  the passage
+- "Caught between two fires" -- a military variant of the same
+  structure, mapping crossfire onto the flanking-dangers geometry
+- "The lesser of two evils" -- the abstract formulation that drops
+  the mythological imagery entirely but preserves the core structure
+  of forced choice among harmful options
+- "Steering toward Scylla" -- choosing the known, bounded loss over
+  the catastrophic uncertainty, used in risk management and strategic
+  planning
+
+## Origin Story
+
+Scylla and Charybdis appear in Book XII of Homer's *Odyssey* (c. 8th
+century BCE). Circe warns Odysseus of the strait and advises him to
+pass close to Scylla's cliff rather than risk Charybdis' whirlpool.
+The passage is one of the most famous episodes in the poem, and its
+geography has been tentatively identified with the Strait of Messina
+between Sicily and mainland Italy, where real currents and rock
+formations produce navigational hazards.
+
+The idiom "between Scylla and Charybdis" entered Latin through Virgil
+and became a standard expression in European languages by the medieval
+period. Unlike many classical idioms that have faded into dead
+metaphor, this one retains its mythological awareness in educated
+usage -- speakers who invoke Scylla and Charybdis generally know they
+are referring to the *Odyssey*. The vernacular equivalent "between a
+rock and a hard place" (American English, early 20th century) serves
+speakers who want the same structure without the classical baggage.
+
+The phrase gained renewed currency in game theory and decision science,
+where the structure of forced choice between two losses is formalized
+in concepts like "dilemma," "tradeoff," and "minimax." The
+mythological version remains useful because it adds what formal
+decision theory lacks: the emotional weight of the choice, the
+irreversibility of the passage, and the trauma of surviving it.
+
+## References
+
+- Homer. *Odyssey*, Book XII -- the canonical account of Odysseus'
+  passage through the strait, including Circe's advice
+- Virgil. *Aeneid*, Book III, lines 420-432 -- the Roman retelling
+  that transmitted the idiom into Latin literary culture
+- Kahneman, D. & Tversky, A. "Prospect Theory: An Analysis of
+  Decision Under Risk," *Econometrica* 47(2), 1979 -- the formal
+  framework for understanding why people evaluate losses differently,
+  which explains the psychological structure the myth captures


### PR DESCRIPTION
## Summary

- Adds `scylla-and-charybdis` mapping as a **conceptual-metaphor** from Homer's *Odyssey*
- Maps the narrow strait flanked by two monsters onto forced choice between two harmful options
- Creates new `decision-making` target frame (existing frames did not capture this target domain)
- Covers the asymmetric risk structure (bounded vs. catastrophic loss), Circe's advisory role, and connections to game theory and prospect theory
- Validator passes with zero errors

Closes #1126

## Validation

```
✓ uv run scripts/validate.py validate — 0 errors
```

Generated with [Claude Code](https://claude.com/claude-code)