### PR TITLE
Add mapping: faustian-bargain

### DIFF
--- a/catalog/mappings/faustian-bargain.md
+++ b/catalog/mappings/faustian-bargain.md
@@ -1,0 +1,158 @@
+---
+slug: faustian-bargain
+name: Faustian Bargain
+kind: archetype
+source_frame: mythology
+target_frame: economics
+categories:
+  - mythology-and-religion
+  - ethics-and-morality
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - damocles-sword
+  - augean-stables
+---
+
+## What It Brings
+
+Doctor Faustus sells his soul to the devil in exchange for twenty-four years
+of unlimited knowledge, power, and pleasure. The bargain is explicit: you
+get everything you want now, and you pay with everything you are later. The
+archetype maps this structure onto any transaction where short-term gain
+comes at the price of long-term, often irreversible, destruction -- and
+where the person making the deal knows, or should know, the cost at the
+time of signing.
+
+- **The terms are clear; the trade is voluntary** -- Faust is not tricked.
+  Mephistopheles states the price explicitly: your soul, at the end of
+  the term. Faust signs in blood. The archetype insists that the
+  worst bargains are not the ones where you are deceived but the ones
+  where you understand the cost and agree anyway. This maps onto the
+  executive who takes the golden parachute knowing the company will suffer,
+  the politician who accepts the donation knowing the policy cost, the
+  addict who understands the consequences and uses anyway.
+- **The payment is incommensurable with the reward** -- Faust gets
+  knowledge, pleasure, and power -- temporal goods. He pays with his
+  soul -- an eternal good. The archetype captures transactions where the
+  currencies are fundamentally different and cannot be rationally compared:
+  trading health for money, privacy for convenience, democratic norms for
+  electoral victory, environmental stability for quarterly earnings. The
+  Faustian structure makes the incommensurability visible.
+- **The enjoyment period obscures the reckoning** -- for twenty-four years,
+  the deal looks brilliant. Faust has everything. The cost is deferred,
+  abstract, and easy to forget. The archetype maps onto any situation where
+  delayed consequences create an illusion of costlessness: technical debt
+  that enables rapid shipping, deficit spending that funds popular programs,
+  fossil fuel energy that powers prosperity while accumulating atmospheric
+  carbon. The Faustian bargain is specifically about the temporal gap
+  between benefit and payment.
+- **The pattern recurs across every domain** -- tech companies trading user
+  privacy for growth, nations trading sovereignty for economic integration,
+  individuals trading integrity for advancement, startups trading
+  sustainability for scale. The archetype is not bound to any single field
+  because its structure -- short-term gain, long-term ruin, voluntary
+  agreement -- describes a universal decision failure.
+- **Renegotiation is impossible** -- Faust cannot renegotiate with
+  Mephistopheles when the term expires. The deal is final. The archetype
+  maps this irreversibility onto commitments that cannot be unwound:
+  environmental damage that cannot be reversed, trust that cannot be
+  restored, precedents that cannot be unset. The Faustian element is not
+  just that the price is high but that the transaction is one-way.
+
+## Where It Breaks
+
+- **Most real bargains are not with the devil** -- Faust's counterparty
+  is a supernatural agent of pure malice who wants Faust's soul for
+  its own sake. Real counterparties in asymmetric bargains -- venture
+  capitalists, employers, governments -- have mixed motives and are
+  not ontologically evil. The archetype's moral clarity (the deal is with
+  the devil, therefore it is wrong) does not transfer cleanly to
+  situations where the counterparty is an ordinary institution offering
+  ordinary terms that happen to be unfavorable.
+- **The metaphor assumes the decision-maker knows the cost** -- Faust
+  is explicitly told the price. But many real Faustian bargains are
+  identified only in retrospect, when the bill comes due. The CFC
+  manufacturers of the 1960s did not know they were trading the ozone
+  layer for refrigerant convenience. Calling a deal "Faustian" implies
+  foreknowledge that may not have existed, retroactively assigning blame
+  for what was genuinely uncertain.
+- **Faust gets supernatural powers; most bargains deliver mundane
+  returns** -- the literary Faust receives the ability to travel through
+  time, summon the dead, and command spirits. The grandeur of the reward
+  makes the trade seem almost reasonable. Real Faustian bargains typically
+  involve far more modest gains -- a quarterly earnings bump, a slightly
+  faster product launch, a marginal political advantage -- which makes
+  them harder to dramatize and easier to rationalize.
+- **Redemption is possible in some versions** -- Goethe's Faust is
+  ultimately saved. The angels snatch his soul from Mephistopheles because
+  Faust's striving redeems him. This contradicts the archetype's core
+  message that the deal is irreversible. If the Faustian bargain can be
+  escaped through sufficient virtue, it is not really a Faustian bargain.
+  The two major literary traditions (Marlowe: damned; Goethe: saved)
+  encode fundamentally different attitudes toward the possibility of
+  redemption from bad decisions.
+- **The binary framing obscures intermediate outcomes** -- Faust either
+  keeps his soul or loses it. But most real bargains produce outcomes on
+  a spectrum. The company that traded quality for growth might end up
+  somewhat diminished, not destroyed. The politician who made one
+  compromise might recover credibility. The archetype's all-or-nothing
+  structure makes every bad deal look like damnation, which can produce
+  fatalism ("we've already sold our soul, so nothing matters now") or
+  false drama.
+
+## Expressions
+
+- "A Faustian bargain" -- the standard idiom for any deal that trades
+  long-term well-being for short-term advantage, especially when the
+  trader understands the cost
+- "Selling your soul" -- the generalized descendant, now applied to any
+  moral compromise for material gain, fully detached from the Faust
+  narrative in everyday usage
+- "A deal with the devil" -- the colloquial equivalent, applicable to
+  any alliance with a partner whose interests are fundamentally opposed
+  to yours
+- "Faustian pact" -- the variant emphasizing the contractual nature of
+  the arrangement, favored in political and diplomatic commentary
+- "The bill comes due" -- the moment when deferred Faustian costs
+  materialize, used in finance, politics, and environmental discourse
+- "Mephistophelean" -- adjective for the tempter who offers attractive
+  terms with hidden or deferred costs, rarely used outside literary
+  criticism
+
+## Origin Story
+
+The historical Georg Faust (c. 1480-1540) was a German itinerant
+alchemist, astrologer, and self-promoter who acquired a reputation for
+black magic during his lifetime. After his death (reportedly in an
+alchemical explosion), legends accumulated rapidly. The anonymous German
+*Faustbuch* (1587) -- *Historia von D. Johann Fausten* -- crystallized
+the story into its canonical form: a scholar who sells his soul to the
+devil for twenty-four years of knowledge and power.
+
+Christopher Marlowe's *The Tragical History of the Life and Death of
+Doctor Faustus* (c. 1592) brought the story to the English stage, ending
+with Faust's damnation. Goethe's *Faust* (Part 1, 1808; Part 2, 1832)
+transformed the story into a philosophical epic and, crucially, redeemed
+its protagonist. The two endings -- Marlowe's damnation and Goethe's
+salvation -- created the interpretive split that persists in the
+metaphor's usage: some speakers mean "a deal you cannot escape" and
+others mean "a deal you might survive if you strive hard enough."
+
+The phrase "Faustian bargain" became common in English political and
+ethical discourse in the 20th century, particularly during the Cold War,
+where it described alliances with authoritarian regimes for strategic
+advantage.
+
+## References
+
+- Anonymous. *Historia von D. Johann Fausten* (1587) -- the original
+  Faustbuch that established the narrative template
+- Marlowe, C. *The Tragical History of Doctor Faustus* (c. 1592) -- the
+  English dramatic version ending in damnation
+- Goethe, J.W. von. *Faust* (Part 1, 1808; Part 2, 1832) -- the
+  philosophical reinterpretation that complicates the archetype by
+  offering redemption
+- Berman, M. *All That Is Solid Melts into Air* (1982) -- reads the Faust
+  legend as a metaphor for modernity's trade of stability for progress


### PR DESCRIPTION
## Summary

- Adds `faustian-bargain` mapping as an `archetype` from Germanic/Christian tradition
- Source frame: `mythology`, target frame: `economics`
- Maps the Faust legend's structure of trading long-term well-being for short-term gain onto business, politics, technology, and environmental decisions
- Covers Marlowe vs. Goethe endings, incommensurable currencies, deferred costs
- All required frames already exist

Closes #1130

## Validation

✓ `uv run scripts/validate.py validate` — 0 errors

Generated with [Claude Code](https://claude.com/claude-code)