### PR TITLE
Add mapping: cerberus

### DIFF
--- a/catalog/mappings/cerberus.md
+++ b/catalog/mappings/cerberus.md
@@ -1,0 +1,161 @@
+---
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- security
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Cerberus
+related:
+- gordian-knot
+- damocles-sword
+slug: cerberus
+source_frame: mythology
+target_frame: network-security
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+Cerberus was the monstrous three-headed dog that guarded the entrance to
+the Greek underworld. He permitted the dead to enter but prevented anyone
+from leaving, and he kept the living from entering uninvited. The metaphor
+maps this guardian function onto access control systems, security
+protocols, and gatekeeping mechanisms -- anything that stands at a
+boundary and enforces directional or identity-based rules about who may
+pass.
+
+- **The guardian is monstrous by design** -- Cerberus is not a friendly
+  doorman. He is a three-headed dog with a serpent's tail, a mane of
+  snakes, and claws. The metaphor imports this deliberately terrifying
+  quality: a security system named Cerberus (or its Latinized form
+  Kerberos) is not meant to be welcoming. The monstrosity is functional.
+  The MIT Kerberos authentication protocol, developed in the 1980s, was
+  named to convey that the system is a fierce, uncompromising guardian
+  of network boundaries. The name tells users and attackers alike that
+  this is not a system to be trifled with.
+
+- **Three heads map onto multi-factor or multi-party verification** --
+  Cerberus's three heads have been variously interpreted, but in the
+  security domain they map naturally onto the three entities in the
+  Kerberos protocol: the client, the server, and the Key Distribution
+  Center. The multiplicity is structural, not decorative. A single-headed
+  guardian can be fooled or distracted; three heads watching
+  simultaneously are harder to evade. The metaphor suggests that
+  effective gatekeeping requires multiple simultaneous checks.
+
+- **The boundary is directional** -- Cerberus enforces asymmetric rules.
+  The dead may enter Hades but not leave. The living may not enter at
+  all. This maps onto access control systems that enforce different
+  permissions for different directions and different identities: a
+  firewall that allows outbound traffic but blocks inbound, an API
+  gateway that permits reads but restricts writes, a border control
+  system that distinguishes between entry and exit.
+
+- **The guardian is not the authority** -- Cerberus does not make policy.
+  He enforces Hades' rules. The metaphor preserves this separation
+  between enforcement and authority: a Kerberos server does not decide
+  who should have access; it enforces the policies set by administrators.
+  The guardian is powerful but subordinate, fearsome but instrumental.
+
+## Where It Breaks
+
+- **Cerberus can be bypassed** -- the myth includes multiple stories of
+  heroes getting past Cerberus. Orpheus lulled him with music. The Sibyl
+  drugged him with a honey cake. Heracles wrestled him into submission.
+  If the metaphor is taken seriously, it implies that any security system
+  can be circumvented with sufficient skill, deception, or brute force.
+  This is arguably accurate for real security systems, but it undermines
+  the very confidence the name is meant to inspire. A guardian that
+  heroes routinely defeat is not a strong brand for an authentication
+  protocol.
+
+- **The three heads have no consistent mapping** -- in the original
+  myth, the three heads are simply three heads. They do not represent
+  distinct functions, perspectives, or verification methods. The
+  Kerberos protocol's three-party architecture is a convenient
+  coincidence, not a structural parallel. Trying to map each head to a
+  specific protocol component produces forced analogies that do not
+  illuminate either the myth or the technology.
+
+- **Cerberus guards a place; network security guards a resource** --
+  the underworld is a physical location with a single entrance. Network
+  resources are distributed, replicated, and accessible from multiple
+  points simultaneously. The single-gateway model that Cerberus implies
+  is architecturally outdated in an era of distributed systems, zero-trust
+  networks, and cloud computing where there is no single gate to guard.
+
+- **The metaphor assumes a clear inside and outside** -- Cerberus stands
+  at the border between the world of the living and the world of the
+  dead. This presupposes a clear boundary with a definable perimeter.
+  Modern network security has largely abandoned perimeter-based models
+  in favor of zero-trust architectures where every request is verified
+  regardless of origin. The Cerberus metaphor is a perimeter metaphor,
+  and perimeter thinking is precisely what contemporary security
+  frameworks are trying to move beyond.
+
+- **Cerberus never sleeps but servers go down** -- the mythological
+  guardian is eternal and tireless. Real authentication servers require
+  maintenance, experience outages, and must be redundantly deployed. The
+  metaphor imports an assumption of permanence and reliability that no
+  actual system achieves, creating expectations that the technology
+  cannot meet.
+
+## Expressions
+
+- "Kerberos" -- the Latinized spelling used for the MIT authentication
+  protocol, now the standard network authentication system in Windows
+  Active Directory and many enterprise environments
+
+- "A cerberus at the gate" -- the generic usage for any fierce or
+  unyielding gatekeeper, applied to doormen, receptionists, executive
+  assistants, and anyone who controls access to a person or resource
+
+- "Three-headed dog" -- the descriptive form used when the speaker
+  wants to emphasize the multiplicity or ferocity of a security
+  mechanism without using the proper name
+
+- "Guarding the gates of hell" -- the expanded allusion, used
+  humorously for anyone assigned to an unpleasant gatekeeping role
+  (e.g., moderating online forums, manning a complaints desk)
+
+- "Sop to Cerberus" -- from the Sibyl's honey cake in the *Aeneid*,
+  meaning a bribe or concession offered to get past a gatekeeper,
+  still used in British English though increasingly rare
+
+## Origin Story
+
+Cerberus appears in the earliest Greek literary sources: Hesiod's
+*Theogony* (c. 700 BCE) describes him as a fifty-headed dog, later
+standardized to three heads by the classical period. Homer mentions him
+obliquely in the *Iliad* and *Odyssey*. The most detailed mythological
+accounts come from Apollodorus' *Bibliotheca* and Virgil's *Aeneid*
+(Book 6), where the Sibyl drugs Cerberus with a soporific cake to guide
+Aeneas into the underworld.
+
+The security application of the name dates to 1988, when MIT's Project
+Athena released the Kerberos authentication protocol (using the Latin
+spelling). The choice of name was deliberate: the protocol authenticates
+across a three-party system (client, server, trusted third party),
+and the mythological guardian's function -- enforcing access rules at a
+boundary -- mapped cleanly onto the protocol's purpose. Kerberos became
+the default authentication protocol for Microsoft Windows 2000 and
+remains foundational to enterprise network security.
+
+The word "cerberus" as a common noun meaning "a fierce guardian" has been
+in English since at least the 16th century. By the 21st century, most
+speakers encounter the word primarily through the Kerberos protocol or
+through general cultural references to Greek mythology, rather than
+through direct reading of classical texts.
+
+## References
+
+- Hesiod. *Theogony*, 310-312 -- the earliest literary reference to
+  Cerberus, describing him as a fifty-headed dog
+- Virgil. *Aeneid*, Book 6.417-423 -- the Sibyl's drugged cake,
+  source of the "sop to Cerberus" idiom
+- Neuman, B.C. and Ts'o, T. "Kerberos: An Authentication Service for
+  Computer Networks." *IEEE Communications Magazine* 32.9 (1994) --
+  the definitive technical description of the protocol and its naming


### PR DESCRIPTION
## Summary

- Adds `cerberus` dead metaphor mapping from Greek mythology
- A fierce gatekeeper; authentication/access control systems (Kerberos protocol)
- Source frame: mythology, Target frame: network-security

Closes #1123
Part of #219 (fantasy-mythology-folklore import project)

## Validator output

```
All content valid.
```

(27 pre-existing dangling-reference warnings, none introduced by this PR)