### PR TITLE
Add mapping: augean-stables

### DIFF
--- a/catalog/mappings/augean-stables.md
+++ b/catalog/mappings/augean-stables.md
@@ -1,0 +1,142 @@
+---
+slug: augean-stables
+name: Augean Stables
+kind: dead-metaphor
+source_frame: mythology
+target_frame: governance
+categories:
+  - mythology-and-religion
+  - law-and-governance
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - hydra-code
+  - damocles-sword
+---
+
+## What It Brings
+
+King Augeas of Elis kept vast herds of cattle whose stables had not been
+cleaned in thirty years. The filth was so deep and so old that no ordinary
+effort could remove it. Heracles, as his fifth labor, diverted two rivers
+through the stables and flushed them clean in a single day. The metaphor
+maps accumulated institutional filth -- corruption, technical debt,
+regulatory cruft, bureaucratic dysfunction -- onto a physical space so
+fouled that only a radical, nonstandard intervention can restore it.
+
+- **Accumulation over time is the core problem** -- the stables are not
+  dirty because of one bad event. They are dirty because nobody cleaned
+  them for thirty years. The metaphor captures the specific failure mode
+  of deferred maintenance: each day's neglect is trivial, but the
+  cumulative result is catastrophic. Applied to organizations, it names
+  the condition where years of small compromises, ignored warnings, and
+  "we'll fix it later" decisions have produced a mess that no longer
+  yields to incremental effort.
+- **Normal methods are insufficient** -- the point of the myth is not
+  that the stables were hard to clean. It is that shoveling -- the normal
+  method -- could not work at the scale of filth involved. Heracles did
+  not shovel faster; he changed the approach entirely by diverting rivers.
+  The metaphor argues that some institutional messes require a
+  fundamentally different kind of intervention: a new regulatory
+  framework, a complete rewrite, a change of leadership, a structural
+  reorganization rather than more of the same effort applied harder.
+- **The mess is somebody else's responsibility** -- Augeas owned the
+  stables. Heracles was brought in from outside. The metaphor often
+  carries this structure: the new CEO inherits the predecessor's
+  corruption, the incoming government inherits the previous
+  administration's debt, the new engineering lead inherits the legacy
+  codebase. The Augean framing positions the cleaner as a heroic outsider
+  confronting someone else's long-neglected problem.
+- **The cleanup is a single decisive act** -- Heracles did not clean the
+  stables gradually over weeks. He diverted the rivers and it was done in
+  a day. The metaphor imports this temporal compression: an Augean cleanup
+  is imagined as a dramatic, one-time event rather than a slow process.
+  This maps onto political rhetoric ("drain the swamp") and corporate
+  turnarounds ("clean house") where the promise is swift, total renewal.
+
+## Where It Breaks
+
+- **Institutional messes cannot be flushed with a river** -- Heracles'
+  solution is physical and mechanical: water in, filth out. But the
+  accumulated dysfunction of a government agency, a codebase, or a
+  corporate culture is not a substance that can be washed away. It is
+  embedded in relationships, processes, incentive structures, and
+  institutional memory. The metaphor's most seductive feature -- the
+  promise of a single decisive intervention -- is also its most
+  dangerous. Real institutional reform is slow, partial, and iterative,
+  nothing like diverting a river.
+- **The metaphor ignores what the water destroys** -- diverting a river
+  through a building is not a precision operation. It removes the filth,
+  but it also damages the structure, destroys anything useful that was
+  mixed in with the mess, and floods the surrounding area. Applied to
+  organizations, this maps onto the collateral damage of radical reform:
+  the competent employees who leave during a restructuring, the useful
+  processes that are discarded along with the dysfunctional ones, the
+  institutional knowledge that is lost when you "clean house."
+- **Augeas refused to pay** -- in the myth, Augeas promised Heracles a
+  tenth of his cattle as payment, then reneged when the job was done,
+  arguing that the rivers had done the work, not Heracles. The metaphor
+  rarely includes this detail, but it is structurally significant:
+  those who benefit from institutional cleanup often refuse to credit or
+  compensate the cleaner. Reformers are frequently punished by the
+  institutions they reform.
+- **The stables get dirty again** -- the myth treats the cleanup as
+  permanent: labor completed, move on to the next. But stables that hold
+  cattle will accumulate waste again tomorrow. The metaphor has no
+  vocabulary for maintenance, ongoing hygiene, or the systemic changes
+  needed to prevent re-accumulation. It frames reform as a heroic episode
+  rather than a permanent practice.
+- **Thirty years is suspiciously precise** -- the mythological
+  exaggeration (no cleaning for three decades) makes the metaphor feel
+  applicable only to extreme cases. This can prevent people from
+  recognizing moderate accumulations of institutional dysfunction as
+  Augean in character. You do not need thirty years of neglect to produce
+  a mess that resists incremental cleanup; five years of deferred
+  maintenance can do it.
+
+## Expressions
+
+- "Cleaning the Augean stables" -- the standard idiom for undertaking a
+  massive cleanup of accumulated institutional mess, often used without
+  awareness of the mythological source
+- "An Augean task" -- any job so large and so dirty that normal effort
+  seems futile, frequently applied to regulatory reform, legacy code
+  migration, or organizational restructuring
+- "Herculean effort" -- the related but distinct idiom that emphasizes
+  the strength required rather than the nature of the mess, often used
+  interchangeably but structurally different
+- "Drain the swamp" -- a political variant that borrows the same
+  structural logic (accumulated filth requiring radical drainage) without
+  the classical reference
+- "Clean house" -- the domesticated version, applied to organizational
+  purges and leadership changes
+
+## Origin Story
+
+The Augean stables appear in the canonical list of the Twelve Labors of
+Heracles, attested in Apollodorus' *Bibliotheca* (c. 1st-2nd century CE)
+and Diodorus Siculus' *Library of History* (1st century BCE). The detail
+about diverting the rivers Alpheus and Peneus comes from Apollodorus.
+In some traditions, this labor was disqualified by Eurystheus because
+Heracles had been promised payment, making it a commercial transaction
+rather than a true labor -- an ironic detail given that Augeas never paid.
+
+The idiom entered English by the 17th century and was common in political
+rhetoric by the 19th century, particularly in reform movements targeting
+government corruption. By the 20th century, "Augean" had become a
+standard adjective for any situation of overwhelming accumulated filth,
+though its frequency has declined as classical literacy has waned. Most
+contemporary speakers who use the phrase know it means "a huge mess" but
+cannot identify Augeas, Heracles, or the rivers involved.
+
+## References
+
+- Apollodorus. *Bibliotheca*, Book 2.5.5 -- the canonical account of
+  the fifth labor, including the river-diversion strategy
+- Diodorus Siculus. *Library of History*, Book 4.13 -- an earlier account
+  that emphasizes the scale of the herds and the impossibility of normal
+  cleaning
+- "Augean" in *Oxford English Dictionary* -- documents English usage from
+  the 17th century onward, tracking the shift from classical allusion to
+  general-purpose adjective


### PR DESCRIPTION
## Summary

- Adds `augean-stables` mapping as a **dead-metaphor** from Greek mythology
- Maps accumulated institutional filth (corruption, technical debt, bureaucratic dysfunction) onto the Heracles labor of cleaning King Augeas' thirty-year-uncleaned stables
- Uses existing `mythology` source frame and `governance` target frame
- Validator passes with zero errors

Closes #1122

## Test plan

- [x] `uv run scripts/validate.py validate` passes (zero errors, only pre-existing dangling-reference warnings)
- [ ] Review mapping body sections for accuracy and depth
- [ ] Verify `kind: dead-metaphor` is correct (source domain is invisible to most users of the idiom)

Generated with [Claude Code](https://claude.com/claude-code)