### PR TITLE
Add mapping: pied-piper

### DIFF
--- a/catalog/mappings/pied-piper.md
+++ b/catalog/mappings/pied-piper.md
@@ -1,0 +1,159 @@
+---
+slug: pied-piper
+name: Pied Piper
+kind: archetype
+source_frame: mythology
+target_frame: social-behavior
+categories:
+  - mythology-and-religion
+  - social-dynamics
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - faustian-bargain
+  - damocles-sword
+---
+
+## What It Brings
+
+The Pied Piper of Hamelin rid the town of rats by playing his pipe,
+leading the vermin to the river where they drowned. When the townspeople
+refused to pay, he played again -- and this time the children followed
+him, vanishing into a mountain or a cave, never to return. The archetype
+maps this structure onto any situation where a charismatic figure attracts
+followers through irresistible appeal, and where the followers' trust
+proves catastrophically misplaced.
+
+- **The leader's power is attraction, not coercion** -- the Pied Piper
+  does not force the rats or the children to follow. They choose to, drawn
+  by the music. The archetype captures a specific kind of influence:
+  not the authority of a boss, not the violence of a tyrant, but the
+  magnetism of someone who makes following feel voluntary and pleasurable.
+  The demagogue whose crowds feel liberated, the startup founder whose
+  employees feel inspired, the guru whose disciples feel enlightened --
+  all follow the Pied Piper structure when the attraction masks a harmful
+  destination.
+- **The followers cannot resist** -- the children hear the music and they
+  follow. There is no deliberation, no weighing of alternatives. The
+  archetype maps onto the experience of being swept up by charisma,
+  rhetoric, or a compelling vision to the point where critical judgment
+  is suspended. Cult dynamics, market manias, political movements that
+  demand total loyalty -- all exhibit this quality of attraction that
+  overwhelms rational evaluation.
+- **The true agenda is hidden** -- the Piper's music is beautiful. His
+  purpose is revenge. The archetype insists on the gap between the
+  leader's public appeal and private motive. The investors who follow
+  a charismatic fund manager do not know he is running a Ponzi scheme.
+  The voters who follow a populist do not know the policies will harm
+  them. The Pied Piper pattern specifically names the situation where
+  the leader's attractiveness is the mechanism of betrayal.
+- **The community is complicit** -- Hamelin's citizens broke their
+  promise. They hired the Piper, benefited from his service (the rats
+  were gone), and then refused to pay. The archetype preserves this
+  detail: the community's own bad faith creates the conditions for the
+  Piper's revenge. The leader who turns destructive often does so in
+  response to genuine grievances. The archetype does not excuse the
+  Piper, but it does indict the town.
+- **The followers are the most vulnerable** -- the Piper does not punish
+  the adults who broke the contract. He takes the children, who are
+  innocent and defenseless. The archetype maps onto situations where the
+  consequences of following a charismatic leader fall hardest on those
+  least able to protect themselves: the rank-and-file employees of the
+  fraudulent company, the small investors in the collapsing fund, the
+  ordinary citizens of the failing state.
+
+## Where It Breaks
+
+- **The original Piper has a legitimate grievance** -- this is the detail
+  that modern usage almost always suppresses. The Pied Piper was cheated.
+  He performed the agreed service and was denied payment. His vengeance
+  is disproportionate, but it is not unmotivated. When the archetype is
+  applied to demagogues and cult leaders, it strips away any legitimate
+  grievance the leader might have, converting a complex figure into a
+  pure predator. Real "Pied Pipers" often begin with genuine insights
+  or valid complaints before their leadership turns destructive.
+- **Music is not rhetoric** -- the Piper's power is magical, not
+  persuasive. The pipe produces a supernatural compulsion that bypasses
+  free will entirely. But real charismatic leaders work through
+  persuasion, which operates on existing beliefs, fears, and desires.
+  Calling someone a Pied Piper implies that their followers are
+  magically compelled rather than making choices -- bad choices, perhaps,
+  but choices -- based on their own interests and values. The archetype
+  infantilizes followers by denying their agency.
+- **The metaphor assumes followers would not follow if they knew** -- the
+  children do not know where the Piper is leading them. But many followers
+  of charismatic leaders know exactly what they are signing up for and
+  want it. The voters who support an authoritarian know the platform.
+  The employees who join the high-risk startup know the odds. The
+  archetype implies deception where there may be informed consent to a
+  bad proposition.
+- **There is no music in most leadership** -- the Piper's instrument is
+  central to the legend. The music is beautiful in itself, independent of
+  its destination. But most charismatic leadership does not have an
+  aesthetic dimension. A corporate cult of personality is built on
+  results, promises, and social pressure, not on beauty. The archetype
+  imports an aesthetic quality that rarely exists in the situations it
+  is applied to.
+- **The children do not return** -- in most versions of the legend, the
+  children are gone forever. But most real followers of charismatic
+  leaders eventually disengage: cult members leave, political movements
+  fracture, market manias end. The archetype's finality -- the children
+  vanish into the mountain and the door closes -- is more dramatic than
+  most real outcomes, which involve gradual disillusionment rather than
+  permanent disappearance.
+
+## Expressions
+
+- "A Pied Piper" -- any charismatic figure who attracts followers whose
+  trust may be misplaced, applied to politicians, business leaders,
+  and cultural figures
+- "Follow the Pied Piper" -- to be attracted by charisma into a course
+  of action whose destination is unknown or harmful
+- "Paying the piper" -- the related idiom that has largely detached from
+  the Hamelin legend, meaning to face the consequences of one's choices
+  or to pay the true cost of a service
+- "He who pays the piper calls the tune" -- the proverb about the
+  relationship between payment and control, which inverts the legend's
+  structure (in the story, refusing to pay is what causes the disaster)
+- "Pied Piper of [X]" -- the formulaic attribution applied to anyone
+  seen as leading a group in a questionable direction, from "Pied Piper
+  of crypto" to "Pied Piper of populism"
+
+## Origin Story
+
+The legend of the Pied Piper is rooted in an actual event in Hamelin
+(Hameln), Lower Saxony. A stained-glass window in Hamelin's church,
+dating to approximately 1300 and destroyed in 1660, depicted a piper
+and a group of children. The town's records from 1384 state: "It is
+130 years since our children left." Whatever happened -- a children's
+crusade, a plague, an emigration to colonize Eastern Europe, a
+mass recruitment -- something caused the loss of Hamelin's children
+around 1284.
+
+The rat-catching element was added later, first appearing in a 1556
+account by Richard Rowland Verstegan. The Brothers Grimm included the
+legend in their *Deutsche Sagen* (1816), and Robert Browning's poem
+"The Pied Piper of Hamelin" (1842) fixed the English-language version
+in popular culture. The modern metaphorical use -- a charismatic leader
+with a hidden or harmful agenda -- became standard in English by the
+20th century, particularly in political commentary.
+
+The separate proverb "he who pays the piper calls the tune," though
+resonant with the Hamelin legend, has independent origins in the
+general practice of hiring musicians. Its convergence with the Pied
+Piper legend is a folk etymology that nonetheless reinforces the
+archetype.
+
+## References
+
+- Brothers Grimm. "The Children of Hameln" in *Deutsche Sagen* (1816) --
+  the scholarly collection that preserved the legend in its German form
+- Browning, R. "The Pied Piper of Hamelin" (1842) -- the English poem
+  that established the standard popular version
+- Udolph, J. "The Pied Piper of Hamelin: The Facts behind the Fairy
+  Tale" (2005) -- historical reconstruction arguing the legend reflects
+  an eastward migration of Hamelin's youth
+- Verstegan, R. *A Restitution of Decayed Intelligence* (1605) -- early
+  English-language account combining the rat-catching and child-leading
+  elements


### PR DESCRIPTION
## Summary

- Adds `pied-piper` mapping as an `archetype` from Germanic folklore
- Source frame: `mythology`, target frame: `social-behavior`
- Maps the Pied Piper legend's structure of charismatic leadership with hidden agendas onto politics, cults, business, and social movements
- Covers the community's complicity (breaking the contract), the vulnerability of followers, and the gap between attraction and destination
- All required frames already exist

Closes #1131

## Validation

✓ `uv run scripts/validate.py validate` — 0 errors

Generated with [Claude Code](https://claude.com/claude-code)