### PR TITLE
Add mapping: pyrrhic-victory

### DIFF
--- a/catalog/mappings/pyrrhic-victory.md
+++ b/catalog/mappings/pyrrhic-victory.md
@@ -1,0 +1,136 @@
+---
+slug: pyrrhic-victory
+name: "Pyrrhic Victory"
+kind: dead-metaphor
+source_frame: mythology
+target_frame: competition
+categories:
+  - mythology-and-religion
+  - economics-and-finance
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - damocles-sword
+---
+
+## What It Brings
+
+King Pyrrhus of Epirus defeated the Romans at Heraclea (280 BCE) and
+Asculum (279 BCE), but his losses were so severe that he reportedly
+said, "If we are victorious in one more battle with the Romans, we
+shall be utterly ruined." The structural insight: winning and losing
+are not always opposites. A victory that depletes the victor's
+capacity to continue is functionally a defeat wearing the costume of
+success.
+
+- **The cost ledger outlives the scoreboard** -- Pyrrhus won on the
+  field but lost on the balance sheet. The metaphor imports
+  cost-accounting into domains that normally track only outcomes. A
+  lawsuit won after five years of legal fees and management
+  distraction is a Pyrrhic victory. A market share war won by pricing
+  below cost is a Pyrrhic victory. The metaphor forces attention away
+  from the result and toward what was spent to achieve it.
+- **Victory as resource depletion** -- Pyrrhus could not replace his
+  elite troops; Rome could. The asymmetry was not in fighting ability
+  but in replenishment capacity. The metaphor maps onto any contest
+  where one side has deeper reserves: a startup that outspends a
+  competitor to win a contract but burns through its runway, a nation
+  that wins a war but exhausts its treasury and political will. The
+  question the metaphor asks is not "who won?" but "who can afford
+  to win again?"
+- **The winner's blindspot** -- victories produce celebrations,
+  promotions, and narratives of success. Pyrrhic victory names the
+  cognitive bias that makes it hard to recognize a win as a loss while
+  the garlands are still fresh. The metaphor is almost always applied
+  retrospectively -- the Pyrrhic nature of a victory becomes visible
+  only after the costs accumulate and the capacity for further action
+  is tested.
+
+## Where It Breaks
+
+- **The metaphor assumes a single ledger** -- "Pyrrhic victory" works
+  when costs and benefits can be measured in the same currency: troops
+  lost versus territory gained, money spent versus revenue won. But
+  many real conflicts involve incommensurable values. A civil rights
+  court case that costs millions but establishes a legal precedent is
+  not a Pyrrhic victory just because the financial costs exceeded the
+  financial award. The metaphor struggles with situations where the
+  gains and costs exist in different currencies.
+- **Pyrrhus's problem was strategic, not conceptual** -- Pyrrhus lost
+  because he fought far from home against an enemy with superior
+  manpower reserves. This is a strategic miscalculation, not a paradox
+  of victory. Calling something a "Pyrrhic victory" can mystify what
+  is really a straightforward failure of planning, making bad strategy
+  sound like an existential paradox rather than a correctable error.
+- **The metaphor discourages necessary sacrifice** -- sometimes victory
+  at high cost is still the right choice. Churchill's Britain in 1940
+  paid an enormous price to continue fighting, and the eventual victory
+  left the country financially exhausted and stripped of empire. But
+  calling that outcome a Pyrrhic victory would be perverse. The
+  metaphor can be weaponized to argue against any costly but necessary
+  struggle by framing all expensive wins as self-defeating.
+- **Binary framing of victory and defeat** -- the metaphor refines the
+  binary (this victory is actually a defeat) but does not escape it.
+  Real outcomes are rarely pure victories or defeats. A product launch
+  that captures less market share than projected but establishes brand
+  recognition is neither victory nor defeat -- it is a mixed result.
+  "Pyrrhic victory" only applies to the subset of outcomes that look
+  like wins but function as losses, missing the larger space of
+  ambiguous results.
+- **Historical Pyrrhus was not a fool** -- the modern usage implies
+  that pursuing a Pyrrhic victory is an error. But Pyrrhus was a
+  skilled commander who may have had valid reasons to fight (alliance
+  obligations, reputation, the possibility that Rome would negotiate).
+  The metaphor strips away context to produce a parable about waste,
+  which is a simpler and less useful story than the actual history.
+
+## Expressions
+
+- "Pyrrhic victory" -- the standard expression, now so common that most
+  speakers do not know who Pyrrhus was or what battles are referenced
+- "Another such victory and we are undone" -- the paraphrase of
+  Pyrrhus's remark, used in editorial and political commentary
+- "Won the battle, lost the war" -- the folk equivalent that conveys
+  the same structure without the classical allusion
+- "At what cost?" -- the rhetorical question the metaphor teaches
+  listeners to ask after any announced victory
+- "Pyrrhic" -- the standalone adjective, used in academic and business
+  writing (e.g., "a Pyrrhic acquisition," "a Pyrrhic market share
+  gain")
+
+## Origin Story
+
+The historical Pyrrhus (319-272 BCE) was king of Epirus (modern
+northwestern Greece and southern Albania) and one of the most talented
+military commanders of the Hellenistic period. Hannibal reportedly
+ranked him second only to Alexander among generals. His Italian
+campaign (280-275 BCE) brought him into conflict with the Roman
+Republic, and his victories at Heraclea and Asculum demonstrated
+tactical brilliance but strategic unsustainability.
+
+The remark about being "utterly ruined" by another victory is recorded
+by Plutarch (*Life of Pyrrhus*, c. 100 CE). Whether Pyrrhus actually
+said it is unknowable, but the attribution was established early enough
+to shape the metaphor's development.
+
+"Pyrrhic victory" entered English in the 19th century and became a
+standard expression in military, political, and business writing by the
+20th century. Its use expanded dramatically during and after World War I,
+when the concept of winning at catastrophic cost became disturbingly
+literal. Today, the expression is used across domains -- business,
+law, politics, sports, personal relationships -- and functions as a
+dead metaphor. Most speakers who say "Pyrrhic victory" could not
+identify Pyrrhus, his opponents, or the battles in question.
+
+## References
+
+- Plutarch. *Life of Pyrrhus* (c. 100 CE) -- the primary source for
+  Pyrrhus's remark and the narrative of his Italian campaign
+- Diodorus Siculus. *Library of History*, fragments (c. 60 BCE) --
+  earlier account, partly lost
+- Champion, J. *Pyrrhus of Epirus* (2009) -- modern military history
+  contextualizing the campaigns and their strategic logic
+- Tirole, J. "The Theory of Industrial Organization" (1988) -- on
+  price wars and market competition where the logic of Pyrrhic victory
+  applies to economic strategy


### PR DESCRIPTION
## Summary

- Adds `pyrrhic-victory` mapping: dead metaphor from Greek history for victory so costly it functions as defeat
- Source frame: mythology, Target frame: competition
- Categories: mythology-and-religion, economics-and-finance

Closes #1120

## Validator output

All content valid. Zero errors.

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors
- [x] All referenced frames and categories exist

Generated with [Claude Code](https://claude.com/claude-code)