### PR TITLE
Add mapping: procrustean-bed

### DIFF
--- a/catalog/mappings/procrustean-bed.md
+++ b/catalog/mappings/procrustean-bed.md
@@ -1,0 +1,145 @@
+---
+slug: procrustean-bed
+name: "Procrustean Bed"
+kind: dead-metaphor
+source_frame: mythology
+target_frame: social-behavior
+categories:
+  - mythology-and-religion
+  - social-dynamics
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - gordian-knot
+---
+
+## What It Brings
+
+Procrustes, a bandit from Greek mythology, offered travelers a bed for
+the night. If the guest was too short, he stretched them on a rack. If
+too tall, he amputated the excess. The bed always fit -- because the
+guest was made to fit the bed, not the other way around. The structural
+insight: when a standard is enforced by mutilating whatever does not
+conform, the problem is the standard, not the non-conformity.
+
+- **The standard precedes the thing it measures** -- Procrustes does not
+  examine his guests and build beds to suit them. The bed exists first,
+  and the guest is altered to match. The metaphor maps onto any system
+  where the framework is fixed and the data, people, or reality must be
+  deformed to fit: standardized tests that measure compliance rather than
+  understanding, job descriptions that screen out capable candidates who
+  lack arbitrary credentials, data models that force real-world
+  complexity into rigid schemas.
+- **Enforced conformity destroys the thing it claims to serve** --
+  Procrustes kills his guests while claiming to provide hospitality. The
+  metaphor captures the paradox of systems that harm their stated
+  beneficiaries through the mechanism of standardization. A healthcare
+  protocol that requires a 15-minute appointment for every patient
+  regardless of condition stretches some encounters and amputates others,
+  serving the schedule rather than the patient.
+- **Two modes of violence: stretching and cutting** -- the metaphor
+  provides two specific operations, not just one. Stretching maps onto
+  inflation (padding a resume to meet requirements, inflating metrics to
+  hit targets, extending a project to fill a budget cycle). Cutting maps
+  onto reduction (simplifying a complex argument to fit a tweet, cutting
+  features to meet a deadline, excluding edge cases to fit a model). Both
+  are Procrustean -- the metaphor names the structural equivalence of
+  inflation and reduction when both serve a fixed template.
+
+## Where It Breaks
+
+- **The metaphor implies a villain** -- Procrustes is a bandit who
+  deliberately tortures travelers. Real Procrustean systems usually lack
+  a villain. Standardized testing was designed with good intentions
+  (equity, comparability, scalability). Bureaucratic forms are meant to
+  create fairness through consistency. The metaphor imports malice into
+  situations that are more often the product of institutional inertia,
+  resource constraints, or genuine attempts at fairness. Calling a
+  system "Procrustean" can shut down discussion of whether the
+  standardization has legitimate purposes.
+- **Some standardization is necessary and beneficial** -- the metaphor
+  is purely pejorative. But interchangeable parts, building codes,
+  medical dosing protocols, and electrical standards all work precisely
+  because they impose uniform requirements and reject what does not
+  conform. A screw that does not fit the standard thread is not a victim
+  of Procrustean violence; it is a defective part. The metaphor
+  provides no vocabulary for distinguishing between harmful
+  standardization and necessary standardization.
+- **The bed is not always arbitrary** -- Procrustes's bed has no
+  rational basis; its dimensions are meaningless. But many real
+  standards are based on evidence, consensus, or physical constraints.
+  A bridge's load limit is not a Procrustean imposition; it is an
+  engineering requirement. The metaphor treats all fixed standards as
+  equally arbitrary, which can undermine legitimate constraints by
+  framing them as oppressive.
+- **The metaphor is asymmetric in practice** -- "Procrustean" is almost
+  always used to criticize standardization from the perspective of the
+  exception, the outlier, the non-conforming case. This makes it a tool
+  for special pleading: anyone who does not fit a standard can invoke
+  Procrustes to frame the standard as violent. The metaphor does not
+  help distinguish between legitimate exceptions and cases that
+  genuinely should conform.
+- **Nassim Taleb's inversion** -- Taleb uses "Procrustean bed" in *The
+  Black Swan* and *Antifragile* to describe the tendency to force
+  messy reality into neat models, particularly in finance and
+  statistics. This is a productive extension, but it has also made the
+  metaphor a general-purpose weapon against quantitative modeling,
+  sometimes deployed against models that are genuinely useful despite
+  being imperfect.
+
+## Expressions
+
+- "Procrustean bed" -- the full expression, used in academic and
+  editorial writing for any system that enforces conformity by
+  deforming its subjects
+- "Procrustean" -- the adjective, used for standards, frameworks, or
+  policies that force-fit diverse cases into a single template
+- "One-size-fits-all" -- the folk equivalent, conveying the same
+  criticism without the classical allusion
+- "Fitting the data to the model" -- the statistical version: adjusting
+  observations to match a theory rather than revising the theory
+- "Cookie-cutter approach" -- another folk equivalent, emphasizing the
+  uniformity of output rather than the violence of the process
+- "Stretching or cutting to fit" -- the explicit invocation of
+  Procrustes's two operations, used when distinguishing between
+  inflation and reduction
+
+## Origin Story
+
+Procrustes (also called Damastes or Polypemon) appears in the myth
+cycle of Theseus. He was a rogue smith and bandit who kept a house by
+the road between Athens and Eleusis. Theseus killed him by subjecting
+him to his own treatment -- placing him on the bed and cutting him to
+fit -- in one of the labors Theseus performed on his way to Athens.
+
+The primary ancient sources are Apollodorus (*Bibliotheca*, c. 1st-2nd
+century CE), Diodorus Siculus (*Library of History*, c. 60 BCE), and
+Plutarch (*Life of Theseus*, c. 100 CE). The myth is part of the
+broader Theseus cycle, which parallels the labors of Heracles and
+served to establish Athens's heroic founding narrative.
+
+"Procrustean" entered English in the 19th century as a literary and
+philosophical adjective. It gained wider currency in the 20th century,
+particularly in criticism of bureaucracy, standardized education, and
+quantitative social science. Nassim Nicholas Taleb's use in *The Black
+Swan* (2007) and *Antifragile* (2012) brought the metaphor to a
+broader audience, specifically as a critique of forcing complex,
+fat-tailed reality into normal distributions and linear models.
+
+Today the metaphor is semi-dead: educated speakers generally know
+the reference, but "one-size-fits-all" has largely replaced it in
+common usage. "Procrustean" survives mainly in academic, editorial,
+and policy writing.
+
+## References
+
+- Apollodorus. *Bibliotheca*, Epitome I (c. 1st-2nd century CE) --
+  the fullest ancient account of Procrustes in the Theseus cycle
+- Plutarch. *Life of Theseus* (c. 100 CE) -- the biographical
+  treatment, embedding Procrustes in the political mythology of Athens
+- Taleb, N.N. *The Black Swan* (2007) -- modern popularization of the
+  metaphor as a critique of forcing complex reality into neat models
+- Taleb, N.N. *Antifragile* (2012) -- extends the Procrustean
+  critique to systems that eliminate variability rather than learning
+  from it


### PR DESCRIPTION
## Summary

- Adds `procrustean-bed` mapping: dead metaphor from Greek mythology for enforcing conformity by deforming non-conforming subjects
- Source frame: mythology, Target frame: social-behavior
- Categories: mythology-and-religion, social-dynamics

Closes #1121

## Validator output

All content valid. Zero errors.

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors
- [x] All referenced frames and categories exist

Generated with [Claude Code](https://claude.com/claude-code)