### PR TITLE
Add mapping: cerberus

### DIFF
--- a/catalog/mappings/cerberus.md
+++ b/catalog/mappings/cerberus.md
@@ -1,0 +1,155 @@
+---
+slug: cerberus
+name: Cerberus
+kind: dead-metaphor
+source_frame: mythology
+target_frame: network-security
+categories:
+  - mythology-and-religion
+  - security
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - damocles-sword
+  - excalibur
+---
+
+## What It Brings
+
+Cerberus is the three-headed dog that guards the entrance to the Greek
+underworld. He lets the dead enter but prevents them from leaving, and
+he prevents the living from entering at all. The structural role is
+precise: Cerberus is not a weapon, not a warrior, not a wall. He is a
+gatekeeper -- an entity that inspects arrivals, applies a policy (dead
+may enter, living may not), and enforces it with overwhelming force.
+
+- **The gatekeeper is not the boundary** -- Cerberus does not block the
+  entrance physically. The entrance exists; the River Styx has been
+  crossed; the gates of Hades stand open. Cerberus is the enforcement
+  logic at the threshold. This maps precisely onto authentication
+  systems: the network port is open, the API endpoint exists, the login
+  page is visible. The access control system -- the Cerberus -- decides
+  who passes. The MIT Kerberos protocol (named via the Latin spelling)
+  embodies this structure directly: it is an authentication service that
+  sits at the boundary between trusted and untrusted zones.
+- **Three heads map to multi-factor verification** -- ancient sources
+  vary on the number of heads (Hesiod says fifty, later tradition
+  standardizes on three), but the three-headed version imports a
+  structural idea: the gatekeeper examines the arrival from multiple
+  angles simultaneously. This maps onto multi-factor authentication,
+  where identity is verified through multiple independent channels.
+  The Kerberos protocol uses a three-party model (client, server,
+  key distribution center) that its designers explicitly connected to
+  the three heads.
+- **The gatekeeper is selectively permeable** -- Cerberus is not a
+  sealed door. He has a policy: shades of the dead pass freely; living
+  heroes must find a way past him (Orpheus with music, Heracles with
+  strength, the Sibyl with a drugged cake for Aeneas). The metaphor
+  captures the idea that access control is not binary lockout but
+  conditional passage. Different credentials produce different outcomes.
+- **Ferocity as deterrence** -- Cerberus is terrifying. Most of the
+  dead do not try to leave; most of the living do not try to enter.
+  The gatekeeper's visible ferocity reduces the load on actual
+  enforcement. In security, this maps onto the deterrence function of
+  visible authentication barriers: CAPTCHAs, challenge questions, and
+  multi-step login flows discourage casual attackers before any real
+  cryptographic work is done.
+
+## Where It Breaks
+
+- **Cerberus can be bypassed** -- every hero who needs to get past
+  Cerberus succeeds. Orpheus charms him with music, Heracles wrestles
+  him into submission, the Sibyl drugs him with a honey cake. The
+  mythological gatekeeper is repeatedly defeated by cleverness, force,
+  or deception. This is an uncomfortable structural parallel for
+  security systems: it suggests that any sufficiently determined attacker
+  will find a way through. But security engineering aspires to build
+  systems that cannot be bypassed by clever individuals, and the
+  Cerberus metaphor subtly undermines confidence in that aspiration.
+- **The gatekeeper has no logging** -- Cerberus reacts to arrivals in
+  real time but maintains no record of who passed, when, or under what
+  conditions. Modern authentication systems depend critically on audit
+  trails, session logs, and anomaly detection. The mythological
+  gatekeeper is purely reactive -- he guards the moment of passage but
+  has no memory and no ability to revoke access after the fact. The
+  metaphor imports a model of security as a single checkpoint rather
+  than a continuous monitoring process.
+- **One entrance assumes one perimeter** -- Cerberus guards the gates
+  of Hades because there is one entrance. Modern networks have
+  thousands of entry points: APIs, ports, user interfaces, third-party
+  integrations. The single-gatekeeper model maps poorly onto
+  distributed systems where the perimeter is everywhere and nowhere.
+  Zero-trust security architectures explicitly reject the Cerberus
+  model, arguing that every request must be authenticated, not just
+  those crossing a single threshold.
+- **The metaphor conflates authentication with authorization** --
+  Cerberus decides both who you are (dead or alive) and what you may
+  do (enter or not). In modern security, these are separate concerns:
+  authentication verifies identity, authorization determines
+  permissions. Conflating them, as the Cerberus metaphor does, can
+  lead to systems where proving your identity is treated as sufficient
+  for full access -- the "once you're past the gate, you're trusted"
+  antipattern.
+- **Cerberus serves a single master** -- Hades commands Cerberus,
+  and the dog's loyalty is absolute and unquestionable. Real
+  authentication systems serve multiple stakeholders with competing
+  interests: users want convenience, administrators want control,
+  regulators want auditability, attackers probe for weaknesses. The
+  mythological simplicity of a single master with total authority over
+  access policy obscures the political complexity of real access
+  control.
+
+## Expressions
+
+- "Kerberos authentication" -- the MIT protocol named after the
+  Latinized form, now the standard authentication protocol in
+  Windows Active Directory environments, used by millions who have
+  no idea they are invoking a three-headed dog
+- "The cerberus of the organization" -- a fierce gatekeeper, usually
+  an executive assistant, IT administrator, or compliance officer who
+  controls access to resources or people
+- "Getting past the three-headed dog" -- navigating a multi-step
+  authentication or approval process
+- "Guard dog" -- the generic descendant, fully detached from
+  mythology, used for any software component that protects a
+  resource from unauthorized access
+- "Watchdog process" -- a software process that monitors system
+  health and terminates misbehaving processes, inheriting the
+  canine guardian metaphor without the mythological specificity
+
+## Origin Story
+
+Cerberus appears in the earliest Greek literary sources: Hesiod's
+*Theogony* (c. 700 BCE) describes him as the fifty-headed hound of
+Hades, while later tradition (Apollodorus, Virgil) standardized the
+three-headed version. The capturing of Cerberus was the twelfth and
+final labor of Heracles, considered the most dangerous because it
+required entering the underworld alive.
+
+The metaphorical leap to computing was made explicit in 1988, when
+Steve Miller and Clifford Neuman at MIT named their network
+authentication protocol "Kerberos" (using the Latin spelling). The
+three-party architecture (client, server, Key Distribution Center)
+was deliberately mapped onto the three heads. The protocol became a
+foundational component of enterprise computing when Microsoft adopted
+it as the default authentication mechanism in Windows 2000.
+
+By the 2020s, "Kerberos" is a dead metaphor in IT: system
+administrators configure Kerberos tickets daily without thinking about
+Greek mythology. The broader use of "cerberus" for any fierce
+gatekeeper has faded from common English, surviving mainly in
+literary and academic contexts, but the protocol keeps the name alive
+in technical vocabulary.
+
+## References
+
+- Hesiod. *Theogony* (c. 700 BCE), lines 310-312 -- the earliest
+  literary reference to the hound of Hades
+- Apollodorus. *Bibliotheca*, Book 2.5.12 -- the twelfth labor of
+  Heracles, capturing Cerberus
+- Neuman, B.C. & Ts'o, T. "Kerberos: An Authentication Service for
+  Computer Networks," *IEEE Communications* 32(9), 1994 -- the
+  technical description of the protocol and its naming rationale
+- Garman, J. *Kerberos: The Definitive Guide* (O'Reilly, 2003) --
+  comprehensive reference that opens with the mythological connection


### PR DESCRIPTION
## Summary

- Adds `cerberus` mapping as a **dead-metaphor** from Greek mythology
- Maps the three-headed guardian of Hades onto authentication and access control systems
- Covers the MIT Kerberos protocol naming, multi-factor authentication parallels, and the gatekeeper-as-policy-enforcer structure
- Uses existing `mythology` source frame and `network-security` target frame
- Validator passes with zero errors

Closes #1123

## Validation

```
✓ uv run scripts/validate.py validate — 0 errors
```

Generated with [Claude Code](https://claude.com/claude-code)