### PR TITLE
Add mapping: gordian-knot

### DIFF
--- a/catalog/mappings/gordian-knot.md
+++ b/catalog/mappings/gordian-knot.md
@@ -1,0 +1,165 @@
+---
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- social-dynamics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Gordian Knot
+related:
+- augean-stables
+- damocles-sword
+slug: gordian-knot
+source_frame: mythology
+target_frame: social-behavior
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+Gordius, a peasant who became king of Phrygia, tied his ox-cart to a pole
+in the temple of Zeus with a knot so intricate that no one could find its
+ends. An oracle declared that whoever untied it would rule all of Asia.
+Alexander the Great, confronted with the knot in 333 BCE, cut it with his
+sword. The metaphor maps an impossibly complex entanglement onto any
+problem that resists conventional analysis -- and maps Alexander's sword
+stroke onto the decision to bypass complexity rather than resolve it.
+
+- **The knot represents problems whose complexity is the problem** --
+  a Gordian knot is not merely difficult. It is difficult in a way that
+  makes the standard approach (finding the ends, tracing the strands,
+  working through the tangle patiently) effectively impossible. The
+  metaphor names situations where the interconnections themselves are
+  the obstacle: regulatory frameworks so interlocking that no single
+  provision can be changed without affecting dozens of others,
+  geopolitical conflicts where every proposed solution creates new
+  stakeholders, legacy codebases where every module depends on every
+  other module. The knot is not a puzzle to be solved but a structure
+  that defeats the concept of solution.
+
+- **Cutting names a category of action, not just a method** -- Alexander
+  did not untie the knot; he redefined the problem. The oracle said
+  "whoever loosens this knot" and Alexander decided that a sword counts
+  as loosening. The metaphor imports this epistemological move: to "cut
+  the Gordian knot" is to refuse the terms of the problem as stated
+  and substitute a different frame. A startup that cannot compete on
+  features abandons the feature war and competes on price. A diplomat
+  who cannot negotiate a treaty between two countries brokers a
+  bilateral agreement that renders the treaty unnecessary. The cut is
+  always a reframing.
+
+- **Boldness is valorized over patience** -- the knot sat in the temple
+  for generations. Many people presumably attempted to untie it using
+  careful, methodical approaches. Alexander's fame comes from the speed
+  and violence of his solution. The metaphor consistently celebrates
+  decisive, even reckless, action over careful analysis. When someone
+  says "we need to cut the Gordian knot," they are advocating for bold
+  simplification, not for more research.
+
+- **The oracle legitimizes the result** -- the prophecy said the person
+  who loosened the knot would rule Asia. Alexander did go on to conquer
+  the Persian Empire. The metaphor carries a hidden teleological
+  structure: cutting the knot worked, therefore it was the right
+  approach. This survivorship bias is built into every invocation of
+  the phrase.
+
+## Where It Breaks
+
+- **Most complex problems are not knots** -- a knot is a single physical
+  object with a binary state: tied or untied. Real institutional,
+  political, and technical problems are distributed across many actors,
+  systems, and time horizons. They cannot be "cut" in a single stroke
+  because there is no single thing to cut. The metaphor encourages the
+  belief that somewhere in every complex situation there is a single
+  point of intervention, a single cord to sever, when in reality the
+  complexity is genuine and irreducible. Attempting to "cut" such
+  problems typically shifts the complexity elsewhere rather than
+  eliminating it.
+
+- **Alexander's solution destroyed information** -- untying the knot
+  would have preserved the rope intact. Cutting it destroyed the knot's
+  structure permanently. In problem-solving terms, brute-force solutions
+  that bypass complexity often destroy valuable structure: the company
+  that resolves a complex merger dispute by pulling out of the deal, the
+  government that simplifies its tax code by eliminating deductions that
+  served real purposes, the engineer who rewrites a legacy system and
+  loses years of embedded domain knowledge. The metaphor treats this
+  destruction as costless because the knot itself had no value. But in
+  real systems, the "knot" -- the complex interdependencies -- often
+  encodes important information.
+
+- **The prophecy is unfalsifiable** -- Alexander cut the knot and
+  conquered Asia. But correlation is not causation, and we do not know
+  what would have happened if someone had untied it properly. The
+  metaphor inherits this problem: when someone "cuts the Gordian knot"
+  in business or politics, any subsequent success is attributed to the
+  bold stroke, and any subsequent failure is attributed to other factors.
+  The metaphor has no mechanism for evaluating whether the cut was
+  actually the right move.
+
+- **The metaphor erases the people harmed by the cut** -- Alexander's
+  campaign to "rule Asia" involved the conquest and subjugation of
+  millions of people. The knot-cutting is remembered as a moment of
+  genius; the decade of warfare that followed is a separate story. When
+  leaders "cut Gordian knots" in organizational contexts -- eliminating
+  a complex process, overriding stakeholder objections, forcing through
+  a restructuring -- the people displaced by that boldness are as
+  invisible as the Persians in the knot story.
+
+- **Patience sometimes works** -- the metaphor assumes the knot is
+  genuinely impossible to untie, but we only have Alexander's word for
+  that. Many problems that appear intractable yield to sustained,
+  patient analysis. The Gordian knot metaphor provides rhetorical cover
+  for impatience, framing the refusal to engage with complexity as
+  strategic brilliance rather than laziness or incapacity.
+
+## Expressions
+
+- "Cut the Gordian knot" -- the standard idiom for resolving an
+  intractable problem through bold, unconventional action, used widely
+  in business, politics, and everyday speech
+
+- "A Gordian knot" -- any problem so complex and tangled that
+  conventional approaches seem hopeless, common in policy discussions
+  and editorial writing
+
+- "Gordian" -- the adjective form, used to describe problems,
+  situations, or entanglements that resist systematic unraveling
+  (e.g., "Gordian complexity")
+
+- "Untie the Gordian knot" -- the less common variant that implies
+  patient resolution rather than violent simplification, sometimes
+  used to contrast with the cutting metaphor
+
+- "Slice through the knot" -- a variant that preserves the structure
+  while softening the violence of "cut," common in management writing
+
+## Origin Story
+
+The story of the Gordian knot is attested in multiple ancient sources,
+including Arrian's *Anabasis of Alexander* (2nd century CE), Plutarch's
+*Life of Alexander*, and Quintus Curtius Rufus's *Histories of Alexander
+the Great*. The sources disagree on the method: Arrian reports that
+Alexander cut the knot with his sword, while Aristobulus (quoted by
+Arrian) says Alexander removed the pin from the yoke-pole, which allowed
+the knot to be pulled apart. The cutting version prevailed in popular
+memory, probably because it is more dramatic.
+
+The idiom entered English by the 16th century. By the 18th century,
+"cutting the Gordian knot" was a standard metaphor in political rhetoric
+for decisive leadership. It remains widely used, though many speakers
+know only the phrase and not the story behind it -- placing it firmly
+in dead-metaphor territory.
+
+## References
+
+- Arrian. *Anabasis of Alexander*, Book 2.3 -- the most detailed
+  ancient account, including the competing traditions of cutting versus
+  removing the pin
+- Plutarch. *Life of Alexander*, 18 -- the briefer account that
+  emphasizes the oracle and Alexander's ambition
+- Quintus Curtius Rufus. *Histories of Alexander the Great*, 3.1 --
+  the Latin account that helped transmit the story to medieval and
+  Renaissance Europe


### PR DESCRIPTION
## Summary

- Adds `gordian-knot` dead metaphor mapping from Greek mythology
- An intractable problem solved by bold, unconventional action rather than analysis
- Source frame: mythology, Target frame: social-behavior

Closes #1118
Part of #219 (fantasy-mythology-folklore import project)

## Validator output

```
All content valid.
```

(27 pre-existing dangling-reference warnings, none introduced by this PR)