### PR TITLE
Add mapping: showing-true-colors

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,28 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- embodied-experience
+roles:
+- vessel
+- crew
+- captain
+- wind
+- sea
+- rigging
+- cargo
+- port
+- course
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of sailing ships and maritime life -- navigation, rigging,
+weather, combat at sea, and the hierarchical social order aboard ship.
+One of the most productive dead-metaphor source domains in English:
+centuries of naval dominance embedded seafaring vocabulary so deeply
+into everyday language that most speakers have no idea they are using
+nautical terms. The physical realities of wind, rope, canvas, and
+rolling decks map onto social behavior, mental states, and embodied
+experience with unusual structural precision because life at sea was
+both physically extreme and socially enclosed.

--- a/catalog/mappings/showing-true-colors.md
+++ b/catalog/mappings/showing-true-colors.md
@@ -1,0 +1,150 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Showing True Colors
+related:
+- loose-cannon
+slug: showing-true-colors
+source_frame: seafaring
+target_frame: social-behavior
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+"Colors" in naval parlance are the ship's flag -- the national ensign
+that identifies whose navy or merchant fleet the vessel belongs to.
+International custom and the laws of war permitted ships to fly false
+colors to approach an enemy or avoid confrontation, but required them
+to raise their true colors before firing. A warship might fly a
+neutral flag to close distance, then at the moment of attack haul down
+the false flag and run up its actual ensign. The metaphor maps this
+tactical deception-then-reveal sequence onto social behavior.
+
+- **Identity is something displayed, not inherent** -- the flag does
+  not change the ship. A French frigate flying British colors is still
+  a French frigate. But in the visual world of age-of-sail warfare,
+  identity was entirely a matter of what flag flew at the masthead.
+  The metaphor imports a model of social identity as performance:
+  what you show the world is your operative identity, regardless of
+  what you "really" are underneath. Showing true colors means
+  switching from one displayed identity to another, not revealing
+  some hidden essence.
+- **Deception is expected and legitimate** -- the nautical practice
+  was not dishonorable; it was standard tactics. Ships were expected
+  to fly false colors. The requirement was only that you show your
+  true flag before combat. The metaphor preserves this nuance in a
+  way that modern usage has largely forgotten: the original mapping
+  did not condemn the deception but treated it as a normal part of
+  strategic interaction. The moral weight fell on the reveal, not
+  the concealment.
+- **The reveal is a commitment to action** -- raising the true colors
+  was not merely an honest gesture; it was a declaration of hostile
+  intent. Once your flag went up, battle was imminent. The metaphor
+  imports a link between revealing identity and committing to
+  conflict. When we say someone "showed their true colors," we
+  usually mean they dropped a pretense in order to act on their
+  real agenda -- the reveal and the action are simultaneous, just
+  as the flag and the broadside were.
+- **The audience was deceived on purpose** -- the target ship was
+  meant to misread the flag. The metaphor imports intentional
+  deception as a structural element: the false identity was not an
+  accident or misunderstanding but a deliberate strategy. When we
+  say someone showed their true colors, we imply that the earlier,
+  pleasant presentation was calculated, not merely polite.
+
+## Where It Breaks
+
+- **People are not flags** -- a flag is a simple, unambiguous symbol:
+  it is either the French tricolor or it is not. Human identity is
+  layered, contradictory, and contextual. The metaphor implies that
+  a person has one "true" identity concealed behind one "false" one,
+  which is a drastic simplification. People who behave differently
+  in different contexts are not necessarily flying false colors;
+  they may be genuinely different in different situations. The
+  binary flag model (true/false) cannot capture the multiplicity
+  of human self-presentation.
+- **The metaphor presupposes hostile intent** -- in the naval context,
+  showing true colors preceded an attack. The expression inherits
+  this adversarial framing: "showing true colors" almost always
+  means revealing something negative. Nobody says "she showed her
+  true colors" to describe someone turning out to be unexpectedly
+  kind. The metaphor has a built-in negativity bias that distorts
+  its application -- it is only used when the revealed identity is
+  worse than the displayed one.
+- **The temporal structure is too clean** -- the naval sequence is
+  crisp: false flag, then true flag, then combat. Human identity
+  reveals are rarely this clean. People's "true" motives emerge
+  gradually, inconsistently, and sometimes retroactively (we
+  reinterpret past behavior in light of new information). The
+  metaphor's decisive-moment structure -- the flag comes down, the
+  flag goes up -- misrepresents the messy, incremental way people
+  actually reveal themselves.
+- **"Colors" has lost its specific meaning** -- modern speakers
+  understand "true colors" as a vague synonym for "real character."
+  The flag is gone, the ship is gone, the tactical context is gone.
+  The expression floats free of its source domain, which means it
+  has lost the structural features that made it analytically
+  interesting: the legitimacy of deception, the link between reveal
+  and action, the visual semiotics of flag recognition. What remains
+  is a generic phrase for unmasking.
+
+## Expressions
+
+- "Showing true colors" -- revealing one's real character or
+  intentions after a period of concealment
+- "Showed his true colors" -- past tense, almost always negative:
+  the revealed identity is worse than the displayed one
+- "True colors" -- used independently to mean real character: "we
+  finally saw her true colors"
+- "Flying false colors" -- the deception phase, still used in
+  formal or literary English to mean presenting a deliberately
+  misleading identity
+- "Sailing under false colors" -- variant of the above, with the
+  nautical source slightly more visible
+- "Nailing your colors to the mast" -- a related naval expression
+  meaning to commit irrevocably (a nailed flag cannot be hauled
+  down in surrender), which preserves the flag-as-identity mapping
+
+## Origin Story
+
+The practice of flying false colors was widespread in the age of
+sail, from the 16th through the 19th century. It was governed by
+evolving customs and eventually by international law. The key rule
+-- widely observed though not always followed -- was that a ship
+must show its true national ensign before opening fire. Flying
+false colors to avoid engagement or to gather intelligence was
+considered legitimate; fighting under a false flag was not.
+
+The figurative use of "true colors" in English dates to at least
+the 17th century. The expression "to show one's colors" appears
+in Restoration-era writing, and by the 18th century it was
+conventional enough to appear in non-nautical contexts. The related
+expression "with flying colors" (meaning triumphantly) comes from
+the same domain: a victorious ship returned to port with its colors
+flying high, while a defeated ship struck its colors (lowered its
+flag in surrender).
+
+The Cyndi Lauper song "True Colors" (1986) completed the
+expression's detachment from its naval origin by reframing "true
+colors" as something positive -- the authentic self that should be
+celebrated rather than concealed. This inversion is notable: the
+naval metaphor treated the reveal of true colors as a threat,
+while the pop-cultural usage treats it as an act of courage and
+self-acceptance.
+
+## References
+
+- Rodger, N.A.M. *The Command of the Ocean* (2004) -- British naval
+  practice including flag protocols
+- OED, "colours, n." -- nautical sense and figurative extensions
+  from the 17th century onward
+- Grotius, H. *De Jure Belli ac Pacis* (1625) -- early discussion
+  of the laws of war including ruses at sea
+- Jeans, P.D. *Ship to Shore: A Dictionary of Everyday Words and
+  Phrases Borrowed from the Sea* (2004)


### PR DESCRIPTION
## Summary

- Adds `showing-true-colors` dead-metaphor mapping (seafaring -> social-behavior)
- Adds `seafaring` frame
- Warships flying false flags then raising true ensign before firing maps onto revealing concealed identity

Closes #1273

## Validator output

```
All content valid.
```

Generated with [Claude Code](https://claude.com/claude-code)