### PR TITLE
Add mapping: faustian-bargain

### DIFF
--- a/catalog/mappings/faustian-bargain.md
+++ b/catalog/mappings/faustian-bargain.md
@@ -1,0 +1,173 @@
+---
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- economics-and-finance
+- ethics-and-morality
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Faustian Bargain
+related:
+- damocles-sword
+- trojan-war
+slug: faustian-bargain
+source_frame: mythology
+target_frame: economics
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+Doctor Faustus, a scholar dissatisfied with the limits of human knowledge,
+sells his soul to the devil in exchange for twenty-four years of unlimited
+power, knowledge, and pleasure. The contract is explicit: Mephistopheles
+provides everything Faustus desires now; in return, Faustus surrenders his
+soul for eternity after the term expires. The metaphor maps this structure
+-- trading something of ultimate long-term value for something of immediate
+short-term benefit -- onto any exchange where the cost is deferred, hidden,
+or existential.
+
+- **The bargain is voluntary and informed** -- Faustus is not tricked. He
+  signs the contract with full knowledge of its terms. The devil does not
+  deceive him about the price; Faustus simply values the present more than
+  the future. The metaphor imports this structure of informed consent to
+  bad trades: the person making a Faustian bargain knows it is a bad deal
+  in the long run. They do it anyway. This maps onto technical debt taken
+  on knowingly, fossil fuel dependence maintained despite climate science,
+  authoritarian alliances formed for short-term stability, and any
+  situation where the decision-maker understands the future cost and
+  accepts it.
+- **The payment is incommensurable with the purchase** -- Faustus trades
+  his eternal soul for temporal pleasures. The two sides of the exchange
+  are not just unequal; they belong to different categories of value. A
+  soul is not a commodity that can be priced; earthly knowledge and
+  pleasure are not infinite. The metaphor captures transactions where the
+  cost and the benefit cannot be measured on the same scale: a company
+  trading its reputation for quarterly earnings, a politician trading
+  democratic norms for electoral advantage, a researcher trading
+  intellectual integrity for funding.
+- **The devil is patient** -- Mephistopheles does not rush. He provides
+  excellent service for twenty-four years. The metaphor imports the
+  structure of a creditor who is perfectly content to wait because the
+  payment, when it comes, will be absolute. This maps onto systems
+  where negative consequences accumulate silently during a long period
+  of apparent benefit: environmental degradation behind economic growth,
+  health consequences behind years of poor diet, institutional erosion
+  behind short-term political gains.
+- **The term expires** -- the most structurally important element. The
+  bargain has a clock. Faustus enjoys his powers for a defined period,
+  and then the bill comes due -- suddenly, completely, and without
+  possibility of renegotiation. The metaphor imports the dread of the
+  deadline: the approaching moment when deferred costs materialize all
+  at once. This maps onto debt maturity dates, environmental tipping
+  points, the moment technical debt makes a system unmaintainable, and
+  any situation where a long period of borrowed time ends abruptly.
+
+## Where It Breaks
+
+- **Faustus's soul is a theological concept; most traded values are
+  secular** -- the original bargain depends on a Christian cosmology in
+  which the soul is real, eternal, and infinitely valuable. Without that
+  framework, the metaphor's asymmetry weakens. When we say a corporation
+  made a "Faustian bargain," what is the corporate soul? Reputation?
+  Culture? Long-term viability? These are real but not transcendent. The
+  metaphor borrows its dramatic weight from theology and applies it to
+  secular trade-offs that are serious but not literally eternal.
+- **The devil in the metaphor flatters the decision-maker** -- calling
+  something a "Faustian bargain" implies that what was received was
+  genuinely powerful and desirable -- knowledge, capability, competitive
+  advantage. Faustus got real magic. But many bad long-term trades are
+  not Faustian at all; they are simply bad trades where the short-term
+  benefit was also meager. A company that takes on crushing debt for a
+  mediocre acquisition has not made a Faustian bargain; it has made a
+  stupid one. The metaphor can dignify poor decisions by implying that
+  the short-term gain was at least magnificent.
+- **Faustus cannot renegotiate; real bargains often can be revised** --
+  the devil's contract is absolute. There is no restructuring, no
+  partial repayment, no bankruptcy protection. But real-world
+  "Faustian" situations usually allow for course correction: technical
+  debt can be paid down, environmental policies can change, political
+  alliances can be dissolved. The metaphor's dramatic finality --
+  the soul is forfeit, period -- can induce fatalism about situations
+  that are actually reversible with sufficient effort.
+- **The metaphor assumes a clear moment of choice** -- Faustus signs
+  a contract at a specific moment. But many real Faustian situations
+  are not single decisions; they are accumulated patterns. Nobody
+  signed a contract trading the climate for industrialization. The
+  "bargain" emerged from millions of individual decisions over
+  centuries. The metaphor imposes a narrative of deliberate choice
+  onto processes that are often diffuse, emergent, and without a
+  single decision-maker.
+- **Faust's story has a contested ending** -- in Marlowe's version
+  (1604), Faustus is damned. In Goethe's version (1808), Faust is
+  redeemed. The metaphor typically assumes Marlowe's ending
+  (damnation), but Goethe's revision suggests that even a Faustian
+  bargain might be survivable -- that striving and growth can
+  ultimately outweigh the contract's terms. The metaphor is less
+  stable than it appears because its two most important source texts
+  disagree about the outcome.
+
+## Expressions
+
+- "Faustian bargain" -- the standard idiom for any exchange of
+  long-term value for short-term gain, so common in English that many
+  speakers do not know who Faust was
+- "A deal with the devil" -- the vernacular equivalent that has
+  largely replaced the classical reference in everyday speech, losing
+  the specific Faustian structure while preserving the sense of a
+  transaction with dark consequences
+- "Selling your soul" -- the fully generalized version, detached
+  from both Faust and any specific devil, used for any compromise of
+  core values for material benefit
+- "Mephistophelean" -- the adjective form, describing a tempter who
+  offers exactly what you want while concealing or deferring the true
+  cost
+- "The bill comes due" -- the temporal element of the Faustian
+  structure, naming the moment when deferred costs materialize,
+  used without explicit reference to Faust but preserving his
+  narrative arc
+
+## Origin Story
+
+The historical Johann Georg Faust (c. 1480-1540) was a German
+itinerant alchemist, astrologer, and magician whose reputation for
+dark dealings with supernatural forces made him a legendary figure
+within decades of his death. The anonymous *Historia von D. Johann
+Fausten* (1587) was the first published version of the legend,
+presenting Faust as a cautionary tale of intellectual overreach
+and damnation.
+
+Christopher Marlowe's *The Tragical History of the Life and Death
+of Doctor Faustus* (c. 1604) gave the story its most influential
+English form. Marlowe's Faustus is a brilliant scholar who
+deliberately chooses earthly power over salvation, and his final
+soliloquy -- begging for time as the clock strikes midnight -- is
+one of English drama's most famous scenes.
+
+Johann Wolfgang von Goethe's *Faust* (Part One, 1808; Part Two,
+1832) transformed the legend into a philosophical epic. Goethe's
+Faust is redeemed rather than damned, and the work reframes the
+bargain as a wager about whether earthly experience can satisfy
+the human spirit.
+
+"Faustian bargain" entered common English usage by the late 19th
+century and became a standard political and journalistic metaphor
+by the mid-20th century. By now it functions as a dead metaphor:
+most speakers who use it mean "a trade-off with hidden long-term
+costs" without thinking about Faust, Mephistopheles, or the
+theological stakes of the original story.
+
+## References
+
+- Marlowe, Christopher. *The Tragical History of the Life and Death
+  of Doctor Faustus* (c. 1604) -- the English dramatic source,
+  ending in damnation
+- Goethe, Johann Wolfgang von. *Faust* (Part One, 1808; Part Two,
+  1832) -- the German philosophical epic, ending in redemption
+- *Historia von D. Johann Fausten* (1587) -- the anonymous German
+  chapbook that launched the legend
+- Palmer, Philip Mason and Robert Pattison More. *The Sources of the
+  Faust Tradition* (1936) -- a comprehensive survey of Faust
+  materials from the historical Faust to the literary tradition


### PR DESCRIPTION
## Summary

- Adds `faustian-bargain` mapping -- the Faust legend's deal with the devil, now a dead metaphor for trading long-term value for short-term gain
- Kind: `dead-metaphor` (speakers use "Faustian bargain" as a set phrase without engaging with the Faust narrative)
- Source frame: mythology, Target frame: economics

Closes #1130
Part of #219

## Validator output

All content valid. (28 warnings, all pre-existing dangling references plus one cross-branch reference to trojan-war.)

## Validation

✓ `uv run scripts/validate.py validate` — 0 errors

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
