### PR TITLE
Add mapping: loose-cannon

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,28 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- embodied-experience
+roles:
+- vessel
+- crew
+- captain
+- wind
+- sea
+- rigging
+- cargo
+- port
+- course
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of sailing ships and maritime life -- navigation, rigging,
+weather, combat at sea, and the hierarchical social order aboard ship.
+One of the most productive dead-metaphor source domains in English:
+centuries of naval dominance embedded seafaring vocabulary so deeply
+into everyday language that most speakers have no idea they are using
+nautical terms. The physical realities of wind, rope, canvas, and
+rolling decks map onto social behavior, mental states, and embodied
+experience with unusual structural precision because life at sea was
+both physically extreme and socially enclosed.

--- a/catalog/mappings/loose-cannon.md
+++ b/catalog/mappings/loose-cannon.md
@@ -1,0 +1,132 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Loose Cannon
+related: []
+slug: loose-cannon
+source_frame: seafaring
+target_frame: social-behavior
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+A naval cannon weighed one to three tons. Secured to the deck by heavy
+rope tackle, it was manageable. Unsecured on a rolling ship, it became
+a nightmare: a multi-ton iron cylinder sliding unpredictably across a
+pitching deck, crushing anyone in its path and capable of smashing
+through the hull from the inside. The crew that was supposed to be
+protected by the cannon was now endangered by it. The metaphor maps
+this specific physical scenario onto social behavior with several
+structural imports.
+
+- **The danger comes from inside** -- a loose cannon is not an
+  external threat. It is a piece of the ship's own equipment, placed
+  there on purpose, that has broken free of its restraints. The
+  metaphor imports the idea that the most dangerous person in an
+  organization is not an outsider but an insider who was supposed to
+  be an asset. The cannon was brought aboard to fight enemies; loose,
+  it fights the crew. When we call someone a loose cannon, we mean
+  they were trusted with power and are now wielding it without
+  control.
+- **Confinement amplifies the danger** -- on open ground, a rolling
+  cylinder would eventually stop. On a ship, the walls bounce it
+  back. The enclosed space of the gun deck turns a single loose object
+  into a sustained, multi-directional threat. The metaphor imports
+  this containment structure: a loose cannon is worst in a tight
+  organization, a small team, a closed community -- anywhere the
+  damage ricochets rather than dissipating.
+- **The problem is the absence of restraint, not the object itself**
+  -- the cannon is exactly the same object whether secured or loose.
+  The difference is entirely in the tackle that holds it in place.
+  The metaphor implies that the person in question is not inherently
+  bad -- they are powerful, and the structures that should channel
+  that power have failed. This is a subtlety most users of the
+  expression miss: calling someone a loose cannon is as much an
+  indictment of the organization's restraint systems as of the
+  individual.
+- **Unpredictability is the core feature** -- a loose cannon does not
+  aim. It rolls wherever the deck tilts. The metaphor imports
+  randomness: a loose cannon is not someone pursuing a hostile agenda
+  but someone whose actions cannot be predicted. The danger is not
+  malice but chaos.
+
+## Where It Breaks
+
+- **People have intentions; cannons do not** -- a cannon rolls
+  according to physics. A person described as a loose cannon is
+  usually acting on some internal logic, however poorly considered.
+  The metaphor strips agency and motive from the person, reducing
+  them to a mass obeying gravity. This can prevent useful analysis:
+  if you treat a disruptive team member as a literal loose cannon
+  (pure physics, no psychology), you will try to restrain them
+  rather than understanding why they are acting as they are.
+- **The metaphor implies the only solution is re-securing** -- on a
+  ship, you lash the cannon down or throw it overboard. There is no
+  third option. Applied to people, this maps onto either controlling
+  them (reasserting restraints) or removing them (firing, expelling).
+  The dead metaphor has no vocabulary for negotiation, persuasion,
+  or accommodation -- responses that are often more effective with
+  actual humans than with actual cannons.
+- **Loose cannons on ships were rare emergencies** -- the metaphor
+  implies an acute crisis. But many people described as loose cannons
+  are chronic rather than acute: they are persistently unpredictable,
+  not catastrophically so. The metaphor's crisis framing can lead to
+  overreaction, treating a pattern of minor disruptions as if it
+  were an existential threat to the hull.
+- **The metaphor has lost its weight** -- most English speakers have
+  never seen a naval cannon, let alone a loose one. The expression
+  now means something like "unpredictable person" without the
+  visceral terror of a three-ton iron cylinder sliding across a
+  wooden deck toward your legs. The dead metaphor has been tamed
+  into a mild criticism, losing the life-or-death urgency that made
+  the original image so powerful.
+
+## Expressions
+
+- "He's a loose cannon" -- an unpredictable person whose actions
+  endanger the group
+- "Loose cannon on deck" -- emphasizing the immediate danger of an
+  uncontrolled actor within an organization
+- "We can't have a loose cannon in this department" -- the restraint
+  framing: the organization needs to secure or remove the threat
+- "She went off like a loose cannon" -- conflation with "going off"
+  (firing), which is actually a different metaphor -- loose cannons
+  roll, they do not fire
+- "A cannon loose on the gun deck" -- the fuller nautical image,
+  rarely used but more precise
+
+## Origin Story
+
+The phrase originates in the age of sail, when warships carried dozens
+of heavy guns on enclosed gun decks. Each cannon was restrained by a
+system of ropes and pulleys (the "gun tackle") that allowed it to be
+run out for firing and hauled back for reloading. If the tackle broke
+in rough seas, the cannon would begin rolling across the deck with
+the ship's motion, gaining momentum with each roll.
+
+Victor Hugo provided the most vivid literary depiction in
+*Ninety-Three* (1874), describing a loose carronade on a revolutionary
+warship: "Nothing more terrible can happen to a vessel in open sea."
+Hugo devoted an entire chapter to the scene, treating the loose cannon
+as both a literal threat and a metaphor for revolutionary violence
+unleashed without direction.
+
+The figurative use of "loose cannon" in English dates to the late 19th
+and early 20th century, becoming common in political journalism by
+the mid-20th century. The nautical origin was already fading by then;
+most users of the expression understood it as meaning "uncontrolled
+and dangerous" without picturing a rolling gun on a wooden deck.
+
+## References
+
+- Hugo, V. *Ninety-Three* (1874), Part I, Book II, Chapter V --
+  the carronade chapter
+- OED, "loose cannon, n." -- figurative use from the late 19th century
+- Smyth, W.H. *The Sailor's Word-Book* (1867) -- period naval
+  vocabulary and tackle descriptions


### PR DESCRIPTION
## Summary

- Adds `loose-cannon` dead-metaphor mapping (seafaring -> social-behavior)
- Adds `seafaring` frame (new, shared by upcoming nautical entries)
- An unsecured cannon on a rolling deck maps onto an unpredictable person who endangers their own group

Closes #1270

## Validator output

```
All content valid.
```

Generated with [Claude Code](https://claude.com/claude-code)