### PR TITLE
Add mapping: karma

### DIFF
--- a/catalog/mappings/karma.md
+++ b/catalog/mappings/karma.md
@@ -1,0 +1,157 @@
+---
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- social-dynamics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Karma
+related:
+- moral-accounting
+slug: karma
+source_frame: mythology
+target_frame: social-behavior
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+In Hindu and Buddhist philosophy, karma (Sanskrit: *karman*, "action" or
+"deed") is the principle that actions produce consequences that shape
+future experience -- across this life and subsequent ones. The universe
+keeps a moral ledger. Good actions generate merit; harmful actions
+generate demerit. The ledger balances over time, possibly over multiple
+lifetimes. The metaphor maps this cosmic accounting system onto everyday
+social experience: the intuition that good and bad behavior will
+eventually be repaid in kind.
+
+- **Moral cause and effect** -- "what goes around comes around." The
+  core mapping treats moral actions as causes that inevitably produce
+  proportionate effects. Being generous will bring you generosity; being
+  cruel will bring you suffering. The metaphor imports a causal
+  structure from theology into secular social life, making moral
+  behavior feel like physics: every action has an equal and opposite
+  reaction. This is satisfying because it promises that the universe
+  is just, even when human institutions are not.
+- **Delayed but inevitable consequences** -- karma does not promise
+  instant repayment. The consequences may arrive years, decades, or
+  lifetimes later. This maps onto the social observation that
+  reputational effects compound over time. The manager who mistreats
+  subordinates may not face consequences today, but "karma" predicts
+  that the accumulated ill will eventually manifest. The temporal delay
+  is part of the metaphor's appeal: it explains why bad people sometimes
+  prosper (karma has not caught up yet) without abandoning the premise
+  that they will eventually be punished.
+- **The word has fully detached from its theological context** -- most
+  English speakers who say "that's karma" are not invoking the doctrine
+  of samsara, the cycle of rebirth, or the metaphysics of action in
+  the Bhagavad Gita. They mean something closer to "poetic justice" or
+  "what you deserve." The theological architecture -- rebirth, dharma,
+  liberation from the cycle -- is entirely absent from casual usage.
+  "Karma" in English is a secular synonym for "cosmic fairness."
+- **Reputation as a karmic system** -- online platforms have made the
+  metaphor literal. Reddit karma, Stack Overflow reputation, and
+  similar systems create explicit numerical ledgers of social merit.
+  The term "karma" was chosen for Reddit's system deliberately,
+  importing the idea that contributions and transgressions are tracked
+  and quantified. The metaphor has been reified into an actual
+  mechanism.
+
+## Where It Breaks
+
+- **The original doctrine is not about punishment** -- in Hindu and
+  Buddhist philosophy, karma is not a system of reward and punishment
+  imposed by a moral authority. It is an impersonal natural law, more
+  like gravity than like a court. Actions produce consequences through
+  causal chains, not through divine judgment. The Western appropriation
+  of "karma" almost always reintroduces a moral agent -- an implicit
+  universe that watches, judges, and repays -- that the original
+  doctrine explicitly denies. The metaphor imports the mechanism while
+  replacing the metaphysics.
+- **Karma in the original context spans lifetimes; secular karma does
+  not** -- the full karmic doctrine requires reincarnation to make
+  sense. Bad things happen to good people in this life because of
+  actions in previous lives. Remove reincarnation, and the system's
+  explanatory power collapses: it cannot account for undeserved
+  suffering or unearned prosperity within a single lifetime. Secular
+  "karma" simply ignores this problem, asserting that consequences
+  will arrive eventually without explaining the mechanism or the
+  timeline.
+- **The metaphor can justify victim-blaming** -- if bad outcomes are
+  karmic consequences of bad actions, then people who suffer must have
+  done something to deserve it. This is the dark side of the metaphor:
+  it can rationalize indifference to suffering by implying that the
+  sufferer earned their fate. In its original context, this logic was
+  used to justify caste hierarchy -- lower-caste birth was explained as
+  the karmic result of past-life transgressions. The secular version
+  carries the same structural risk without the theological sophistication
+  to navigate it.
+- **Moral accounting assumes commensurability** -- karma treats all
+  moral actions as entries in a single ledger that can be summed. But
+  moral experience is not fungible. Does a lifetime of small kindnesses
+  offset one act of betrayal? Does charitable giving cancel out
+  environmental destruction? The metaphor assumes that moral actions
+  can be added and subtracted like currency, which is exactly the
+  accounting model of morality that philosophers from Kant to Williams
+  have challenged.
+- **"Instant karma" contradicts the core structure** -- John Lennon's
+  "Instant Karma" and the popular phrase "instant karma" describe
+  immediate consequences for bad behavior. But the entire point of the
+  karmic system is that consequences are not instant -- they unfold
+  across vast timescales. Instant karma is a contradiction in terms
+  that reveals how far the English word has drifted from its source.
+
+## Expressions
+
+- "That's karma" -- the all-purpose expression for poetic justice, used
+  when someone receives a consequence that feels proportionate to their
+  prior behavior
+- "Karma will get you" -- the warning form, predicting future
+  consequences for present bad behavior
+- "Good karma / bad karma" -- treating karma as a substance that
+  accumulates, like credit or debt in a moral bank account
+- "Instant karma" -- immediate poetic justice, contradicting the
+  original doctrine's emphasis on delayed consequences
+- "Reddit karma" -- the literal reification of the metaphor into a
+  numerical reputation system, tracking upvotes and downvotes as a
+  moral ledger
+- "Karmic debt" -- the financial metaphor layered on top of the
+  theological one, treating accumulated bad actions as a balance owed
+- "What goes around comes around" -- the fully secularized version that
+  preserves the karmic structure without the Sanskrit word
+
+## Origin Story
+
+Karma as a philosophical concept appears in the earliest Upanishads
+(c. 800-500 BCE), particularly the Brihadaranyaka Upanishad, which
+states: "By good deeds one becomes good, by evil deeds one becomes evil."
+The concept was central to both Hindu and Buddhist thought, though the
+two traditions differ on mechanism: Hinduism generally treats karma as
+operating on an enduring soul (*atman*) across rebirths, while Buddhism
+denies a permanent self and treats karma as a causal chain operating on
+the stream of consciousness.
+
+The word entered English in the early 19th century through colonial
+encounters with Indian philosophy. Theosophy (Helena Blavatsky, 1870s
+onward) popularized a simplified version of karma in Western esoteric
+circles. By the mid-20th century, the counterculture had adopted "karma"
+as a general-purpose term for cosmic justice, stripped of its
+metaphysical specificity. John Lennon's "Instant Karma!" (1970)
+accelerated the word's integration into everyday English.
+
+By the 21st century, "karma" is a dead metaphor in most English
+contexts. Reddit adopted it as the name for its reputation system in
+2005, completing the word's transformation from a doctrine about
+liberation from the cycle of rebirth into a number next to a username.
+
+## References
+
+- Doniger, W. *The Laws of Manu* (trans., 1991) -- karma as a
+  structuring principle of Hindu social and moral order
+- Reichenbach, B.R. *The Law of Karma: A Philosophical Study* (1990)
+  -- analytical treatment of karmic theory and its logical structure
+- Obeyesekere, G. *Imagining Karma: Ethical Transformation in
+  Amerindian, Buddhist, and Greek Rebirth* (2002) -- comparative
+  study of karmic doctrines across cultures


### PR DESCRIPTION
## Summary

- Adds `karma` mapping: dead metaphor from Hindu/Buddhist philosophy for moral cause and effect
- Source frame: mythology, Target frame: social-behavior
- Kind: `dead-metaphor` (most English speakers using "karma" are unaware of the theological context)

Closes #1100, part of #219.

## Validator output

```
All content valid.
```

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors
- [ ] Review mapping body sections for accuracy and depth

Co-Authored-By: metaphorex-miner <miner@metaphorex.org>