### PR TITLE
Add mapping: sphinx-riddle

### DIFF
--- a/catalog/mappings/sphinx-riddle.md
+++ b/catalog/mappings/sphinx-riddle.md
@@ -1,0 +1,143 @@
+---
+slug: sphinx-riddle
+name: Sphinx Riddle
+kind: archetype
+source_frame: mythology
+target_frame: social-behavior
+categories:
+  - mythology-and-religion
+  - social-dynamics
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - augean-stables
+  - damocles-sword
+---
+
+## What It Brings
+
+The Sphinx sat outside Thebes and posed a riddle to every traveler: "What
+walks on four legs in the morning, two at noon, and three in the evening?"
+Those who answered wrong were devoured. Oedipus answered correctly -- man --
+and the Sphinx destroyed itself. The pattern maps onto any situation where
+passage, advancement, or survival depends on answering a gatekeeper's
+challenge correctly, with severe consequences for failure.
+
+- **Access is conditional on intellectual performance** -- the Sphinx does
+  not ask for payment, credentials, or loyalty. It asks a question. You
+  pass or you die. The archetype maps onto technical interviews, doctoral
+  defenses, security challenge questions, and any gatekeeping mechanism
+  where the key is knowledge rather than status or force. The power
+  asymmetry is total: the gatekeeper sets the terms, and the traveler
+  must perform on demand.
+- **The challenge has exactly one correct answer** -- the Sphinx's riddle
+  is not a conversation or a negotiation. There is one right answer and
+  all others are fatal. This maps onto pass/fail evaluations where
+  partial credit does not exist: bar exams, licensing tests, security
+  clearances, compliance audits. The binary structure -- correct or
+  devoured -- eliminates the middle ground where most real assessment
+  operates.
+- **The gatekeeper is destroyed by the correct answer** -- this is the
+  most structurally interesting element. The Sphinx does not congratulate
+  Oedipus and step aside. It kills itself. The archetype suggests that
+  some gatekeeping mechanisms are sustained by the mystique of their
+  challenge. Once someone demonstrates that the riddle is solvable, the
+  gatekeeper's power evaporates. Monopolies broken by an innovation,
+  credentialing bodies undermined by open-access alternatives, and
+  bureaucratic barriers bypassed by a legal challenge all follow this
+  structure.
+- **The riddle is about self-knowledge** -- the answer to the Sphinx's
+  riddle is "man" -- the very species of the person being asked. The
+  archetype captures situations where the challenge is not external
+  knowledge but self-understanding. "Who are you? What is your nature?
+  What do you become?" These are the questions that organizational
+  consultants, therapists, and strategists pose as gatekeeping challenges.
+- **The pattern recurs across domains** -- fairy-tale bridge trolls, tech
+  interview whiteboard challenges, Monty Python's Bridge of Death, the
+  riddle game in *The Hobbit*, escape room puzzles, CAPTCHAs. The
+  archetype of a guardian who demands a correct answer before granting
+  passage is one of the most widely distributed narrative structures in
+  human culture.
+
+## Where It Breaks
+
+- **Real gatekeeping rarely has one correct answer** -- the Sphinx's
+  riddle has a single solution. But most institutional gatekeeping
+  involves judgment, ambiguity, and multiple acceptable responses. A job
+  interview is not a riddle with one answer; a doctoral defense does not
+  have a password. The archetype's clean binary (right answer = passage,
+  wrong answer = death) obscures the subjective, negotiated, and often
+  arbitrary nature of real gatekeeping.
+- **The myth assumes the challenge is fair** -- the Sphinx poses the same
+  riddle to everyone. Real gatekeeping is often rigged: different questions
+  for different applicants, standards that shift depending on who is asking,
+  unwritten rules that insiders know and outsiders do not. The archetype
+  implies a meritocratic structure (anyone who knows the answer passes)
+  that rarely exists in practice.
+- **Destroying the gatekeeper is rarely the outcome** -- Oedipus's correct
+  answer annihilates the Sphinx. But answering a job interview correctly
+  does not destroy the interview process. Passing the bar exam does not
+  eliminate the bar. Most real gatekeeping mechanisms survive the passage
+  of successful candidates. The archetype's dramatic resolution -- the
+  gate falls forever once solved -- flatters revolutionaries and misleads
+  reformers.
+- **The Sphinx does not learn** -- it poses the same riddle to every
+  traveler. Real gatekeeping adapts: interview questions change, security
+  challenges rotate, regulatory requirements evolve. The archetype models
+  a static, solvable challenge, but most institutional gates are dynamic
+  and resist permanent solutions.
+- **Oedipus's reward is catastrophe** -- this is the detail the archetype
+  consistently suppresses. Oedipus passes the Sphinx's test and enters
+  Thebes, where he unknowingly marries his mother and murders his father.
+  The riddle's answer -- "man" -- is ironic: the man who knows what man is
+  does not know who he himself is. The archetype of triumphant
+  riddle-solving omits the aftermath where getting past the gate leads
+  to ruin.
+
+## Expressions
+
+- "Riddle of the Sphinx" -- a challenge that seems impossible but has a
+  simple, elegant answer, applied to scientific puzzles, business problems,
+  and diagnostic mysteries
+- "Sphinxlike" -- inscrutably silent and threatening, describing anyone
+  who guards information behind an impassive facade
+- "Answer the riddle" -- to solve the key problem that unlocks everything
+  else, implying that complex situations have a single decisive question
+- "Gatekeeper" -- the generalized descendant of the Sphinx, now standard
+  vocabulary in organizational theory, journalism, and platform economics
+- "You shall not pass" -- the pop-culture echo (Tolkien, via Gandalf) of
+  the Sphinx's structural role: a guardian on a threshold who demands
+  something before granting passage
+- "Prove you're not a robot" -- CAPTCHAs as the digital Sphinx, posing a
+  challenge that (theoretically) only humans can answer
+
+## Origin Story
+
+The Sphinx appears in Hesiod's *Theogony* as a daughter of Orthrus and
+Chimera (or of Typhon and Echidna), but the riddle episode is best known
+from Sophocles' *Oedipus Rex* (c. 429 BCE) and later from Apollodorus'
+*Bibliotheca*. The Egyptian sphinx is older and structurally different --
+a guardian figure without the riddle tradition -- but the two merged in
+Greek cultural imagination.
+
+The riddle itself ("What has one voice and walks on four legs, then two,
+then three?") appears in variant forms across ancient sources. Its answer
+-- a human being, who crawls as an infant, walks upright in maturity, and
+uses a cane in old age -- makes the riddle a meditation on the human
+condition disguised as a puzzle. The archetype's cross-cultural persistence
+(bridge trolls in Norse mythology, riddle contests in Sanskrit epics,
+the riddle game in Anglo-Saxon tradition) suggests that the pattern of
+intellectual gatekeeping resonates across very different cultural contexts.
+
+## References
+
+- Sophocles. *Oedipus Rex* (c. 429 BCE) -- the canonical dramatic
+  treatment, though the riddle scene itself occurs before the play's
+  action begins
+- Apollodorus. *Bibliotheca*, 3.5.8 -- the fullest ancient prose account
+  of the riddle and the Sphinx's destruction
+- Hesiod. *Theogony*, 326-328 -- the Sphinx's genealogy as a monstrous
+  offspring of primordial beings
+- Edmunds, L. *The Sphinx in the Oedipus Legend* (1981) -- scholarly
+  analysis of the Sphinx tradition across Greek sources


### PR DESCRIPTION
## Summary

- Adds `sphinx-riddle` mapping as an `archetype` from Greek/Egyptian mythology
- Source frame: `mythology`, target frame: `social-behavior`
- The Sphinx's riddle as the universal pattern of intellectual gatekeeping — passage depends on answering a guardian's challenge correctly
- Recurs across myths (bridge trolls), tech (interview whiteboarding, CAPTCHAs), and institutions (bar exams, doctoral defenses)
- All required frames already exist

Closes #1128

## Validation

✓ `uv run scripts/validate.py validate` — 0 errors

Generated with [Claude Code](https://claude.com/claude-code)