### PR TITLE
Add mapping: round-table

### DIFF
--- a/catalog/mappings/round-table.md
+++ b/catalog/mappings/round-table.md
@@ -1,0 +1,142 @@
+---
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- law-and-governance
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Round Table
+related:
+- excalibur
+- damocles-sword
+slug: round-table
+source_frame: mythology
+target_frame: governance
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+In Arthurian legend, King Arthur commissioned a round table so that no
+knight could claim precedence by sitting at its head. The geometry solved a
+political problem: a rectangular table has ends, and the person at the end
+holds authority. A circle has no end. The metaphor maps this geometric
+insight -- that the shape of the meeting space determines the power
+structure -- onto governance, organizational design, and deliberation.
+
+- **No head of table means no head** -- the round table eliminates the
+  spatial signal of hierarchy. In organizations, a "roundtable discussion"
+  promises that all participants speak with equal authority, that no one's
+  contribution outranks another's by virtue of where they sit or what
+  title they hold. The physical form imports the political principle:
+  equality is a property of the arrangement, not a declaration.
+- **Visibility produces accountability** -- at a round table, every
+  participant faces every other participant. There is no back row, no
+  hidden seat. The geometry makes disengagement visible and silence
+  conspicuous. In practice, this maps onto meeting formats designed
+  to ensure that quieter voices are drawn out and that no participant
+  can hide behind the person in front of them.
+- **Bounded membership creates an elite** -- Arthur's Round Table had a
+  fixed number of seats (150 in some traditions, 13 in others). The
+  metaphor carries this constraint: a roundtable is not open to everyone.
+  It is an invitation-only gathering of peers. "Roundtable" in modern
+  usage implies both equality among participants and exclusion of
+  non-participants. The UN Security Council, a corporate board, and a
+  policy roundtable all share this structure: equal within, exclusive
+  without.
+- **The shape has outlived the story** -- most people who say "roundtable"
+  in a professional context are not thinking about King Arthur, Lancelot,
+  or the Quest for the Holy Grail. The word functions as a pure synonym
+  for "egalitarian discussion format." The Arthurian origin is decorative
+  at best, invisible at worst.
+
+## Where It Breaks
+
+- **Round tables still have power differentials** -- the geometric
+  equality is a fiction. At Arthur's own Round Table, Arthur was still
+  king. He chose who sat there. He set the quests. A circle of chairs
+  does not dissolve the fact that some participants have more resources,
+  more information, more allies, or more institutional authority than
+  others. The metaphor can be used to perform equality without delivering
+  it -- a circle of chairs in a room where everyone knows who the boss
+  is changes nothing about the power structure.
+- **Consensus is not the same as equality** -- the round table implies
+  that equal seating produces equal decision-making. But consensus
+  processes can be slower, can be dominated by the most persistent voice,
+  and can produce lowest-common-denominator outcomes. The metaphor has
+  no vocabulary for the costs of egalitarian process: deadlock, diffusion
+  of responsibility, and the tyranny of structurelessness that Jo Freeman
+  identified in her 1972 essay.
+- **The Arthurian Round Table failed** -- this is the most significant
+  breakage the metaphor suppresses. Arthur's fellowship of equals
+  dissolved into civil war. Lancelot's affair with Guinevere, Mordred's
+  rebellion, and the knights' individual quests for the Grail all pulled
+  the fellowship apart. The source narrative is a story about the failure
+  of egalitarian governance, not its success. Using "roundtable" as a
+  positive organizational metaphor requires ignoring that the original
+  roundtable ended in catastrophe.
+- **Circles do not scale** -- a round table for 8 people works. A round
+  table for 80 does not. The geometry that produces face-to-face
+  visibility at small scale produces anonymity and chaos at large scale.
+  The metaphor provides no guidance for how egalitarian governance works
+  beyond the size of a single table, which is why real governance
+  systems -- parliaments, congresses, councils -- abandoned the circle
+  for structured hierarchies as they grew.
+- **The metaphor obscures the role of the convener** -- someone organized
+  the roundtable. Someone sent the invitations, set the agenda, and
+  chose the participants. That person has more power than anyone at the
+  table, and the round shape hides it. The metaphor makes the convener
+  invisible, which can be a deliberate strategy for exercising power
+  while appearing not to.
+
+## Expressions
+
+- "Roundtable discussion" -- the dominant modern usage, meaning a meeting
+  format where participants are treated as equals, often used for panel
+  events and policy discussions
+- "A seat at the table" -- the derived expression emphasizing inclusion,
+  where the table's shape is implied to be round even when not stated
+- "Knights of the Round Table" -- the original Arthurian expression,
+  still used humorously or aspirationally for a team of elite equals
+- "Round-table conference" -- the formal political variant, as in the
+  Round Table Conferences on Indian constitutional reform (1930-1932),
+  where the shape was chosen deliberately to signal equality between
+  British and Indian delegates
+- "Bring everyone to the table" -- the invitation to participate in
+  egalitarian deliberation, with the round shape assumed
+
+## Origin Story
+
+The Round Table first appears in Wace's *Roman de Brut* (1155), a
+Norman French adaptation of Geoffrey of Monmouth's *Historia Regum
+Britanniae*. Wace adds the detail that Arthur had the table made round
+to prevent quarrels over precedence among his knights. The motif was
+elaborated in the French Vulgate Cycle (13th century) and Malory's
+*Le Morte d'Arthur* (1485), where the table becomes central to the
+fellowship's identity.
+
+The metaphorical use of "round table" for egalitarian discussion
+appears in English by the 18th century. The Round Table Conferences of
+1930-1932, convened in London to discuss Indian self-governance, gave
+the term political currency in the 20th century. Algernon Sidney's Round
+Table club (19th century) and various fraternal organizations also used
+the name.
+
+By the mid-20th century, "roundtable" had become a dead metaphor in
+professional and media contexts. Conference organizers, television
+producers, and policy institutes use it to describe any panel discussion
+among notional equals. Most users would be surprised to learn they are
+invoking King Arthur.
+
+## References
+
+- Wace. *Roman de Brut* (1155) -- the earliest literary source for the
+  Round Table as a deliberate solution to the problem of precedence
+- Malory, T. *Le Morte d'Arthur* (1485) -- the canonical English-language
+  treatment of the Arthurian Round Table and its dissolution
+- Freeman, J. "The Tyranny of Structurelessness" (1972) -- the classic
+  analysis of how apparently egalitarian structures can mask informal
+  power hierarchies, directly relevant to the round-table metaphor's
+  blind spots


### PR DESCRIPTION
## Summary

- Adds `round-table` mapping: dead metaphor from Arthurian legend for egalitarian discussion format and flat hierarchy
- Source frame: mythology, Target frame: governance
- Kind: `dead-metaphor` (most speakers using "roundtable" are unaware of the Arthurian origin)

Closes #1098, part of #219.

## Validator output

```
All content valid.
```

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors
- [ ] Review mapping body sections for accuracy and depth

Co-Authored-By: metaphorex-miner <miner@metaphorex.org>