### PR TITLE
Add mapping: in-the-doldrums

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,32 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- natural-phenomena
+- travel
+roles:
+- vessel
+- crew
+- captain
+- anchor
+- keel
+- rigging
+- wind
+- current
+- port
+- cargo
+- heading
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of sailing and maritime navigation -- ships, crews, weather,
+rigging, anchors, and the sea itself. One of the oldest and richest source
+domains in English, dating to an era when oceanic travel was the dominant
+mode of long-distance movement and trade. Seafaring generated enormous
+specialized vocabulary, much of which has drifted into general usage as
+dead metaphor: people say "on an even keel" or "taken aback" with no
+awareness of the nautical origin. The domain is structurally rich because
+ships are complex systems operating in hostile, unpredictable environments
+with limited resources and no easy exit -- conditions that map readily
+onto business, psychology, and organizational life.

--- a/catalog/mappings/in-the-doldrums.md
+++ b/catalog/mappings/in-the-doldrums.md
@@ -1,0 +1,116 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: In the Doldrums
+related:
+- even-keel
+slug: in-the-doldrums
+source_frame: seafaring
+target_frame: mental-experience
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+The doldrums are the Intertropical Convergence Zone, a belt of ocean near
+the equator where the northeast and southeast trade winds meet and cancel
+each other out. Sailing ships entering this zone could be becalmed for
+days or weeks -- no wind, no movement, no recourse. The crew could only
+wait, rationing water and watching the sails hang slack.
+
+This maps onto depression, stagnation, and low morale with unusual
+structural precision:
+
+- **Absence, not obstruction** -- the doldrums are not a storm, a reef,
+  or an enemy fleet. There is nothing to fight. The problem is the
+  absence of the very thing that makes movement possible. This maps
+  perfectly onto a specific kind of psychological stagnation: not the
+  kind caused by an identifiable obstacle, but the kind caused by a
+  mysterious loss of motivation, energy, or direction. You are not
+  blocked; you are becalmed.
+- **No agency, no timeline** -- a becalmed ship cannot sail its way out.
+  The crew cannot manufacture wind. They can only wait for conditions to
+  change, with no way to predict when that will happen. This maps onto
+  the experience of depression or organizational malaise where effort
+  feels pointless because the problem is not a lack of effort but a
+  lack of the environmental conditions that make effort productive.
+- **Geographic specificity as trap** -- the doldrums are a known zone.
+  Sailors knew where they were, knew they were dangerous, and sometimes
+  entered them anyway because the zone lay between the trade wind belts
+  they needed to reach. This maps onto the experience of predictable
+  low periods -- post-project slumps, seasonal depression, midcareer
+  stagnation -- that you can see coming but cannot avoid because the
+  only path to where you want to be passes through them.
+- **Collective, not individual** -- an entire ship is becalmed, not just
+  one sailor. The metaphor naturally extends to group stagnation: a
+  team, a company, a market sector in the doldrums. The shared nature
+  of the predicament is built into the image.
+
+## Where It Breaks
+
+- **The doldrums end; depression may not** -- the meteorological doldrums
+  are a zone you pass through. Wind eventually returns, or a current
+  carries you to where wind exists. The metaphor imports an optimistic
+  temporal structure: this too shall pass. But clinical depression is
+  not a zone on a map; it does not guarantee its own ending. Using
+  "doldrums" for serious depression can minimize the condition by
+  implying it is a temporary weather pattern rather than a potentially
+  chronic illness.
+- **The metaphor hides the internal** -- doldrums are an external
+  condition. The ship is fine; the wind is missing. But depression is
+  often internal: neurochemistry, trauma, cognitive patterns. Calling
+  it "the doldrums" externalizes the cause and can imply that the
+  person just needs to wait for better weather, rather than seek
+  treatment for an internal condition.
+- **Passivity as the only response** -- in the actual doldrums, waiting
+  was genuinely the only option for a sailing ship. But in psychological
+  or organizational stagnation, passivity is often the worst response.
+  The metaphor can validate inaction by framing it as the natural and
+  correct response to the situation, when in fact initiative, therapy,
+  or structural change might be exactly what is needed.
+- **The word has become too mild** -- "doldrums" in modern usage often
+  means little more than "a bit bored" or "slightly sluggish." The
+  original maritime terror -- men dying of thirst, ships rotting in
+  place, crews driven to despair -- has been worn down to a polite
+  euphemism. The dead metaphor has lost the very extremity that made
+  the mapping powerful.
+
+## Expressions
+
+- "The economy is in the doldrums" -- the most common modern usage,
+  describing a period of low growth with no clear cause or remedy
+- "Stuck in the doldrums" -- emphasizing the inability to self-rescue,
+  the feeling of being trapped in stagnation
+- "Pull out of the doldrums" -- the recovery narrative, implying that
+  wind has returned, often used for markets or moods
+- "The summer doldrums" -- seasonal low activity in financial markets
+  or newsrooms, directly echoing the geographic predictability of the
+  original zone
+- "Shaking off the doldrums" -- implying that the stagnation can be
+  overcome by effort, which subtly contradicts the original metaphor
+  where effort was precisely what could not help
+
+## Origin Story
+
+The word "doldrums" likely derives from "dol" (an archaic word for dull
+or stupid) combined with the pattern of "tantrums." It entered English
+in the early 19th century, initially referring to the equatorial calm
+zone and almost simultaneously to a state of listlessness or depression.
+The nautical and psychological meanings developed in parallel rather than
+one preceding the other, which is unusual for nautical dead metaphors --
+most begin as purely technical terms that later acquire figurative
+meanings. By the mid-19th century, "in the doldrums" was established as
+a general English idiom for any state of inactivity or low spirits, and
+most speakers had lost awareness of the maritime reference entirely.
+
+## References
+
+- Kemp, P. *The Oxford Companion to Ships and the Sea* (1976) -- standard
+  reference for the meteorological and nautical meaning of the doldrums
+- OED, "doldrums" -- traces the parallel emergence of nautical and
+  psychological senses in the early 1800s


### PR DESCRIPTION
## Summary

- Adds `in-the-doldrums` dead metaphor mapping (seafaring -> mental-experience)
- Creates `seafaring` source frame (shared by subsequent nautical-terms PRs)
- Resolves #1274 (sub-issue of #1226 nautical-terms project)

## Validator output

`All content valid.` (28 pre-existing dangling-reference warnings, zero errors)

## Test plan

- [ ] Frontmatter matches schema (slug, name, kind, frames, categories, dates)
- [ ] "Where It Breaks" section is substantive
- [ ] Expressions drawn from real usage
- [ ] Validator passes with zero errors

Generated with [Claude Code](https://claude.com/claude-code)