### PR TITLE
Add mapping: bitter-end

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,32 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- natural-phenomena
+- travel
+roles:
+- vessel
+- crew
+- captain
+- anchor
+- keel
+- rigging
+- wind
+- current
+- port
+- cargo
+- heading
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of sailing and maritime navigation -- ships, crews, weather,
+rigging, anchors, and the sea itself. One of the oldest and richest source
+domains in English, dating to an era when oceanic travel was the dominant
+mode of long-distance movement and trade. Seafaring generated enormous
+specialized vocabulary, much of which has drifted into general usage as
+dead metaphor: people say "on an even keel" or "taken aback" with no
+awareness of the nautical origin. The domain is structurally rich because
+ships are complex systems operating in hostile, unpredictable environments
+with limited resources and no easy exit -- conditions that map readily
+onto business, psychology, and organizational life.

--- a/catalog/mappings/bitter-end.md
+++ b/catalog/mappings/bitter-end.md
@@ -1,0 +1,117 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Bitter End
+related:
+- in-the-doldrums
+slug: bitter-end
+source_frame: seafaring
+target_frame: event-structure
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+The bitts are heavy posts bolted to a ship's deck, used to secure the
+anchor cable. The bitter end is the final length of chain or rope fastened
+to the bitts -- the absolute last section. When a ship pays out anchor
+cable and reaches the bitter end, there is nothing left to deploy. The
+anchor is at maximum depth, the cable is fully extended, and the ship
+has exhausted its primary means of holding position.
+
+This maps onto perseverance through the worst phase of any ordeal:
+
+- **Exhaustion of resources as a boundary** -- the bitter end is not a
+  gradual decline but a hard limit. There is chain, and then there is no
+  chain. This maps onto situations where resources (money, patience,
+  energy, political capital) run out discretely rather than gradually.
+  "To the bitter end" means pushing until there is literally nothing
+  left to give, not just until it gets difficult.
+- **The final segment is the harshest** -- the last fathoms of anchor
+  chain are the ones paid out in the worst conditions: the anchor has
+  not held, the storm is intensifying, the seabed is too deep. The
+  phrase carries the implication that the final stage of any process is
+  not merely the last but the most painful. This maps well onto project
+  death marches, terminal illness, and the final stages of any
+  protracted struggle.
+- **No retreat possible** -- once you have paid out the bitter end,
+  you cannot pay out more. The metaphor encodes irreversibility: you
+  are committed, for better or worse. This maps onto decisions and
+  processes that cannot be reversed or extended -- you have used
+  everything, and now you face the outcome with whatever you have.
+- **The hidden infrastructure** -- the bitts are a structural component
+  that most people never notice until they matter. The bitter end is
+  defined by its attachment to something most observers are unaware of.
+  This maps onto the experience of discovering the true limits of a
+  system only when those limits are reached: you did not know you were
+  running out until you ran out.
+
+## Where It Breaks
+
+- **The folk etymology dominates** -- most speakers assume "bitter end"
+  refers to bitterness, the taste of suffering. This folk etymology is
+  so entrenched that it has effectively replaced the nautical meaning.
+  The metaphor now operates on the emotional register (enduring
+  bitterness) rather than the structural one (reaching the last link of
+  chain). This is not just a loss of origin knowledge; it is a
+  fundamental shift in what the metaphor maps. The dead metaphor has
+  been reanimated with a different skeleton.
+- **Orderliness vs. chaos** -- paying out anchor chain to the bitter end
+  is a controlled, deliberate process performed by trained crew. But
+  "to the bitter end" in modern usage implies grinding through chaos,
+  suffering, or deterioration. The original image is mechanical and
+  procedural; the modern meaning is emotional and dramatic. The
+  discipline of the source domain is lost in the transfer.
+- **The metaphor implies heroism in stubbornness** -- "fighting to the
+  bitter end" is almost always framed as admirable. But the nautical
+  reality of reaching the bitter end was not heroic; it was a crisis.
+  It meant the anchor might not hold, the ship might drag, the
+  situation was desperate. The metaphor can valorize refusal to quit
+  when quitting might be the rational choice, importing a heroic frame
+  onto what may be foolish persistence.
+- **Binary vs. gradual** -- the actual bitter end is a discrete boundary
+  (chain or no chain). But most endurance situations involve gradual
+  degradation rather than a sudden limit. The metaphor imposes a
+  cliff-edge structure onto experiences that are actually slopes,
+  which can mislead people about when they have truly exhausted their
+  options.
+
+## Expressions
+
+- "To the bitter end" -- persevering through the worst, most painful
+  final phase of a struggle, the most common form
+- "Stay until the bitter end" -- remaining present through the worst
+  of something, whether a meeting, a relationship, or a decline
+- "Fight to the bitter end" -- refusing to surrender or compromise,
+  carrying the implication of exhausting all resources before conceding
+- "The bitter end of the negotiations" -- the final, most contentious
+  phase where both parties have nearly exhausted their positions
+- "See it through to the bitter end" -- a commitment to finish what
+  was started regardless of cost
+
+## Origin Story
+
+The nautical origin is well attested but frequently contested by those
+who prefer the folk etymology. Captain John Smith's *A Sea Grammar*
+(1627) describes the bitts and the practice of paying out cable to the
+bitter end. The transition from technical nautical term to general idiom
+occurred during the 18th and 19th centuries, but the phrase was likely
+reinforced by the coincidence with "bitter" meaning unpleasant -- a
+coincidence so powerful that it effectively re-motivated the dead
+metaphor along emotional rather than mechanical lines. The King James
+Bible's use of "bitter" in descriptions of suffering (Proverbs 5:4,
+"her end is bitter as wormwood") may have accelerated the conflation.
+
+## References
+
+- Smith, J. *A Sea Grammar* (1627) -- early documentation of the bitts
+  and the bitter end as nautical terminology
+- Kemp, P. *The Oxford Companion to Ships and the Sea* (1976) --
+  standard reference for nautical derivation
+- OED, "bitter end" -- traces both the nautical and the folk-etymological
+  interpretations


### PR DESCRIPTION
## Summary

- Adds `bitter-end` dead metaphor mapping (seafaring -> event-structure)
- Includes `seafaring` source frame
- Resolves #1275 (sub-issue of #1226 nautical-terms project)

## Validator output

`All content valid.` (28 pre-existing dangling-reference warnings, zero errors)

## Test plan

- [ ] Frontmatter matches schema
- [ ] "Where It Breaks" section is substantive
- [ ] Expressions drawn from real usage
- [ ] Validator passes with zero errors

Generated with [Claude Code](https://claude.com/claude-code)