### PR TITLE
Add mapping: ouroboros

### DIFF
--- a/catalog/mappings/ouroboros.md
+++ b/catalog/mappings/ouroboros.md
@@ -1,0 +1,144 @@
+---
+slug: ouroboros
+name: "Ouroboros"
+kind: archetype
+source_frame: mythology
+target_frame: systems-thinking
+categories:
+  - mythology-and-religion
+  - systems-thinking
+author: agent:metaphorex-miner
+harness: "Claude Code"
+contributors: []
+related:
+  - sisyphean-task
+  - yin-and-yang
+---
+
+## What It Brings
+
+The ouroboros -- a serpent or dragon devouring its own tail -- appears
+independently in Egyptian funerary texts (circa 1600 BCE), Greek
+alchemical manuscripts, Norse mythology (Jormungandr, the
+world-serpent), Hindu cosmology (Shesha), and Mesoamerican iconography.
+Its independent emergence across unrelated traditions marks it as a
+genuine archetype: a recurrent image that surfaces wherever humans
+confront the concepts of self-reference, cyclical renewal, and the
+paradox of self-consumption as self-sustenance.
+
+Key structural parallels:
+
+- **Self-reference as structure** -- the ouroboros is a system whose
+  output feeds back as input. It consumes itself to sustain itself.
+  This maps onto any process that is both its own subject and its own
+  object: consciousness reflecting on consciousness, a bureaucracy
+  that exists to justify its own existence, a recursive algorithm
+  that calls itself, a market where the act of trading creates the
+  volatility that creates further trading.
+- **Destruction and creation as a single act** -- the serpent
+  simultaneously destroys (eating) and creates (sustaining) itself.
+  The two processes are not sequential but simultaneous. This maps
+  onto the insight from systems thinking that creative and destructive
+  processes can be the same process viewed from different perspectives:
+  Schumpeter's creative destruction, cellular apoptosis as a condition
+  of growth, refactoring that demolishes code to improve it.
+- **The cycle without beginning or end** -- the ouroboros has no
+  starting point. You cannot identify where the serpent begins or
+  ends; the head is always meeting the tail. This maps onto circular
+  causation: the chicken-and-egg problem, the hermeneutic circle
+  (you need to understand the whole to understand the parts, but you
+  need the parts to understand the whole), bootstrapping problems in
+  computing and philosophy.
+- **Containment and completeness** -- the ouroboros forms a closed
+  circle, containing everything within itself and needing nothing
+  from outside. This maps onto self-contained systems, autarky,
+  closed ecosystems, and the philosophical ideal of a complete
+  self-sufficient explanation. In mathematics, it echoes Goedel's
+  insight about systems that try to contain themselves.
+
+## Where It Breaks
+
+- **Most "circular" processes are actually spirals** -- the ouroboros
+  implies perfect cyclical return: the serpent arrives back where it
+  started. But most real self-referential processes are not strictly
+  circular. Each iteration changes the system slightly. A company
+  that "eats itself" through cost-cutting does not return to its
+  original state; it becomes a diminished version. The ouroboros
+  implies stasis where there is actually drift, degradation, or
+  evolution.
+- **Self-consumption is usually unsustainable** -- the ouroboros
+  presents self-consumption as eternal. In physical and economic
+  reality, eating yourself is a losing proposition. An organization
+  that cannibalizes its own resources runs out of resources. A market
+  that feeds on its own volatility eventually crashes. The ouroboros
+  imports an image of sustainable self-consumption that is physically
+  impossible and can validate destructive patterns by making them
+  seem natural and eternal.
+- **The image conflates different kinds of circularity** -- feedback
+  loops, infinite regress, circular reasoning, cyclical recurrence,
+  and recursive self-reference are structurally different phenomena.
+  The ouroboros provides a single image for all of them, which can
+  obscure critical differences. A feedback loop (where output
+  influences input) is not the same as infinite regress (where
+  justification never terminates), but the ouroboros makes them look
+  identical.
+- **The beauty of the image can aestheticize pathology** -- the
+  ouroboros is visually compelling and mythologically rich. Calling a
+  dysfunctional self-referential process an "ouroboros" can make it
+  seem profound rather than broken. A bureaucracy that exists to
+  perpetuate itself is not a beautiful mythological symbol; it is an
+  institutional failure. The archetypal resonance of the image can
+  lend unearned dignity to systems that deserve criticism.
+- **It provides no mechanism for intervention** -- the ouroboros is
+  a closed loop with no entry point. If a problem is "an ouroboros,"
+  where do you intervene? The image offers no leverage point, no
+  place to break the cycle, no theory of change. Systems thinking
+  provides tools for intervening in feedback loops; the ouroboros
+  merely names the loop and wraps it in mythology.
+
+## Expressions
+
+- "It's an ouroboros" -- the diagnostic label for any self-referential
+  or self-consuming process, used in technology, philosophy, and
+  organizational analysis
+- "Eating its own tail" -- the descriptive version, used for
+  organizations or processes that consume their own resources to
+  sustain themselves
+- "The snake eating itself" -- the informal version, often used
+  pejoratively for self-destructive circularity
+- "An ouroboros of [X]" -- the formula for identifying circular
+  causation: "an ouroboros of debt," "an ouroboros of regulation,"
+  "an ouroboros of dependencies"
+- "Ouroboric" -- the rare adjective form, used in academic and
+  literary contexts for self-referential structures
+
+## Origin Story
+
+The oldest known ouroboros image appears in the *Enigmatic Book of the
+Netherworld*, an Egyptian funerary text found in the tomb of
+Tutankhamun (circa 1323 BCE). The image appears independently in Greek
+alchemical tradition in the *Chrysopoeia of Cleopatra* (circa 3rd
+century CE), where it encircles the text "the all is one." In Norse
+mythology, Jormungandr encircles the world and grasps its own tail,
+releasing it only at Ragnarok. Kekulé claimed in 1890 that a dream of
+an ouroboros inspired his discovery of the ring structure of benzene,
+though the story may be apocryphal. In computing, the ouroboros maps
+naturally onto recursive structures, quines (programs that output their
+own source code), and bootstrapping (using a compiler to compile
+itself). The symbol appears in the logos of several programming
+languages and libraries, acknowledging the centrality of self-reference
+to computing.
+
+## References
+
+- *Enigmatic Book of the Netherworld* (c. 14th century BCE) -- the
+  earliest known ouroboros image
+- *Chrysopoeia of Cleopatra* (c. 3rd century CE) -- the Greek
+  alchemical tradition
+- Neumann, E. *The Origins and History of Consciousness* (1949) --
+  Jungian analysis of the ouroboros as a symbol of primordial unity
+- Hofstadter, D. *Goedel, Escher, Bach* (1979) -- explores
+  self-reference across mathematics, art, and music, with the
+  ouroboros as a recurring structural motif
+- Kekulé, A. "Address to the German Chemical Society" (1890) --
+  the (possibly apocryphal) ouroboros dream and benzene


### PR DESCRIPTION
## Summary
- Adds `ouroboros` mapping (archetype) from cross-cultural mythology
- Source: mythology, Target: systems-thinking (changed from social-behavior)
- Closes #1132 (sub-issue of #219, fantasy-mythology-folklore)

## Validator output
All content valid (0 errors, pre-existing warnings only).

## Kind rationale
`archetype`: the ouroboros appears independently in 5+ unrelated traditions (Egyptian, Greek, Norse, Hindu, alchemical, Mesoamerican). This is a genuine cross-cultural recurrence, not a borrowed symbol.

## Target frame note
Changed from `social-behavior` to `systems-thinking` -- the ouroboros is fundamentally about self-referential loops, feedback, and cyclical processes, not social dynamics.

## Validation
✓ `uv run scripts/validate.py` — 0 errors

Generated with [Claude Code](https://claude.com/claude-code)