### PR TITLE
Add mapping: tantalus

### DIFF
--- a/catalog/mappings/tantalus.md
+++ b/catalog/mappings/tantalus.md
@@ -1,0 +1,134 @@
+---
+slug: tantalus
+name: Tantalus
+kind: dead-metaphor
+source_frame: mythology
+target_frame: mental-experience
+categories:
+  - mythology-and-religion
+  - psychology
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - damocles-sword
+  - augean-stables
+---
+
+## What It Brings
+
+Tantalus, king of Sipylus, was condemned to stand in a pool of water beneath
+a fruit tree for eternity. When he reached for the fruit, the branches
+withdrew. When he stooped to drink, the water receded. The punishment was not
+deprivation but proximity: the desired thing was always almost within reach,
+never quite attainable. The metaphor maps this structure -- visible,
+approachable, but permanently ungratifiable desire -- onto psychological
+experience and everyday frustration.
+
+- **The object of desire is perceptible but inaccessible** -- "a tantalizing
+  glimpse," "a tantalizing offer." The word preserves the myth's core
+  structure: you can see, smell, almost touch the thing you want, but
+  the final step of acquisition is blocked. This is distinct from mere
+  absence. The tantalizing thing is present enough to activate desire and
+  absent enough to prevent satisfaction.
+- **Proximity intensifies suffering** -- the cruelty of Tantalus's
+  punishment is not that he cannot have water and fruit. It is that they
+  are right there. The metaphor captures the psychological insight that
+  nearness to a desired outcome amplifies frustration. A lottery ticket
+  one digit off the winning number is more painful than one that misses
+  entirely. A job candidate who reaches the final round and is rejected
+  suffers more than one who never applied.
+- **The cycle repeats indefinitely** -- Tantalus does not try once and give
+  up. He reaches, fails, recovers, reaches again. The metaphor maps this
+  repetitive structure onto experiences of recurring almost-success: the
+  startup that almost closes funding, the writer who almost lands the
+  agent, the team that almost wins the championship, year after year.
+- **The word has fully detached from its source** -- "tantalizing" is used
+  by millions of speakers who have never heard of Tantalus. It appears on
+  restaurant menus, in perfume advertisements, and in clickbait headlines.
+  The mythological origin is invisible; the word functions as a pure
+  adjective meaning "attractively out of reach."
+
+## Where It Breaks
+
+- **Tantalus deserved his punishment; most tantalizing situations are
+  amoral** -- in the myth, Tantalus committed horrific crimes: he served
+  his own son Pelops as a meal to the gods, testing their omniscience. His
+  punishment was divine justice for specific transgressions. But "tantalizing"
+  carries no moral freight. A tantalizing dessert menu is not punishment for
+  sin. The metaphor has shed the entire ethical structure of the source
+  narrative, keeping only the phenomenology of frustrated desire.
+- **The mythological tantalization is eternal; real tantalization is
+  temporary** -- Tantalus's punishment has no end. Real tantalizing
+  experiences are transient: eventually you eat the dessert, get the job,
+  or stop wanting it. The metaphor imports a feeling of endlessness that
+  rarely matches reality, which is why it works best for momentary
+  sensations ("a tantalizing aroma") rather than sustained conditions.
+- **The metaphor erases the active agent** -- the gods designed Tantalus's
+  punishment. Someone decided that the water would recede and the branches
+  would withdraw. But "tantalizing" in modern usage implies no torturer.
+  A tantalizing possibility just happens to be attractive and unreachable;
+  there is no malicious architect behind it. The metaphor strips away agency
+  and intentionality, converting deliberate torture into accidental
+  frustration.
+- **"Tantalize" has acquired a positive valence** -- perhaps the most
+  dramatic breakage. Tantalus's experience is pure suffering: unrelieved,
+  unending frustration designed as punishment. But "tantalizing" is
+  frequently a compliment. A tantalizing trailer for a film, a tantalizing
+  hint of what's to come, a tantalizing preview -- these are desirable.
+  The word has migrated from naming torture to naming pleasurable
+  anticipation. The metaphor now endorses the sensation it was coined to
+  condemn.
+- **The myth is about punishment for hubris; the word is about appetite** --
+  Tantalus's story is ultimately about the consequences of transgressing
+  divine boundaries. But the English word is about wanting things: food,
+  information, experiences. The entire cosmological and moral framework
+  has been discarded in favor of a narrow sensory-appetitive meaning.
+
+## Expressions
+
+- "Tantalizing" -- the dominant surviving form, meaning attractively just
+  out of reach, used so commonly that no mythological awareness is required
+  or expected
+- "A tantalizing glimpse" -- the most frequent collocation, naming a brief
+  partial view that stimulates desire to see more
+- "Tantalize the taste buds" -- food writing's favored cliche, reducing an
+  eternal divine punishment to a pleasant sensation before dinner
+- "Tantalizing offer" -- in negotiation and marketing, an offer attractive
+  enough to engage interest but not yet accepted, preserving the structure
+  of desire-without-consummation
+- "Tantalizingly close" -- the adverbial form that most faithfully preserves
+  the myth's structure: almost there, not quite, the gap between reach and
+  grasp
+
+## Origin Story
+
+Tantalus appears in Homer's *Odyssey* (Book 11), where Odysseus sees him
+in the Underworld standing in water that drains away when he bends to
+drink, beneath fruit trees whose branches the wind lifts when he reaches
+for them. Pindar's first *Olympian Ode* gives the alternate punishment of
+a stone suspended above his head (later merged with Damocles in popular
+confusion). The crime varies by source: Pindar says he stole nectar and
+ambrosia from the gods' table; the more gruesome tradition (Apollodorus,
+Hyginus) has him killing and cooking his son Pelops to test the gods.
+
+"Tantalize" entered English in the late 16th century, initially carrying
+the full weight of the myth: to tantalize someone was to torment them
+with unattainable desires. By the 18th century, the word had softened.
+By the 20th century, "tantalizing" was a standard positive adjective in
+food criticism and advertising, and the mythological connection was
+effectively dead for most speakers. The tantalus -- a locked case
+displaying but securing liquor decanters -- preserves the original
+punitive sense in a minor domestic object.
+
+## References
+
+- Homer. *Odyssey*, Book 11.582-592 -- the earliest surviving description
+  of Tantalus's punishment in the Underworld
+- Pindar. *Olympian Ode* 1 -- the alternate tradition of Tantalus's crime
+  and punishment, emphasizing the theft of divine food
+- Apollodorus. *Bibliotheca*, Epitome 2.1-2.3 -- the infanticide tradition,
+  where Tantalus serves Pelops to the gods
+- "Tantalize" in *Oxford English Dictionary* -- documents the semantic
+  shift from mythological torment to everyday enticement across four
+  centuries of English usage


### PR DESCRIPTION
## Summary

- Adds `tantalus` mapping as a `dead-metaphor` from Greek mythology
- Source frame: `mythology`, target frame: `mental-experience`
- Tantalus's punishment of proximity-without-satisfaction survives in "tantalizing," now fully detached from its mythological source
- All required frames already exist

Closes #1127

## Validator output

```
All content valid.
```

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors

Generated with [Claude Code](https://claude.com/claude-code)