### PR TITLE
Add mapping: pandemonium

### DIFF
--- a/catalog/mappings/pandemonium.md
+++ b/catalog/mappings/pandemonium.md
@@ -1,0 +1,132 @@
+---
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- social-dynamics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Pandemonium
+related:
+- augean-stables
+- damocles-sword
+slug: pandemonium
+source_frame: mythology
+target_frame: social-behavior
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+John Milton coined "Pandaemonium" in *Paradise Lost* (1667) as the name
+of the capital city of Hell -- literally "all demons" in Greek
+(pan + daimonion). It was a proper noun: a specific place, an infernal
+palace built by Mammon where Satan convened his parliament of fallen
+angels. By the 18th century the word had migrated from place to state,
+from a city to a condition. Today "pandemonium" means wild uproar, total
+disorder, a scene of uncontrolled chaos. The demons are gone. The
+architecture is gone. Only the noise remains.
+
+- **Chaos as a collective phenomenon** -- pandemonium is never solitary.
+  One person cannot create pandemonium; it requires a crowd, a room, a
+  market, a stadium. The word imports from its origin the idea of a
+  chaotic assembly -- many agents, each acting on separate impulses,
+  producing a result that is louder and more disordered than any
+  individual contribution. This maps well onto financial panics, social
+  media pile-ons, and organizational crises where the disorder emerges
+  from the interaction of many actors rather than from any single cause.
+- **The disorder has an architectural container** -- Milton's
+  Pandaemonium is a building. The chaos happens inside a structure. The
+  word retains this sense: pandemonium "breaks out" in a courtroom, a
+  classroom, a parliament. There is always an implied space that should
+  contain order but has failed to do so. Pandemonium is not wilderness
+  chaos; it is institutional chaos, the disorder that erupts when a
+  structure designed for controlled activity loses control.
+- **Noise is the dominant sensory register** -- when people say
+  "pandemonium broke out," they almost always mean sound: shouting,
+  screaming, crashing, overlapping voices. The visual dimension is
+  secondary. This maps Milton's original scene, where the council of
+  demons in Pandaemonium is characterized by competing speeches,
+  arguments, and rhetorical performances. The metaphor privileges
+  auditory chaos over visual disorder.
+- **The word has fully detached from its source** -- most English
+  speakers who use "pandemonium" do not know it was coined by Milton,
+  do not associate it with Hell, and would not recognize "all demons"
+  as its etymology. It functions as a pure synonym for "chaos" or
+  "uproar," with no theological residue.
+
+## Where It Breaks
+
+- **Milton's Pandaemonium was orderly, not chaotic** -- this is the
+  deepest irony. The Pandaemonium of *Paradise Lost* is an organized
+  deliberative body. The fallen angels hold a structured debate. Moloch
+  argues for open war; Belial for inaction; Mammon for building a rival
+  empire; Beelzebub for corrupting humanity. Satan presides. Votes are
+  taken. The scene is a dark parliament, not a riot. The modern meaning
+  of "pandemonium" inverts the original: Milton's word named the
+  terrifying order of Hell, not its disorder. The metaphor survives by
+  contradicting its source.
+- **"All demons" implies malicious agency; modern pandemonium does not**
+  -- the etymology encodes intentional evil. Demons are not confused
+  animals; they are fallen angels with purposes. But modern pandemonium
+  is amoral. Pandemonium at a rock concert, pandemonium after a winning
+  goal, pandemonium in a kindergarten -- none of these carry moral
+  weight. The metaphor has shed the entire moral structure of its source,
+  keeping only the sonic intensity.
+- **Pandemonium suggests a single explosive event; real disorder
+  accumulates** -- the word's usage pattern implies a moment of
+  eruption: "pandemonium broke out." But most organizational or social
+  disorder does not erupt. It accumulates gradually through many small
+  failures of coordination, communication, and governance. The
+  pandemonium framing makes disorder feel sudden and dramatic, which
+  can obscure the slow processes that actually produced it.
+- **The word carries excitement as much as alarm** -- "pandemonium"
+  in a sports broadcast is celebratory. "Pandemonium erupted in the
+  stadium" after a last-second victory is a positive description. The
+  word has acquired a valence that ranges from thrilling to terrifying,
+  which is structurally incoherent with a city of demons. Milton's
+  Pandaemonium is never fun. The metaphor now covers both ecstatic and
+  catastrophic chaos, a range its source does not support.
+
+## Expressions
+
+- "Pandemonium broke out" -- the standard collocation, treating disorder
+  as a sudden event that erupts in an otherwise controlled environment
+- "Pandemonium reigned" -- the variant that emphasizes duration,
+  suggesting that chaos has taken over and established itself as the
+  governing condition
+- "Sheer pandemonium" -- the intensified form, common in journalism and
+  sports commentary, used when ordinary "chaos" feels insufficient
+- "It was pandemonium" -- the retrospective summary, typically describing
+  a scene the speaker found overwhelming
+
+## Origin Story
+
+Milton coined "Pandaemonium" in *Paradise Lost* (1667), Book I, lines
+756-757: "A solemn Councel forthwith to be held / At Pandaemonium, the
+high Capital / Of Satan and his Peers." The word was his invention,
+built from Greek roots to name the seat of infernal government. It
+was a place-name, capitalized and specific.
+
+By the mid-18th century, the word had begun its migration from proper
+noun to common noun, from a place to a condition. Samuel Johnson's
+*Dictionary* (1755) did not include it, but by the 19th century
+"pandemonium" appeared regularly in newspapers and political rhetoric
+as a synonym for uproar. The lowercase spelling became standard. By
+the 20th century, the Miltonic origin was effectively invisible to
+most speakers. The word is now one of English's most successful coined
+terms -- a neologism so thoroughly absorbed that it feels like it has
+always existed.
+
+## References
+
+- Milton, John. *Paradise Lost*, Book I (1667) -- the coinage of
+  "Pandaemonium" as the capital of Hell, including the architectural
+  description of the building and the council held within it
+- *Oxford English Dictionary*, "pandemonium" -- documents the semantic
+  migration from proper noun (capital of Hell) to common noun (wild
+  uproar), with citations from the 18th century onward
+- Empson, William. *Milton's God* (1961) -- analysis of the
+  Pandaemonium council scenes and their political implications, relevant
+  to understanding how orderly Milton's Hell actually was


### PR DESCRIPTION
## Summary

- Adds `pandemonium` mapping -- Milton's coined place-name for Hell's capital, now a dead metaphor meaning chaotic uproar
- Kind: `dead-metaphor` (source domain fully invisible to most speakers)
- Source frame: mythology, Target frame: social-behavior

Closes #1125
Part of #219

## Validator output

All content valid. (27 pre-existing dangling reference warnings, none from this entry.)

## Validation

✓ `uv run scripts/validate.py validate` — 0 errors

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
