### PR TITLE
Add mapping: scylla-and-charybdis

### DIFF
--- a/catalog/frames/decision-making.md
+++ b/catalog/frames/decision-making.md
@@ -1,0 +1,26 @@
+---
+created: '2026-03-14'
+name: Decision-Making
+related:
+- economics
+- ethics-and-morality
+- puzzles-and-games
+roles:
+- agent
+- option
+- constraint
+- risk
+- trade-off
+- outcome
+- dilemma
+slug: decision-making
+updated: '2026-03-14'
+---
+
+The process of choosing among alternatives under conditions of
+uncertainty, constraint, or competing values. As a target domain,
+decision-making absorbs metaphors from navigation (crossroads, at a
+fork), warfare (strategy, tactical retreat), gambling (hedging bets,
+doubling down), and mythology (Scylla and Charybdis, Hobson's choice).
+The frame emphasizes the agent who must choose, the options available,
+the constraints that limit them, and the consequences that follow.

--- a/catalog/mappings/scylla-and-charybdis.md
+++ b/catalog/mappings/scylla-and-charybdis.md
@@ -1,0 +1,148 @@
+---
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- social-dynamics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Scylla and Charybdis
+related:
+- damocles-sword
+- tantalus
+slug: scylla-and-charybdis
+source_frame: mythology
+target_frame: decision-making
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+In Homer's *Odyssey*, Odysseus must sail through a narrow strait flanked
+by two monsters. Scylla, a six-headed creature perched on a cliff, will
+snatch and devour six sailors. Charybdis, a whirlpool on the opposite
+side, will swallow the entire ship. There is no safe passage. Circe
+advises Odysseus to hug Scylla's side: lose six men rather than risk
+losing everyone. The metaphor maps this structure -- two dangers, no
+safe option, forced choice between defined loss and catastrophic risk --
+onto decision-making under constraint.
+
+- **The choice is between two harms, not between good and bad** -- this
+  is the metaphor's central structural contribution. "Between Scylla and
+  Charybdis" does not describe a choice between a good option and a bad
+  one. Both options are bad. The only question is which kind of damage
+  you prefer. This maps onto decisions where every available path has
+  real costs: laying off staff versus running out of runway, raising
+  prices versus losing market share, chemotherapy versus untreated
+  cancer. The metaphor names the specific predicament of choosing among
+  losses.
+- **The dangers are qualitatively different** -- Scylla is precise,
+  limited, and certain: exactly six sailors will die. Charybdis is
+  total, chaotic, and probabilistic: the whole ship might be swallowed.
+  The metaphor captures the distinction between a known, bounded loss
+  and an uncertain, potentially catastrophic one. This maps onto risk
+  management decisions where the choice is between accepting a
+  predictable cost and gambling on an outcome that could be much worse
+  or, occasionally, much better.
+- **The strait is narrow -- you cannot avoid both** -- the geographic
+  structure matters. The two dangers are close enough that steering away
+  from one necessarily brings you closer to the other. The metaphor
+  imports spatial constraint: the decision space itself is compressed.
+  There is no third option, no room to maneuver, no creative solution
+  that avoids both threats. This maps onto situations where
+  organizational, legal, or physical constraints eliminate the middle
+  ground.
+- **Someone must choose** -- Odysseus is the captain. He cannot delegate
+  the decision, refuse to sail, or wait for conditions to change. The
+  metaphor imports the pressure of irreversible, time-bound choice on
+  a specific decision-maker. This is not a committee decision or a
+  market outcome; it is a leader's burden.
+
+## Where It Breaks
+
+- **Odysseus had intelligence; most decision-makers do not** -- Circe
+  told Odysseus exactly what each monster would do and recommended a
+  strategy. The metaphor implies that both dangers are known and their
+  consequences predictable. But real Scylla-and-Charybdis decisions
+  usually involve significant uncertainty about both options. A CEO
+  choosing between two bad strategies does not have a goddess explaining
+  the precise cost of each. The metaphor makes dilemmas feel more
+  legible than they typically are.
+- **The strait is a one-time passage; real dilemmas recur** -- Odysseus
+  sails through the strait once. The metaphor frames the decision as a
+  singular event with a defined outcome. But most organizational and
+  political dilemmas are ongoing: the same trade-off between cost-cutting
+  and quality, between security and usability, between speed and
+  thoroughness presents itself repeatedly. The metaphor's narrative
+  structure (approach, passage, aftermath) does not accommodate chronic
+  dilemmas.
+- **Six sailors die and nobody discusses it afterward** -- the *Odyssey*
+  moves on. The dead sailors are not named in this passage, their
+  families are not consulted, and Odysseus does not face accountability
+  for his choice. The metaphor can sanitize the human cost of
+  "acceptable losses" by framing them as the rational choice of a
+  competent leader. In organizations, the people who are the "six
+  sailors" -- laid off employees, deprioritized users, abandoned
+  projects -- are specific humans whose losses are not as clean as the
+  myth suggests.
+- **"Between Scylla and Charybdis" can justify inaction** -- the
+  metaphor's emphasis on the impossibility of a good outcome can be
+  used to avoid responsibility. If both options are terrible, the
+  decision-maker can claim that any bad outcome was inevitable. This
+  framing obscures the possibility that better options existed but
+  were not considered, or that the decision-maker's earlier choices
+  created the constrained situation in the first place.
+- **The metaphor assumes two threats; real decisions often have more** --
+  the binary structure of the strait (left or right, Scylla or
+  Charybdis) simplifies the decision space to two options. Real
+  dilemmas frequently involve three, four, or more imperfect
+  alternatives, each with different risk profiles. The metaphor's
+  binary framing can cause decision-makers to artificially reduce
+  complex option spaces to two bad choices.
+
+## Expressions
+
+- "Between Scylla and Charybdis" -- the classical idiom for being forced
+  to choose between two equally dangerous alternatives, still current in
+  formal and literary English
+- "Between a rock and a hard place" -- the vernacular English equivalent
+  that has largely replaced the classical reference in everyday speech,
+  preserving the structure while shedding the mythology
+- "Caught between two fires" -- a variant common in military and
+  political contexts
+- "The lesser of two evils" -- the decision strategy that the metaphor
+  implies, choosing the smaller known loss over the larger uncertain one
+- "Hobson's choice" -- a related but distinct idiom (a take-it-or-leave-it
+  offer), often confused with Scylla and Charybdis but structurally
+  different
+
+## Origin Story
+
+Scylla and Charybdis appear in Homer's *Odyssey* (Book 12, c. 8th
+century BCE). Circe warns Odysseus about the strait and advises him
+to choose Scylla's side. The monsters also appear in Apollonius of
+Rhodes' *Argonautica* and in Virgil's *Aeneid*. The phrase "between
+Scylla and Charybdis" was proverbial in Latin by Cicero's time and
+entered English by the 16th century.
+
+The Strait of Messina, between Sicily and mainland Italy, is the
+traditional geographic identification. Ancient sailors navigating this
+passage faced real hazards: a rock shoal on the Calabrian side and a
+genuine whirlpool (Garofalo) on the Sicilian side. The mythological
+monsters may be literary elaborations of actual navigational dangers.
+
+By the 20th century, "between Scylla and Charybdis" had become
+somewhat bookish, increasingly replaced in casual speech by "between
+a rock and a hard place." The classical reference survives primarily
+in literary, academic, and political writing where its mythological
+weight lends gravity to the dilemma being described.
+
+## References
+
+- Homer. *Odyssey*, Book 12 (c. 8th century BCE) -- the primary source,
+  including Circe's warning and Odysseus's passage through the strait
+- Virgil. *Aeneid*, Book 3 (19 BCE) -- the Roman retelling, which adds
+  geographic specificity and connects the strait to Sicilian geography
+- "Between Scylla and Charybdis" in *Oxford Dictionary of Idioms* --
+  documents English usage from the 16th century onward


### PR DESCRIPTION
## Summary

- Adds `scylla-and-charybdis` mapping -- Homer's two monsters flanking a narrow strait, now a dead metaphor for forced choice between two dangers
- Kind: `dead-metaphor` (the classical reference is increasingly replaced by "between a rock and a hard place")
- Source frame: mythology, Target frame: decision-making (new frame)
- Creates `decision-making` frame

Closes #1126
Part of #219

## Validator output

All content valid. (27 pre-existing dangling reference warnings, none from this entry.)

## Validation

✓ `uv run scripts/validate.py validate` — 0 errors

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
