### PR TITLE
Add mapping: sphinx-riddle

### DIFF
--- a/catalog/mappings/sphinx-riddle.md
+++ b/catalog/mappings/sphinx-riddle.md
@@ -1,0 +1,154 @@
+---
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- social-dynamics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Sphinx Riddle
+related:
+- tantalus
+- damocles-sword
+slug: sphinx-riddle
+source_frame: mythology
+target_frame: intellectual-inquiry
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+The Sphinx of Thebes perched on a rock outside the city and posed a riddle
+to every traveler: "What walks on four legs in the morning, two at noon,
+and three in the evening?" Those who failed to answer were killed. Oedipus
+answered correctly -- "a human being" (who crawls as an infant, walks
+upright as an adult, and uses a cane in old age) -- and the Sphinx
+destroyed herself. The metaphor maps this structure -- a gatekeeping test
+where intellectual performance determines passage or destruction -- onto
+any situation where a challenge must be solved to proceed.
+
+- **Knowledge as a gate** -- the Sphinx does not attack travelers at
+  random. She offers a fair test. Anyone who answers correctly passes
+  freely. The metaphor imports the structure of merit-based gatekeeping:
+  the obstacle is cognitive, not physical, and it applies equally to
+  everyone. This maps onto entrance exams, technical interviews, security
+  challenge questions, and any system where demonstrating knowledge is the
+  price of admission. "Solving the sphinx's riddle" means cracking the
+  one problem that stands between you and the next stage.
+- **The riddle has a single correct answer** -- the Sphinx does not
+  evaluate creativity or partial credit. There is one right answer, and
+  you either know it or you die. The metaphor imports this binary
+  structure: pass/fail, live/die, in/out. This maps onto situations
+  where the challenge is definitive rather than probabilistic -- the
+  make-or-break moment, the single exam question that determines
+  everything.
+- **The answer is about self-knowledge** -- the riddle's solution is
+  "a human being." The travelers who fail are destroyed not by obscure
+  trivia but by their inability to recognize themselves. The metaphor
+  carries a Socratic undertone: the hardest riddles are the ones whose
+  answers require you to understand your own nature. This maps onto
+  organizational and personal challenges where the solution requires
+  honest self-examination rather than external expertise.
+- **Solving the riddle destroys the gatekeeper** -- when Oedipus
+  answers correctly, the Sphinx throws herself from the cliff. The
+  test, once passed, eliminates the tester. The metaphor captures the
+  paradox of definitive challenges: a riddle that has been solved is
+  no longer a riddle. A technical interview question that becomes
+  public ceases to be a useful filter. The Sphinx's self-destruction
+  maps onto the obsolescence of any gatekeeping mechanism once its
+  answer is widely known.
+
+## Where It Breaks
+
+- **Real gatekeeping is rarely fair** -- the Sphinx poses the same
+  riddle to everyone and accepts the correct answer regardless of who
+  gives it. This makes the mythological gate perfectly meritocratic.
+  But real-world gatekeeping -- job interviews, university admissions,
+  certification exams -- is shaped by preparation, privilege, cultural
+  context, and evaluator bias. Using the Sphinx metaphor for
+  institutional gatekeeping imports an assumption of fairness that
+  rarely holds. The riddle is the same for everyone; the preparation
+  is not.
+- **The riddle is trivially easy in retrospect** -- "what has four
+  legs, then two, then three?" is not a particularly difficult
+  question. Its power in the myth depends on the travelers' inability
+  to think metaphorically: they take "legs" and "morning/noon/evening"
+  literally. Once you see the answer, you cannot unsee it. This means
+  the Sphinx metaphor works poorly for genuinely hard problems --
+  problems that remain difficult even after you understand them. The
+  metaphor is better suited to insight problems (where the difficulty
+  is reframing) than to computation problems (where the difficulty is
+  sustained effort).
+- **Oedipus solved the riddle and it ruined him** -- this is the
+  detail the metaphor suppresses. Oedipus's reward for solving the
+  Sphinx's riddle was the throne of Thebes and marriage to Jocasta --
+  who turned out to be his mother. The intellectual triumph led
+  directly to the catastrophe. When the Sphinx metaphor is used to
+  celebrate problem-solving, it quietly drops the mythological sequel:
+  that solving one puzzle can propel you into a larger, worse one.
+  The riddle was the easy part.
+- **The binary outcome eliminates learning** -- you solve the riddle
+  or you die. There is no feedback loop, no opportunity to try again,
+  no partial success that teaches you something for next time. Real
+  intellectual challenges are iterative: you fail, learn, adjust, try
+  again. The Sphinx metaphor frames intellectual challenge as a
+  single-shot event, which maps poorly onto research, debugging,
+  creative work, and most forms of sustained problem-solving.
+- **The Sphinx is female and monstrous; the solver is male and
+  heroic** -- the myth's gender structure is not incidental. The
+  deadly gatekeeper is a female hybrid creature; the solver who
+  destroys her is a male hero. When the metaphor is applied to
+  institutional gatekeeping, this gendered structure can subtly
+  frame obstacles as feminine threats to be overcome by masculine
+  intellect. The metaphor carries mythological baggage about who
+  poses riddles and who solves them.
+
+## Expressions
+
+- "The riddle of the Sphinx" -- the standard idiom for any
+  seemingly impossible intellectual challenge that must be solved to
+  proceed
+- "Sphinx-like" -- describing a person or entity that is inscrutable,
+  enigmatic, and unwilling to reveal information directly
+- "Answer the Sphinx" -- to solve a critical gatekeeping challenge,
+  used in academic and professional contexts
+- "A sphinx without a riddle" -- Oscar Wilde's dismissal of someone
+  who appears mysterious but has no actual depth, inverting the
+  metaphor to describe false complexity
+- "The Sphinx smiles" -- describing an enigmatic, unreadable
+  expression, drawn from the visual representation of the Egyptian
+  Sphinx rather than the Greek narrative
+
+## Origin Story
+
+The Sphinx riddle appears in Sophocles' *Oedipus Tyrannus* (c. 429 BCE)
+by reference, though the riddle itself is more fully recorded in later
+sources including Apollodorus' *Bibliotheca* and the scholia on
+Euripides. The Greek Sphinx is distinct from the Egyptian Sphinx: the
+Greek version is a winged creature with a woman's head and a lion's
+body who actively poses deadly challenges, while the Egyptian Great
+Sphinx at Giza is a silent, monumental guardian.
+
+The riddle of the Sphinx became a metaphorical staple in Western culture
+by the Renaissance. Francis Bacon used it in *The Wisdom of the
+Ancients* (1609) as an allegory for the relationship between science
+and nature. By the 19th century, "sphinx" and "sphinx-like" had become
+standard English adjectives for inscrutability. The riddle itself --
+what walks on four legs, then two, then three -- is now so widely known
+that it functions more as a cultural reference point than as an actual
+puzzle.
+
+## References
+
+- Sophocles. *Oedipus Tyrannus* (c. 429 BCE) -- the canonical dramatic
+  treatment, which references the riddle as backstory to Oedipus's
+  kingship
+- Apollodorus. *Bibliotheca*, 3.5.8 -- the fullest ancient statement of
+  the riddle and its answer
+- Bacon, Francis. *The Wisdom of the Ancients* (1609) -- an early modern
+  allegorical reading of the Sphinx as the relationship between human
+  intellect and natural mystery
+- Vernant, Jean-Pierre and Pierre Vidal-Naquet. *Myth and Tragedy in
+  Ancient Greece* (1972/1988) -- structural analysis of the Oedipus myth,
+  including the riddle as a key to the play's themes of self-knowledge


### PR DESCRIPTION
## Summary

- Adds `sphinx-riddle` mapping -- the Theban Sphinx's gatekeeping riddle, now a dead metaphor for intellectual challenges that must be solved to proceed
- Kind: `dead-metaphor` ("sphinx-like" is used without mythological awareness)
- Source frame: mythology, Target frame: intellectual-inquiry

Closes #1128
Part of #219

## Validator output

All content valid. (27 pre-existing dangling reference warnings, none from this entry.)

## Validation

✓ `uv run scripts/validate.py validate` — 0 errors

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
