### PR TITLE
Add mapping: elysium

### DIFF
--- a/catalog/mappings/elysium.md
+++ b/catalog/mappings/elysium.md
@@ -1,0 +1,153 @@
+---
+slug: elysium
+name: Elysium
+kind: dead-metaphor
+source_frame: mythology
+target_frame: social-behavior
+categories:
+  - mythology-and-religion
+  - social-dynamics
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - excalibur
+  - damocles-sword
+---
+
+## What It Brings
+
+In Greek mythology, Elysium (or the Elysian Fields) is the section of
+the underworld reserved for heroes and the virtuous dead -- a place of
+eternal rest, beauty, and ease, separated from the ordinary afterlife
+of the asphodel meadows and from the punishments of Tartarus. The
+metaphor maps this afterlife geography onto social and political
+aspiration: an Elysium is a state of perfected existence that the
+living can imagine but never fully reach.
+
+- **The ideal as a separate place** -- Elysium is not a condition of
+  the living world improved; it is a fundamentally different location.
+  The metaphor imports this spatial separation: the ideal society,
+  the ideal workplace, the ideal community is always somewhere else,
+  categorically distinct from the flawed present. "Elysian" branding
+  (neighborhoods, resorts, product lines) promises not improvement but
+  transport -- you are not upgrading your life, you are entering a
+  different realm.
+- **Entry is earned, not universal** -- Elysium is exclusive. Only
+  heroes and those favored by the gods reside there; ordinary shades
+  go to the asphodel meadows. The metaphor maps this selectivity onto
+  aspirational communities, gated developments, elite institutions,
+  and premium service tiers. An "Elysian" experience is one that is
+  defined as much by who is excluded as by what is included. The
+  metaphor naturalizes exclusivity by framing it as merit-based
+  sorting rather than arbitrary gatekeeping.
+- **Permanence and timelessness** -- Elysium is eternal. The heroes
+  there do not age, struggle, or change. The metaphor maps this stasis
+  onto utopian thinking: the perfect state, once achieved, requires no
+  further effort. This is deeply attractive and deeply misleading.
+  Real communities, organizations, and systems require continuous
+  maintenance. The Elysian promise of a stable endpoint -- "we will
+  build it once and it will be perfect forever" -- is the structural
+  seduction at the heart of utopian planning.
+- **The afterlife framing implies the present is death** -- if Elysium
+  is the good afterlife, then the current state of affairs is
+  implicitly the bad one. The metaphor can be used to frame ordinary
+  life as suffering from which Elysium offers escape. This structure
+  appears in marketing ("escape to Elysium"), political rhetoric
+  ("our movement will create a new world"), and tech utopianism
+  ("the metaverse will transcend physical limitations").
+
+## Where It Breaks
+
+- **Elysium is for the dead** -- the most fundamental structural
+  problem. In the myth, you reach Elysium by dying. The heroes there
+  have left the world of action, struggle, and growth. Applied to
+  living aspirations, the metaphor quietly imports the idea that
+  perfection requires the cessation of life as it is actually lived.
+  A community that achieves Elysium -- no conflict, no change, no
+  struggle -- is not thriving; it is stagnant. The metaphor mistakes
+  the absence of life's difficulties for the presence of life's goods.
+- **The myth provides no path from here to there** -- mortals do not
+  build Elysium. The gods designate it, and the worthy are transported
+  there after death. The metaphor offers a destination but no
+  construction plan. This is the central weakness of utopian metaphors:
+  they describe the end state vividly but say nothing about the
+  political, economic, or social process of getting there. "We want
+  to create an Elysium" is not a plan; it is a wish.
+- **Exclusivity undermines the ideal** -- Elysium is perfect partly
+  because most people are not there. If everyone could enter, it would
+  become the asphodel meadows. The metaphor smuggles in the idea that
+  an ideal state necessarily requires excluding the unworthy. Applied
+  to real communities, this produces gated enclaves that define
+  themselves by exclusion -- the paradise depends on keeping most
+  people out, which is a morally uncomfortable foundation for any
+  ideal.
+- **Eternal sameness is not desirable** -- Elysium does not change.
+  The heroes feast and rest forever. But human flourishing requires
+  challenge, growth, and the possibility of failure. An unchanging
+  paradise is, in practice, a prison. The metaphor cannot account for
+  the paradox that the conditions people imagine as ideal (no
+  conflict, no scarcity, no uncertainty) would, if actually achieved,
+  produce boredom and meaninglessness.
+- **The metaphor has been commercially flattened** -- "Elysian" in
+  contemporary usage often means nothing more than "luxury" or
+  "premium." The Elysian Fields apartment complex, the Elysium spa,
+  the Elysian product tier. The mythological depth -- the afterlife
+  geography, the merit-based selection, the finality of death -- is
+  stripped away, leaving only a vaguely classical-sounding synonym
+  for "nice." This commercial dead-metaphor usage coexists with the
+  richer metaphorical use, creating ambiguity about which Elysium a
+  speaker intends.
+
+## Expressions
+
+- "Elysian Fields" -- the full classical name, used for neighborhoods,
+  streets, and public spaces (the Champs-Elysees in Paris is literally
+  "Elysian Fields"), often by people who do not know the mythological
+  reference
+- "Elysium" -- an ideal state or place, used in film titles (the 2013
+  Neill Blomkamp film about orbital luxury), product branding, and
+  literary writing
+- "Elysian" -- the adjective meaning blissful, ideal, or heavenly,
+  largely detached from its mythological source and functioning as a
+  general-purpose synonym for "idyllic"
+- "Champs-Elysees" -- the Parisian avenue, the most globally visible
+  survival of the metaphor, whose name is understood by most visitors
+  as meaning "fancy street" rather than "fields of the blessed dead"
+- "A place like Elysium" -- aspirational language in urban planning,
+  real estate, and community design for idealized living spaces
+
+## Origin Story
+
+Elysium first appears in Homer's *Odyssey* (c. 8th century BCE, Book
+IV), where Menelaus is told he will not die but will be sent to the
+Elysian plain at the ends of the earth because he is the son-in-law
+of Zeus. In this earliest version, Elysium is not part of the
+underworld but a separate earthly paradise. Hesiod's *Works and Days*
+describes the Isles of the Blessed, a closely related concept.
+
+The relocation of Elysium to the underworld occurs in later tradition,
+most influentially in Virgil's *Aeneid* (Book VI, 19 BCE), where
+Aeneas visits his father Anchises in the Elysian Fields within Hades.
+Virgil's geography -- Elysium as a blessed district within the
+underworld, adjacent to but separate from Tartarus -- became the
+standard model that passed into Western literary culture.
+
+The metaphorical use in English dates to the Renaissance, and by the
+18th century "Elysian" was a standard adjective for any ideal or
+blissful place. The naming of the Champs-Elysees (1709) cemented the
+association between the classical afterlife and worldly luxury. By the
+21st century, the mythological source is largely invisible in everyday
+use: "Elysian" functions as a prestige adjective whose classical
+origins are felt as vaguely elevated rather than specifically
+mythological.
+
+## References
+
+- Homer. *Odyssey*, Book IV, lines 561-569 -- the earliest literary
+  reference to the Elysian plain
+- Virgil. *Aeneid*, Book VI -- the canonical description of Elysium
+  as a district within the underworld
+- Blomkamp, N. *Elysium* (2013) -- science fiction film that uses the
+  myth as a direct structural metaphor for wealth inequality and
+  spatial segregation


### PR DESCRIPTION
## Summary

- Adds `elysium` mapping as a **dead-metaphor** from Greek mythology
- Maps the afterlife paradise reserved for heroes onto utopian aspiration, exclusivity, and idealized community design
- Covers Champs-Elysees, commercial branding, the Blomkamp film, and the structural problems with utopian metaphors
- Uses existing `mythology` source frame and `social-behavior` target frame
- Validator passes with zero errors

Closes #1124

## Validation

```
✓ uv run scripts/validate.py validate — 0 errors
```

Generated with [Claude Code](https://claude.com/claude-code)