### PR TITLE
Add mapping: taken-aback

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,28 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- embodied-experience
+roles:
+- vessel
+- crew
+- captain
+- wind
+- sea
+- rigging
+- cargo
+- port
+- course
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of sailing ships and maritime life -- navigation, rigging,
+weather, combat at sea, and the hierarchical social order aboard ship.
+One of the most productive dead-metaphor source domains in English:
+centuries of naval dominance embedded seafaring vocabulary so deeply
+into everyday language that most speakers have no idea they are using
+nautical terms. The physical realities of wind, rope, canvas, and
+rolling decks map onto social behavior, mental states, and embodied
+experience with unusual structural precision because life at sea was
+both physically extreme and socially enclosed.

--- a/catalog/mappings/taken-aback.md
+++ b/catalog/mappings/taken-aback.md
@@ -1,0 +1,134 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Taken Aback
+related:
+- loose-cannon
+slug: taken-aback
+source_frame: seafaring
+target_frame: mental-experience
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+"Aback" is a sailing term meaning that the wind is pressing the sails
+flat against the masts -- the wrong side. In normal sailing, wind fills
+the sails from behind, pushing the ship forward. When the wind suddenly
+shifted or the helmsman made an error, the sails would be taken aback:
+pressed backward against the mast, stopping the ship dead or even
+driving it in reverse. For the crew, this was a moment of physical
+shock -- the deck lurched, the rigging groaned, and the ship's forward
+momentum vanished in seconds. The metaphor maps this physical event
+onto psychological experience.
+
+- **Sudden reversal of momentum** -- the ship was moving forward; now
+  it has stopped or is going backward. The metaphor imports a model
+  of surprise that is specifically about interrupted progress. To be
+  taken aback is not merely to be surprised; it is to have your
+  forward motion halted by something you did not see coming. This
+  distinguishes it from simple surprise: it carries the connotation
+  of being in the middle of doing something -- speaking, planning,
+  advancing -- and having that activity forcibly stopped.
+- **The cause is external and invisible** -- wind shifts are not
+  announced. The helmsman does not see the wind change; he feels it
+  when the sails slam backward. The metaphor imports the idea that
+  the surprising information arrives without warning and from a
+  direction you were not monitoring. You were watching the horizon;
+  the wind changed behind you.
+- **Physical staggering maps onto psychological staggering** -- a
+  ship taken aback heels suddenly, and the crew stumbles. The dead
+  metaphor preserves a bodily component: we say someone "was taken
+  aback" and imagine them physically recoiling, stepping back, losing
+  their footing. The nautical origin gives the expression a kinesthetic
+  quality that a neutral word like "surprised" lacks.
+- **Recovery is possible but requires action** -- a competent crew
+  could recover from being taken aback by adjusting the sails and
+  finding the new wind. The metaphor implicitly includes the
+  possibility of regrouping. Being taken aback is a temporary state,
+  not a permanent one. This structural feature is part of why the
+  expression feels milder than "stunned" or "shocked" -- it implies
+  a pause, not a collapse.
+
+## Where It Breaks
+
+- **The expression has been softened beyond recognition** -- in
+  sailing, being taken aback was a dangerous emergency that could
+  dismast a ship or drive it onto rocks. In modern usage, "I was
+  taken aback" often describes mild social surprise: an unexpected
+  comment at dinner, a higher-than-expected price. The dead metaphor
+  has drifted from crisis to inconvenience, and the gap between the
+  source domain's severity and the target domain's mildness makes
+  the mapping structurally dishonest. We use a life-threatening
+  nautical event to describe finding out a meeting was rescheduled.
+- **Wind is not information** -- the original event is purely physical:
+  air pressure on canvas. The metaphorical target is cognitive:
+  processing unexpected information. The mapping works at the level
+  of momentum and reversal but breaks at the level of mechanism.
+  Wind does not require interpretation; surprising news does. A ship
+  cannot choose to ignore the wind shift; a person can choose to
+  dismiss surprising information. The metaphor erases the cognitive
+  processing step between receiving information and being affected
+  by it.
+- **The expression has no active form** -- you cannot "take someone
+  aback" in the way you can "surprise someone." The passive
+  construction ("I was taken aback") is the only natural form,
+  which is a fossil of the nautical grammar: the ship is taken aback
+  by the wind, just as a person is taken aback by news. This
+  grammatical rigidity is a symptom of the metaphor's death -- the
+  expression has ossified into a fixed phrase that speakers use
+  without understanding its internal structure.
+- **The directional logic has been lost** -- "aback" means backward,
+  against the masts. But modern users do not picture backward motion
+  when they say "taken aback." They picture something closer to
+  freezing in place. The loss of the directional component removes
+  the metaphor's most interesting structural feature: the idea that
+  surprise does not merely stop you but pushes you in the wrong
+  direction.
+
+## Expressions
+
+- "I was taken aback" -- surprised and momentarily unable to respond,
+  with the sailing origin entirely invisible
+- "Taken aback by the news" -- the standard usage, where "aback"
+  functions as an adverb that no speaker could define independently
+- "She seemed quite taken aback" -- mild social surprise observed
+  from outside, far from the original nautical emergency
+- "Nothing takes him aback" -- describing someone unflappable, where
+  the negation reveals the metaphor's structure (this person's sails
+  cannot be reversed)
+
+## Origin Story
+
+"Aback" as a nautical term dates to at least the 17th century, with
+the literal meaning of sails pressed against the mast by a headwind
+or wind shift. The figurative use -- meaning startled or disconcerted
+-- appears in English by the late 18th century. Charles Dickens used
+it repeatedly in its figurative sense (e.g., in *David Copperfield*,
+1850), by which point the expression was already conventional enough
+that readers did not need to know sailing to understand it.
+
+The transition from literal to figurative was swift. By the mid-19th
+century, England's maritime culture was ubiquitous enough that nautical
+expressions permeated everyday speech, and "taken aback" joined
+"overwhelmed," "on an even keel," and dozens of other sailing terms
+in losing their source-domain connection. The word "aback" itself
+survived in English almost exclusively within this fixed phrase --
+nobody uses "aback" in any other context, making it a particularly
+pure example of a dead metaphor: a word that exists only as a fossil
+inside an expression whose origin has been forgotten.
+
+## References
+
+- OED, "aback, adv." -- nautical use from the 17th century,
+  figurative use from the late 18th century
+- Smyth, W.H. *The Sailor's Word-Book* (1867) -- "Aback: the
+  situation of the sails when their surfaces are pressed aft against
+  the mast by the force of the wind"
+- Jeans, P.D. *Ship to Shore: A Dictionary of Everyday Words and
+  Phrases Borrowed from the Sea* (2004)


### PR DESCRIPTION
## Summary

- Adds `taken-aback` dead-metaphor mapping (seafaring -> mental-experience)
- Adds `seafaring` frame
- Wind pressing sails backward maps onto the shock of unexpected information

Closes #1271

## Validator output

```
All content valid.
```

Generated with [Claude Code](https://claude.com/claude-code)