### PR TITLE
Prospect: nautical-terms (issue #1226)

### DIFF
--- a/playbooks/nautical-terms/manifest.json
+++ b/playbooks/nautical-terms/manifest.json
@@ -1,0 +1,364 @@
+{
+  "project": "nautical-terms",
+  "project_issue": 1226,
+  "source_type": "archive",
+  "archive_urls": [
+    "https://en.wikipedia.org/wiki/Glossary_of_nautical_terms_(A%E2%80%93L)",
+    "https://en.wikipedia.org/wiki/Glossary_of_nautical_terms_(M%E2%80%93Z)",
+    "https://oceanservice.noaa.gov/navigation/nautical-terms.html",
+    "https://www.rmg.co.uk/stories/maritime-history/nautical-origins-everyday-phrases",
+    "https://www.rubicon3adventure.com/50-sailor-sayings-you-wont-believe-are-part-of-your-daily-speech/"
+  ],
+  "candidates": [
+    {
+      "slug": "loose-cannon",
+      "name": "Loose Cannon",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "social-behavior",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "An unsecured cannon on a rolling deck could crush sailors and smash through the hull. Maps uncontrolled destructive force in a confined space onto an unpredictable person whose actions endanger everyone around them. The containment failure is the key structural element."
+    },
+    {
+      "slug": "taken-aback",
+      "name": "Taken Aback",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "mental-experience",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "When wind suddenly shifted and blew sails flat against the masts, the ship stopped dead or was driven backward. Maps the physical shock of reversed momentum onto the psychological experience of being stunned by unexpected information. The surprise halts forward progress."
+    },
+    {
+      "slug": "three-sheets-to-the-wind",
+      "name": "Three Sheets to the Wind",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "embodied-experience",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "Sheets are ropes controlling sails, not the sails themselves. Three loose sheets meant the ship lurched and staggered uncontrollably. Maps the visible loss of controlled motion onto drunkenness. Sailors used a scale: one sheet was tipsy, three was falling-down drunk."
+    },
+    {
+      "slug": "showing-true-colors",
+      "name": "Showing True Colors",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "social-behavior",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "Warships flew false flags to approach enemies, then raised their actual national ensign before firing. Maps the reveal of concealed identity onto any situation where someone drops a social mask. The deception-then-reveal structure is the core mapping."
+    },
+    {
+      "slug": "in-the-doldrums",
+      "name": "In the Doldrums",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "mental-experience",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "The equatorial belt where trade winds die, leaving sailing ships becalmed for days or weeks. Maps enforced stillness and powerlessness onto depression or stagnation. The critical element: the sailor's predicament is not caused by obstacle but by absence -- no wind, no agency, just waiting."
+    },
+    {
+      "slug": "bitter-end",
+      "name": "Bitter End",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "event-structure",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "The bitter end is the last section of anchor chain secured to the bitts (deck posts). When you reach the bitter end, there is no more chain to pay out -- you are at the absolute limit. Maps physical exhaustion of resources onto persevering through the final, worst part of any ordeal."
+    },
+    {
+      "slug": "cut-and-run",
+      "name": "Cut and Run",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "social-behavior",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "Cutting the anchor cable to flee immediately rather than hauling anchor properly. Maps the sacrifice of expensive equipment for speed of escape onto abandoning commitments hastily. The trade-off between orderly withdrawal and panicked flight is the structural core."
+    },
+    {
+      "slug": "by-and-large",
+      "name": "By and Large",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "language",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "Sailing 'by' meant close to the wind; sailing 'large' meant with the wind behind. A ship that sailed well 'by and large' handled both conditions. Maps versatility across conditions onto general truth-telling: 'by and large' now means 'on the whole, considering everything.' The nuance of the original (two opposite sailing modes) is completely lost."
+    },
+    {
+      "slug": "even-keel",
+      "name": "Even Keel",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "mental-experience",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "A ship on an even keel sits level in the water, neither listing nor pitching. Maps physical stability of a vessel onto emotional or organizational steadiness. The keel is the deepest structural member -- stability comes from below the waterline, from what you cannot see."
+    },
+    {
+      "slug": "know-the-ropes",
+      "name": "Know the Ropes",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "intellectual-inquiry",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "A sailing ship had miles of rigging with hundreds of individual lines, each with a specific function. A competent sailor needed to find and operate any rope by feel, in darkness, in a storm. Maps embodied, practiced knowledge of a complex system onto familiarity with any domain's procedures and conventions."
+    },
+    {
+      "slug": "give-wide-berth",
+      "name": "Give a Wide Berth",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "social-behavior",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "Berth is the space a ship needs to swing at anchor without hitting other vessels or obstructions. Maps spatial safety margins in harbor onto social avoidance. The metaphor preserves the idea that the danger is not in contact but in the unpredictable arc of movement."
+    },
+    {
+      "slug": "above-board",
+      "name": "Above Board",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "ethics-and-morality",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "Cargo and crew visible above the deck boards, not hidden below. Pirates and smugglers concealed fighters or contraband below decks. Maps physical visibility onto moral transparency. The board (deck) is the boundary between honest and concealed."
+    },
+    {
+      "slug": "batten-down-the-hatches",
+      "name": "Batten Down the Hatches",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "event-structure",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "Securing hatch covers with wooden battens and tarpaulin before a storm to prevent the ship from flooding through its deck openings. Maps storm preparation on a vessel onto preparing for any anticipated crisis. The structural insight: seal the vulnerable openings before the threat arrives, not during."
+    },
+    {
+      "slug": "dead-in-the-water",
+      "name": "Dead in the Water",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "event-structure",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "A ship with no wind and no steerage way, sitting motionless and unable to maneuver. Maps complete loss of propulsion onto any project, negotiation, or initiative that has lost all momentum. 'Dead' here means not destroyed but inert -- the ship is intact but powerless."
+    },
+    {
+      "slug": "plain-sailing",
+      "name": "Plain Sailing",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "event-structure",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "Originally 'plane sailing' -- a simplified navigation method that treats the Earth's surface as flat, adequate for short distances. Maps computational simplicity onto easy progress. The irony: the original term meant 'using the simplified approximation,' not 'encountering no difficulty.'"
+    },
+    {
+      "slug": "take-wind-out-of-sails",
+      "name": "Take the Wind Out of Their Sails",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "competition",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "Positioning your ship upwind of an opponent steals their wind, leaving them becalmed while you retain power. Maps tactical energy denial onto deflating someone's argument, enthusiasm, or advantage. The structural element: you do not attack the opponent, you remove the resource they depend on."
+    },
+    {
+      "slug": "shot-across-the-bow",
+      "name": "Shot Across the Bow",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "communication",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "A cannon shot fired deliberately in front of (not at) an approaching ship, demanding it stop and identify itself. Maps calibrated threat -- demonstrating capability without deploying it destructively -- onto warnings in business, diplomacy, and personal relationships. The precision is the point: the shot must be close enough to be credible but miss on purpose."
+    },
+    {
+      "slug": "high-and-dry",
+      "name": "High and Dry",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "social-behavior",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "A ship left stranded above the waterline when the tide recedes. Maps physical stranding onto being abandoned or left without resources. The critical element: the tide went out, not the ship. The stranding is caused by environmental change, not the victim's action."
+    },
+    {
+      "slug": "scuttlebutt",
+      "name": "Scuttlebutt",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "communication",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "The scuttled butt was the water barrel with a hole cut in it for drinking. Sailors gathered around it to exchange news, making it the 18th-century water cooler. Maps the gathering place onto the information exchanged there. The word now means gossip or rumor, completely detached from barrels or water."
+    },
+    {
+      "slug": "fathom",
+      "name": "Fathom",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "intellectual-inquiry",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "To fathom was to measure water depth by lowering a weighted line, six feet at a time (one fathom = the span of outstretched arms). Maps measuring hidden depth beneath a surface onto comprehending something not immediately obvious. 'I can't fathom it' means the depth exceeds my line."
+    },
+    {
+      "slug": "try-different-tack",
+      "name": "Try a Different Tack",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "intellectual-inquiry",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "Tacking is zigzagging into the wind because no sailing vessel can go directly upwind. Each tack is an oblique approach to a destination you cannot reach directly. Maps indirect navigation strategy onto changing one's method or approach. The structural insight: sometimes the only way forward is sideways."
+    },
+    {
+      "slug": "over-a-barrel",
+      "name": "Over a Barrel",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "social-behavior",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "Sailors being punished were sometimes bent over a cannon barrel or deck barrel for flogging. Maps physical vulnerability and powerlessness onto being in a position where someone else holds all the leverage. The posture -- bent, exposed, unable to defend -- is the core image."
+    },
+    {
+      "slug": "at-loggerheads",
+      "name": "At Loggerheads",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "argumentation",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "Loggerheads were long-handled iron tools heated in fire and used to melt pitch for caulking seams. During disputes, sailors reportedly used them as weapons. Maps the improvised weaponization of work tools onto being locked in fierce disagreement. The escalation from work to conflict is the structural parallel."
+    },
+    {
+      "slug": "in-the-offing",
+      "name": "In the Offing",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "event-structure",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "The offing is the part of the sea visible from shore but beyond the anchorage. A ship 'in the offing' is visible on the horizon, approaching but not yet arrived. Maps visible-but-not-yet-here onto events that are imminent and anticipated. The spatial metaphor encodes temporal proximity."
+    },
+    {
+      "slug": "groundswell",
+      "name": "Groundswell",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "social-behavior",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "A deep ocean swell generated by distant storms or seismic activity, arriving without local wind. Maps invisible, distant-origin force onto a surge of public opinion or social movement that builds from deep causes rather than surface events. The power comes from below and from far away."
+    },
+    {
+      "slug": "sailing-close-to-the-wind",
+      "name": "Sailing Close to the Wind",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "ethics-and-morality",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "Sailing as close to the wind direction as possible gains speed but risks the sails luffing (going slack) or the ship being taken aback. Maps the trade-off between efficiency and danger onto behavior that skirts the edge of rules, ethics, or legality. The closer you sail to the line, the more you gain and the more you risk."
+    },
+    {
+      "slug": "between-devil-and-deep-blue-sea",
+      "name": "Between the Devil and the Deep Blue Sea",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "event-structure",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "The 'devil' was the longest seam on the hull, near the waterline, requiring a sailor to hang over the side to caulk it -- trapped between the seam and the ocean. Maps physical entrapment between two dangers onto any dilemma with no good option. Often confused with the theological devil, which masks the nautical origin."
+    },
+    {
+      "slug": "hand-over-fist",
+      "name": "Hand Over Fist",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "economics",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "The rapid hand-over-hand motion of hauling rope or climbing rigging. Maps the visible speed and rhythm of physical labor onto rapid accumulation, especially of money. 'Making money hand over fist' preserves the image of continuous, rapid pulling without pause."
+    },
+    {
+      "slug": "keelhauled",
+      "name": "Keelhauled",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "social-behavior",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "Dragging a sailor under the ship's hull from one side to the other as punishment, scraping against the barnacle-encrusted keel. Maps extreme, sanctioned physical punishment onto severe reprimand. The modern usage (getting keelhauled by your boss) is vastly milder than the original, which was often fatal."
+    },
+    {
+      "slug": "mainstay",
+      "name": "Mainstay",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "physical-objects",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "The heavy rope running from the mainmast to the bow, the primary structural support preventing the mast from falling backward. Maps the single most critical support element onto any person or thing that is the chief support of an institution or system. Without the mainstay, the entire rigging collapses."
+    },
+    {
+      "slug": "leeway",
+      "name": "Leeway",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "spatial-location",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "The sideways drift of a ship downwind from its intended course. Maps the margin between where you are and the hazard (the lee shore) onto tolerance, slack, or room for error. 'Give me some leeway' asks for the spatial margin that prevents disaster. The less leeway, the closer to the rocks."
+    },
+    {
+      "slug": "flagship",
+      "name": "Flagship",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "economics",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "The ship carrying the fleet commander's flag, the most important vessel in the squadron. Maps hierarchical primacy in a naval fleet onto the premier product, store, or initiative in a commercial organization. 'Flagship store,' 'flagship product' -- the word has completely shed its naval meaning for most speakers."
+    },
+    {
+      "slug": "first-rate",
+      "name": "First Rate",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "measurement",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "The Royal Navy classified warships by 'rating' based on number of guns: a first-rate ship of the line carried 100+ guns on three decks. Maps a precise military classification system onto a vague quality judgment. 'First-rate' now means simply 'excellent,' with no memory of the gun-count taxonomy."
+    },
+    {
+      "slug": "copper-bottomed",
+      "name": "Copper-Bottomed",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "economics",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "Sheathing a ship's hull in copper prevented barnacle growth and shipworm damage, but was expensive. Only the best-funded ships got copper bottoms. Maps the most reliable and expensive protection technology onto financial guarantees or investments considered completely trustworthy. Common in British financial language."
+    },
+    {
+      "slug": "jury-rigged",
+      "name": "Jury-Rigged",
+      "kind": "dead-metaphor",
+      "source_frame": "seafaring",
+      "target_frame": "tool-use",
+      "categories": ["linguistics"],
+      "source": "archive",
+      "description": "A jury mast or jury rig was a temporary replacement assembled from whatever materials were available after storm damage. Maps emergency improvisation at sea -- where failure means death -- onto any makeshift solution. Often confused with 'jerry-rigged' (from 'jerry-built'), the two have merged in common usage."
+    }
+  ]
+}

--- a/playbooks/nautical-terms/playbook.md
+++ b/playbooks/nautical-terms/playbook.md
@@ -1,0 +1,166 @@
+---
+project_issue: 1226
+repo: metaphorex/metaphorex
+source_type: web
+status: draft
+---
+
+# Nautical Terms -- Seafaring Metaphors in Everyday Language
+
+## Source Description
+
+The English language contains an extraordinary concentration of dead metaphors
+from seafaring. The Age of Sail (16th-19th centuries) produced professional
+vocabulary that migrated into everyday English as the metaphors' nautical
+origins were forgotten. Terms like "loose cannon," "bitter end," "taken
+aback," and "by and large" are now fully dead -- used daily by people who
+have never been on a sailing vessel.
+
+The primary structured source is the **Wikipedia Glossary of Nautical Terms**,
+split across two pages (A-L and M-Z) with hundreds of entries. However, the
+glossary contains mostly pure nautical vocabulary (starboard, halyard, cleat)
+that never entered metaphorical use. The real value comes from cross-referencing
+the glossary against curated lists of nautical terms that have migrated into
+common usage.
+
+**Primary references cited in the import issue:**
+
+- Olivia Isil, *When a Loose Cannon Flogs a Dead Horse There's the Devil
+  to Pay* (Ragged Mountain Press, 2003) -- book-length treatment of nautical
+  terms in everyday English
+- Beavis & McCloskey, *Salty Dog Talk: The Nautical Origins of Everyday
+  Expressions* (Sheridan House, 1983) -- earlier systematic catalog
+
+## Access Method
+
+**Structured web archives used for extraction:**
+
+1. **NOAA Nautical Terms** --
+   https://oceanservice.noaa.gov/navigation/nautical-terms.html
+   US government page listing common phrases with nautical origins.
+   Well-structured, freely accessible.
+
+2. **Royal Museums Greenwich** --
+   https://www.rmg.co.uk/stories/maritime-history/nautical-origins-everyday-phrases
+   Curated list from the UK's national maritime museum. Includes detailed
+   etymologies and original nautical context. Highest-quality single source
+   for etymological accuracy.
+
+3. **Rubicon3 Sailor Sayings** --
+   https://www.rubicon3adventure.com/50-sailor-sayings-you-wont-believe-are-part-of-your-daily-speech/
+   50-item list with concise origins and modern meanings.
+
+4. **Wikipedia Glossary of Nautical Terms** --
+   https://en.wikipedia.org/wiki/Glossary_of_nautical_terms_(A%E2%80%93L)
+   https://en.wikipedia.org/wiki/Glossary_of_nautical_terms_(M%E2%80%93Z)
+   Comprehensive reference for verifying nautical origins and technical
+   details. Not used as primary extraction source (too much non-metaphorical
+   vocabulary) but essential for fact-checking.
+
+**Extraction script:** `scripts/extract_nautical_metaphors.py` fetches the
+NOAA and RMG pages and extracts term lists. The script is supplementary --
+the actual candidate list was curated by cross-referencing all four web
+archives plus the book references listed in the import issue.
+
+```bash
+uv run playbooks/nautical-terms/scripts/extract_nautical_metaphors.py
+```
+
+## Extraction Strategy
+
+The Wikipedia glossary contains hundreds of entries. The import issue
+estimates 20-35 mappings after heavy curation. The selection criteria:
+
+**Include if:**
+
+1. The term has genuinely migrated into non-nautical discourse -- people
+   use it without knowing its seafaring origin
+2. The term functions as a structural metaphor, not just an etymology
+   curiosity -- it maps a source-domain relationship onto a target domain
+3. There is a substantive "Where It Breaks" -- the nautical origin encodes
+   assumptions that fail when applied to the modern usage
+4. The term appears in at least two of the four web archive sources
+
+**Exclude if:**
+
+- Pure nautical vocabulary that never left the domain (starboard, halyard,
+  bowsprit, jib)
+- Terms where the nautical connection is disputed or folk etymology
+  (e.g., "the whole nine yards" -- disputed origin, possibly not nautical)
+- Terms that are essentially synonyms of already-included terms (e.g.,
+  "smooth sailing" and "plain sailing" are the same metaphor)
+- Terms too thin for a full mapping entry (e.g., "skipper" -- yes it's
+  nautical, no there's nothing interesting to say about where it breaks)
+
+**Result:** 35 candidates selected. All sourced from the web archives above.
+
+**Frame assignment:** All candidates use `seafaring` as source_frame. This
+is a new frame that needs to be created. Target frames vary by what the
+metaphor illuminates in its modern usage.
+
+## Schema Mapping
+
+| Archive field | Metaphorex field | Notes |
+|--------------|-----------------|-------|
+| Term name | `name` | Title-cased |
+| Term slug | `slug` | kebab-cased |
+| Nautical origin | Feeds "What It Brings" | The original seafaring context |
+| Modern meaning | Feeds "What It Brings" | The metaphorical migration |
+| n/a | `kind` | Almost all `dead-metaphor` |
+| n/a | `source_frame` | `seafaring` for all |
+| n/a | `target_frame` | Varies by modern usage domain |
+
+**Kind assignment:** Nearly all entries are `dead-metaphor` -- terms whose
+nautical origins have been forgotten by most speakers. A few could be argued
+as `conceptual-metaphor` if they are still used with awareness of the
+nautical source (e.g., "sailing close to the wind" where the sailing image
+is still somewhat active). The Miner should make the final call.
+
+**Author:** All entries use `author: agent:metaphorex-miner`.
+
+## Gotchas
+
+1. **New frame required:** `seafaring` does not exist in `catalog/frames/`.
+   The Miner must create it. Roles should include: vessel, crew, wind,
+   rigging, cargo, harbor, course, weather, rank, armament.
+
+2. **Category:** All candidates use `linguistics` as their primary category.
+   This is appropriate since the project is about linguistic migration of
+   terms, not about sailing per se.
+
+3. **"Where It Breaks" is the key value-add.** The web archives provide
+   the nautical origin and modern meaning. What they do NOT provide is
+   analysis of where the metaphor fails -- the structural tensions between
+   the nautical source and the modern usage. This is where the Miner adds
+   genuine value. The import issue emphasizes this: "dead metaphors whose
+   limits nobody thinks about are the most interesting."
+
+4. **Disputed etymologies.** Some nautical origins are folk etymology.
+   "The whole nine yards" is excluded because its nautical attribution is
+   disputed. "Let the cat out of the bag" has competing nautical (cat-o'-
+   nine-tails) and market (pig-in-a-poke) etymologies -- it is excluded.
+   "Pipe down" and "toe the line" have both nautical and non-nautical
+   proposed origins. Where included, the Miner should note the disputed
+   etymology.
+
+5. **Clusters by rigging, weather, punishment, and navigation.** The import
+   issue notes that nautical metaphors come in clusters. The Miner should
+   use the `related` field to link terms within clusters:
+   - **Rigging terms:** know-the-ropes, jury-rigged, mainstay,
+     three-sheets-to-the-wind
+   - **Weather/wind terms:** in-the-doldrums, taken-aback,
+     sailing-close-to-the-wind, take-wind-out-of-sails
+   - **Punishment terms:** keelhauled, over-a-barrel
+   - **Navigation terms:** even-keel, leeway, try-different-tack,
+     plain-sailing
+   - **Combat terms:** loose-cannon, shot-across-the-bow,
+     showing-true-colors, first-rate
+
+6. **Existing catalog entry:** `boat-anchor` already exists with
+   source_frame `tool-use` and target_frame `software-programs`. It is a
+   software-specific dead metaphor, not a general nautical term, so it is
+   not duplicated here. The Miner should add `boat-anchor` to the `related`
+   field of relevant entries.
+
+7. **Candidate count (35) is well under the 100 sub-issue cap.** No
+   overflow handling needed.

--- a/playbooks/nautical-terms/scripts/extract_nautical_metaphors.py
+++ b/playbooks/nautical-terms/scripts/extract_nautical_metaphors.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["requests", "beautifulsoup4"]
+# ///
+"""
+Extract nautical terms from curated web archives that have migrated
+into everyday English as metaphors.
+
+Primary sources:
+  - NOAA: https://oceanservice.noaa.gov/navigation/nautical-terms.html
+  - Royal Museums Greenwich: https://www.rmg.co.uk/stories/maritime-history/nautical-origins-everyday-phrases
+  - Rubicon3: https://www.rubicon3adventure.com/50-sailor-sayings-you-wont-believe-are-part-of-your-daily-speech/
+
+The script fetches these pages, parses the nautical terms mentioned,
+and outputs a JSON list of terms with their nautical origin and modern
+metaphorical meaning. This is used as an input to build the manifest.
+
+Usage:
+    python3 extract_nautical_metaphors.py
+    python3 extract_nautical_metaphors.py --cached   # use cached HTML files
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+try:
+    import requests
+    from bs4 import BeautifulSoup
+except ImportError:
+    print("Install deps: pip install requests beautifulsoup4", file=sys.stderr)
+    sys.exit(1)
+
+SOURCES = [
+    {
+        "name": "NOAA Nautical Terms",
+        "url": "https://oceanservice.noaa.gov/navigation/nautical-terms.html",
+    },
+    {
+        "name": "Royal Museums Greenwich",
+        "url": "https://www.rmg.co.uk/stories/maritime-history/nautical-origins-everyday-phrases",
+    },
+]
+
+CACHE_DIR = Path(__file__).parent / ".cache"
+
+
+def fetch_or_cache(url: str, name: str, use_cache: bool) -> str:
+    """Fetch URL content, optionally caching to disk."""
+    CACHE_DIR.mkdir(exist_ok=True)
+    cache_file = CACHE_DIR / f"{name.replace(' ', '_').lower()}.html"
+
+    if use_cache and cache_file.exists():
+        return cache_file.read_text()
+
+    resp = requests.get(url, timeout=30, headers={"User-Agent": "Metaphorex-Prospector/1.0"})
+    resp.raise_for_status()
+    html = resp.text
+    cache_file.write_text(html)
+    return html
+
+
+def extract_noaa(html: str) -> list[dict]:
+    """Extract terms from NOAA nautical terms page."""
+    soup = BeautifulSoup(html, "html.parser")
+    terms = []
+
+    # NOAA uses h2/h3 headings or bold terms followed by descriptions
+    for heading in soup.find_all(["h2", "h3"]):
+        text = heading.get_text(strip=True)
+        # Skip navigation/structural headings
+        if text.lower() in ("", "navigation", "search", "menu"):
+            continue
+        desc_parts = []
+        for sib in heading.find_next_siblings():
+            if sib.name in ("h2", "h3"):
+                break
+            desc_parts.append(sib.get_text(strip=True))
+        desc = " ".join(desc_parts).strip()
+        if desc and len(text) < 100:
+            terms.append({"term": text, "description": desc, "source": "NOAA"})
+
+    return terms
+
+
+def extract_rmg(html: str) -> list[dict]:
+    """Extract terms from Royal Museums Greenwich page."""
+    soup = BeautifulSoup(html, "html.parser")
+    terms = []
+
+    for heading in soup.find_all(["h2", "h3"]):
+        text = heading.get_text(strip=True)
+        if len(text) > 100 or text.lower() in ("", "related stories", "share"):
+            continue
+        desc_parts = []
+        for sib in heading.find_next_siblings():
+            if sib.name in ("h2", "h3"):
+                break
+            desc_parts.append(sib.get_text(strip=True))
+        desc = " ".join(desc_parts).strip()
+        if desc:
+            terms.append({"term": text, "description": desc, "source": "Royal Museums Greenwich"})
+
+    return terms
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Extract nautical metaphors from web archives")
+    parser.add_argument("--cached", action="store_true", help="Use cached HTML files")
+    args = parser.parse_args()
+
+    all_terms = []
+
+    for source in SOURCES:
+        try:
+            html = fetch_or_cache(source["url"], source["name"], args.cached)
+            if "noaa" in source["url"]:
+                terms = extract_noaa(html)
+            elif "rmg" in source["url"]:
+                terms = extract_rmg(html)
+            else:
+                terms = []
+            all_terms.extend(terms)
+            print(f"Extracted {len(terms)} terms from {source['name']}", file=sys.stderr)
+        except Exception as e:
+            print(f"Warning: Failed to fetch {source['name']}: {e}", file=sys.stderr)
+
+    # Deduplicate by normalized term name
+    seen = set()
+    unique = []
+    for t in all_terms:
+        key = re.sub(r"[^a-z]", "", t["term"].lower())
+        if key not in seen:
+            seen.add(key)
+            unique.append(t)
+
+    json.dump(unique, sys.stdout, indent=2)
+    print(f"\nTotal unique terms: {len(unique)}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Playbook, manifest, and extraction script for **Nautical Terms** import project (issue #1226)
- 35 candidate dead metaphors from seafaring that have migrated into everyday English
- All candidates sourced from cross-referencing four structured web archives: NOAA, Royal Museums Greenwich, Wikipedia glossary, Rubicon3
- Extraction script fetches and parses NOAA and RMG pages for term lists

## Archive sources

- [NOAA Nautical Terms](https://oceanservice.noaa.gov/navigation/nautical-terms.html)
- [Royal Museums Greenwich](https://www.rmg.co.uk/stories/maritime-history/nautical-origins-everyday-phrases)
- [Wikipedia Glossary of Nautical Terms (A-L)](https://en.wikipedia.org/wiki/Glossary_of_nautical_terms_(A%E2%80%93L))
- [Rubicon3 Sailor Sayings](https://www.rubicon3adventure.com/50-sailor-sayings-you-wont-believe-are-part-of-your-daily-speech/)

## Candidate highlights (35 total)

Rigging cluster: know-the-ropes, jury-rigged, mainstay, three-sheets-to-the-wind
Weather cluster: in-the-doldrums, taken-aback, sailing-close-to-the-wind
Combat cluster: loose-cannon, shot-across-the-bow, showing-true-colors, first-rate
Navigation cluster: even-keel, leeway, try-different-tack, plain-sailing

## Test plan

- [ ] Surveyor reviews manifest completeness against archive sources
- [ ] Verify no duplicate slugs with existing catalog entries
- [ ] Confirm `seafaring` frame will be created by Miner during extraction

Generated with [Claude Code](https://claude.com/claude-code)