### PR TITLE
Add mapping: golem

### DIFF
--- a/catalog/mappings/golem.md
+++ b/catalog/mappings/golem.md
@@ -1,0 +1,148 @@
+---
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- ai-discourse
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: conceptual-metaphor
+name: Golem
+related:
+- excalibur
+slug: golem
+source_frame: mythology
+target_frame: rule-following
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+In Jewish folklore, a golem is an anthropomorphic figure made from clay and
+animated by inscribing a sacred word (typically *emet*, "truth") on its
+forehead or placing a written name of God in its mouth. The golem obeys its
+creator's commands with absolute literalness. It has immense strength but no
+judgment, no will, and no capacity for interpretation. The metaphor maps
+this structure -- a powerful servant that does exactly what you say, not
+what you mean -- onto automation, artificial intelligence, bureaucracy, and
+any system that executes instructions without understanding intent.
+
+- **Literal compliance without understanding** -- the golem does not
+  interpret commands; it executes them. Rabbi Loew's golem, in the most
+  famous version, is told to fetch water and floods the house because
+  it was never told to stop. This maps precisely onto the behavior of
+  automated systems, algorithms, and bureaucratic processes that
+  optimize for the letter of the instruction while violating its spirit.
+  The AI that maximizes a reward function in unexpected and destructive
+  ways is the golem fetching water.
+- **Power without judgment is dangerous** -- the golem is stronger than
+  any human but has no moral reasoning. The metaphor captures the
+  insight that capability and wisdom are independent variables. A system
+  can be enormously powerful and enormously stupid at the same time.
+  This maps onto industrial automation that can produce millions of
+  defective units before anyone notices, trading algorithms that crash
+  markets in milliseconds, and AI systems that generate fluent nonsense.
+- **The creator is responsible** -- the golem has no agency and therefore
+  no culpability. If it destroys the village, the rabbi who made it is
+  at fault. The metaphor imports a clear attribution of responsibility:
+  the designer of the system, not the system itself, bears moral
+  accountability for its behavior. This is the structural argument
+  behind much of AI ethics discourse -- that the engineers and companies
+  that build AI systems cannot deflect responsibility onto the technology.
+- **Deactivation requires the right word** -- the golem is stopped by
+  erasing a letter from *emet* (truth) to make *met* (death), or by
+  removing the scroll from its mouth. The metaphor imports the idea
+  that a powerful automated process must have a kill switch, and that
+  the kill switch must be accessible to the creator. This maps onto
+  shutdown problems in AI safety and the general engineering principle
+  of corrigibility.
+
+## Where It Breaks
+
+- **The golem has no learning; modern AI does** -- the golem of folklore
+  does not improve, adapt, or modify its behavior based on experience.
+  It executes the same instruction the same way forever. Modern machine
+  learning systems do learn, and their behavior changes over time in ways
+  their creators did not anticipate and cannot fully predict. The golem
+  metaphor, applied to AI, implies a static and predictable servant. Real
+  AI systems are neither static nor predictable, which makes them both
+  more useful and more dangerous than the metaphor suggests.
+- **The golem is singular; automated systems are distributed** -- Rabbi
+  Loew made one golem. It was a discrete entity that could be confronted
+  and deactivated in a specific location. Modern automated systems are
+  distributed across networks, running in multiple instances, often
+  without a single point of control. There is no forehead to erase.
+  The metaphor's assumption of a single, localized entity understates
+  the difficulty of controlling distributed automated systems.
+- **The metaphor romanticizes the creator's knowledge** -- in the
+  folklore, the rabbi who creates the golem understands exactly how it
+  works because he built it from first principles using sacred knowledge.
+  Modern system creators frequently do not understand their own systems.
+  Neural networks are opaque to their designers. Bureaucracies develop
+  emergent behaviors that no single architect planned. The golem metaphor
+  implies a level of creator understanding that is often absent in
+  practice.
+- **Literalness is not the only failure mode** -- the golem fails by
+  being too literal. But real automated systems also fail by being too
+  approximate, too noisy, too biased, or too creative. A large language
+  model that invents plausible-sounding false information is not being
+  literal -- it is being imaginative in ways the golem never was. The
+  metaphor captures one failure mode (literal compliance) while obscuring
+  others that may be more pressing.
+- **The folklore carries a specific cultural weight** -- the Golem of
+  Prague is deeply embedded in Jewish history, particularly the experience
+  of a persecuted community needing a protector. Using "golem" casually
+  as a metaphor for AI strips away the cultural context of a minority
+  community's survival narrative and can flatten a rich theological
+  tradition into a tech analogy.
+
+## Expressions
+
+- "It's a golem" -- describing a system or process that executes
+  instructions with dangerous literalness, common in software engineering
+  and AI safety discussions
+- "Golem problem" -- the challenge of specifying instructions precisely
+  enough that a literal executor produces the intended outcome, closely
+  related to the AI alignment problem
+- "Who wrote the instructions on its forehead?" -- asking who is
+  responsible for the behavior of an automated system, invoking the
+  golem's mechanism of activation
+- "Sorcerer's Apprentice" -- the closely related metaphor from Goethe
+  (and Disney's Fantasia), which recapitulates the golem structure: an
+  animated servant that follows orders too well and cannot be stopped
+- "The golem always turns on its creator" -- the folk wisdom that
+  powerful automated servants inevitably become uncontrollable, echoed
+  in Frankenstein and countless AI narratives
+
+## Origin Story
+
+The concept of an animated clay figure appears in the Talmud (Sanhedrin
+65b), where the sage Rava creates a man and sends him to Rabbi Zeira, who
+speaks to it and, receiving no answer, says "You are from the magicians;
+return to your dust." The most famous golem narrative centers on Rabbi
+Judah Loew ben Bezalel (the Maharal of Prague, c. 1520-1609), who
+allegedly created a golem to protect the Jewish community from anti-Semitic
+attacks. This version was elaborated in the 19th century and became the
+canonical golem story through retellings by Yudl Rosenberg (1909) and
+Chayim Bloch (1920).
+
+The word "golem" entered broader European discourse through these Prague
+narratives and was reinforced by Gustav Meyrink's expressionist novel
+*Der Golem* (1914). It became available as a general metaphor for
+artificial servants in the 20th century, gaining particular currency
+in AI and automation discourse from the 2010s onward as the alignment
+problem made the "literal servant" failure mode feel urgently relevant.
+
+## References
+
+- Scholem, G. "The Idea of the Golem" in *On the Kabbalah and Its
+  Symbolism* (1960) -- the definitive scholarly treatment of the golem
+  tradition in Jewish mysticism
+- Idel, M. *Golem: Jewish Magical and Mystical Traditions on the
+  Artificial Anthropoid* (1990) -- comprehensive historical analysis
+  of the golem concept across Jewish intellectual history
+- Norvig, P. and Russell, S. *Artificial Intelligence: A Modern
+  Approach* (4th ed., 2021) -- discusses the golem as a precursor
+  narrative for AI alignment concerns
+- Wiener, N. *God & Golem, Inc.* (1964) -- early application of the
+  golem metaphor to cybernetics and machine intelligence


### PR DESCRIPTION
## Summary

- Adds `golem` mapping: conceptual metaphor from Jewish folklore for literal rule-following and the AI alignment problem
- Source frame: mythology, Target frame: rule-following
- Kind: `conceptual-metaphor`

Closes #1099, part of #219.

## Validator output

```
All content valid.
```

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors
- [ ] Review mapping body sections for accuracy and depth

Co-Authored-By: metaphorex-miner <miner@metaphorex.org>