### PR TITLE
Add mapping: procrustean-bed

### DIFF
--- a/catalog/frames/social-control.md
+++ b/catalog/frames/social-control.md
@@ -1,0 +1,23 @@
+---
+created: '2026-03-14'
+name: Social Control
+related:
+- social-behavior
+- governance
+roles:
+- authority
+- subject
+- standard
+- enforcement
+- conformity
+- deviance
+slug: social-control
+updated: '2026-03-14'
+---
+
+Mechanisms by which individuals, groups, or institutions regulate behavior
+to maintain order and enforce conformity to norms. Includes formal systems
+(law, bureaucracy, surveillance) and informal ones (shame, peer pressure,
+customs). Productive as a target domain because control mechanisms are
+often invisible to those subject to them, and metaphors make the coercion
+visible.

--- a/catalog/mappings/procrustean-bed.md
+++ b/catalog/mappings/procrustean-bed.md
@@ -1,0 +1,156 @@
+---
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- social-dynamics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Procrustean Bed
+related:
+- gordian-knot
+- augean-stables
+slug: procrustean-bed
+source_frame: mythology
+target_frame: social-control
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+Procrustes (the "Stretcher") was a rogue smith and bandit in Attic
+mythology who kept an iron bed in his lair on the road between Athens
+and Eleusis. He offered hospitality to travelers, then forced them to
+fit the bed exactly: if they were too short, he stretched them on a rack;
+if too tall, he amputated the excess. The bed was the standard; the
+person was the variable. The metaphor maps this structure onto any system
+that forces conformity to an arbitrary standard by distorting the thing
+being measured rather than adjusting the standard.
+
+- **The standard is arbitrary, not the subject** -- the Procrustean
+  insight is that the bed is not the right size for anyone. It was not
+  designed to fit human beings; human beings are forced to fit it. The
+  metaphor names situations where the framework, template, rubric,
+  or process is treated as fixed and the reality it is supposed to
+  serve is mutilated to match. A standardized test that measures
+  compliance with a curriculum rather than understanding. A performance
+  review template that forces every employee into the same categories.
+  A data model that truncates or pads real-world values to fit
+  predetermined column widths.
+
+- **The violence is normalized as hospitality** -- Procrustes offered
+  his bed as a kindness. The metaphor captures the specific horror of
+  coercion disguised as help. "We're putting you through this process
+  for your own development." "This standardized framework will make
+  things easier for everyone." The Procrustean element is not the
+  existence of a standard but the insistence that conformity to the
+  standard is a service to the person being deformed.
+
+- **Cutting and stretching are both distortions** -- the metaphor
+  includes two modes of violence: removal (amputating what exceeds the
+  standard) and inflation (stretching what falls short). Applied to
+  institutions, cutting maps onto suppressing individuality, trimming
+  scope, eliminating nuance, or forcing simplification. Stretching maps
+  onto padding, inflating, over-generalizing, or forcing claims beyond
+  what the evidence supports. Both are driven by the same cause: a
+  rigid template that admits no variation.
+
+- **The word has become a standard adjective** -- "Procrustean" appears
+  in academic writing, policy criticism, and education discourse as a
+  compact label for any one-size-fits-all approach that harms its
+  subjects. Many users know the word means "forcing conformity" without
+  knowing the myth.
+
+## Where It Breaks
+
+- **Some standards are not arbitrary** -- the metaphor treats all
+  standardization as violent conformity, but some standards exist for
+  good reasons. Building codes, medical protocols, and safety
+  regulations impose uniform requirements because the alternative is
+  worse. Not every fixed standard is a Procrustean bed; some are
+  engineered constraints that prevent catastrophe. The metaphor provides
+  no mechanism for distinguishing between a standard that is arbitrary
+  and one that is necessary.
+
+- **Procrustes acts on bodies; institutions act on behavior** -- the
+  myth is about physical mutilation: literal amputation and stretching.
+  Institutional standardization operates on behavior, output, and
+  representation, not on bodies. The metaphor imports the visceral
+  horror of physical violence into situations that are often merely
+  inconvenient or frustrating. Filling out a standardized form is not
+  being stretched on a rack, but the Procrustean label makes it sound
+  like it is. This can trivialize actual coercion by placing it on a
+  continuum with minor bureaucratic annoyances.
+
+- **The bed has one size; real standards have ranges** -- Procrustes's
+  bed is a single fixed length. But most real-world standards define
+  acceptable ranges, not single points. A grading rubric has multiple
+  levels; a building code specifies minimums, not exact dimensions. The
+  metaphor is most accurate for truly rigid, single-point standards and
+  least accurate for systems that allow variation within bounds.
+
+- **The metaphor erases the possibility of good fit** -- in the myth,
+  no traveler fits the bed. But standardized systems do fit many of
+  their subjects adequately. The Procrustean framing assumes universal
+  mismatch, which makes it a tool for critique but not for reform. It
+  can identify when a standard is wrong but cannot help determine what
+  a right standard would look like, because it treats the concept of a
+  standard itself as suspect.
+
+- **Theseus killed Procrustes with his own method** -- in the myth,
+  the hero Theseus forces Procrustes onto his own bed and cuts him to
+  fit. This detail suggests that the appropriate response to forced
+  conformity is retributive violence using the same tool -- a moral
+  structure that modern applications of the metaphor rarely intend.
+
+## Expressions
+
+- "A Procrustean bed" -- the standard idiom for any system or framework
+  that forces its subjects into a predetermined shape, common in
+  academic and policy writing
+
+- "Procrustean" -- the adjective form, applied to standards, methods,
+  frameworks, and institutions that demand rigid conformity (e.g.,
+  "Procrustean standardization," "a Procrustean approach to assessment")
+
+- "One size fits all" -- the colloquial equivalent that preserves the
+  structural complaint without the classical reference
+
+- "Stretching or cutting to fit" -- the expanded form that names both
+  modes of distortion, used when the speaker wants to be specific about
+  the direction of the deformation
+
+- "Cookie-cutter approach" -- a related domestic metaphor that captures
+  the same structural complaint (identical output from varied input) but
+  without the violence
+
+## Origin Story
+
+Procrustes appears in the Theseus cycle of Attic mythology, attested in
+Apollodorus' *Bibliotheca* (c. 1st-2nd century CE), Diodorus Siculus'
+*Library of History*, and Plutarch's *Life of Theseus*. His full name
+varies by source: Damastes, Polypemon, or Prokoptas. He is one of
+several bandits Theseus encounters on the road from Troezen to Athens,
+each representing a different mode of arbitrary violence that the hero
+must overcome.
+
+The adjective "Procrustean" entered English by the 19th century, initially
+in philosophical and political writing about the dangers of imposed
+uniformity. It gained wider currency in the 20th century through education
+reform debates and critiques of bureaucratic standardization. Nassim
+Nicholas Taleb popularized the concept for a modern audience in *The Bed
+of Procrustes* (2010), a collection of aphorisms about how humans force
+the world to fit their models rather than adjusting their models to fit
+the world.
+
+## References
+
+- Apollodorus. *Bibliotheca*, Epitome 1.4 -- the canonical mythological
+  account of Procrustes and his defeat by Theseus
+- Plutarch. *Life of Theseus*, 11 -- the parallel account with emphasis
+  on Theseus as civilizing hero
+- Taleb, N.N. *The Bed of Procrustes: Philosophical and Practical
+  Aphorisms*. Random House, 2010 -- modern application of the metaphor
+  to epistemology, modeling, and the human tendency to distort reality
+  to fit theory


### PR DESCRIPTION
## Summary

- Adds `procrustean-bed` dead metaphor mapping from Greek mythology
- Forcing conformity to an arbitrary standard; one-size-fits-all approaches
- Source frame: mythology, Target frame: social-control (new frame)
- Creates new `social-control` frame

Closes #1121
Part of #219 (fantasy-mythology-folklore import project)

## Validator output

```
All content valid.
```

(27 pre-existing dangling-reference warnings, none introduced by this PR)