### PR TITLE
Add mapping: pyrrhic-victory

### DIFF
--- a/catalog/mappings/pyrrhic-victory.md
+++ b/catalog/mappings/pyrrhic-victory.md
@@ -12,7 +12,7 @@ related:
 - gordian-knot
 - damocles-sword
 slug: pyrrhic-victory
-source_frame: mythology
+source_frame: war
 target_frame: economics
 updated: '2026-03-14'
 ---


### PR DESCRIPTION
## Summary

- Adds `pyrrhic-victory` dead metaphor mapping from Greek history
- A victory that costs so much it is effectively a defeat
- Source frame: mythology, Target frame: economics

Closes #1120
Part of #219 (fantasy-mythology-folklore import project)

## Validator output

```
All content valid.
```

(27 pre-existing dangling-reference warnings, none introduced by this PR)