### PR TITLE
Add mapping: cut-and-run

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,32 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- natural-phenomena
+- travel
+roles:
+- vessel
+- crew
+- captain
+- anchor
+- keel
+- rigging
+- wind
+- current
+- port
+- cargo
+- heading
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of sailing and maritime navigation -- ships, crews, weather,
+rigging, anchors, and the sea itself. One of the oldest and richest source
+domains in English, dating to an era when oceanic travel was the dominant
+mode of long-distance movement and trade. Seafaring generated enormous
+specialized vocabulary, much of which has drifted into general usage as
+dead metaphor: people say "on an even keel" or "taken aback" with no
+awareness of the nautical origin. The domain is structurally rich because
+ships are complex systems operating in hostile, unpredictable environments
+with limited resources and no easy exit -- conditions that map readily
+onto business, psychology, and organizational life.

--- a/catalog/mappings/cut-and-run.md
+++ b/catalog/mappings/cut-and-run.md
@@ -1,0 +1,121 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Cut and Run
+related:
+- bitter-end
+slug: cut-and-run
+source_frame: seafaring
+target_frame: social-behavior
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+When a ship at anchor needed to flee immediately -- an approaching enemy,
+a sudden storm, a shifting lee shore -- the crew could cut the anchor
+cable with an axe rather than spend the time hauling the anchor up through
+the hawsehole. The ship would then run before the wind, sacrificing an
+expensive anchor and cable for speed of escape. The phrase maps the
+structure of emergency abandonment onto social and professional life:
+
+- **Sacrifice of assets for speed** -- cutting the cable destroys
+  valuable equipment. The anchor, chain, and cable were expensive and
+  not easily replaced at sea. The metaphor encodes a specific kind of
+  trade-off: you can leave quickly, but only by abandoning something
+  you have invested in. This maps onto leaving a job without notice
+  (sacrificing references and reputation), abandoning a project
+  (sacrificing sunk costs), or exiting a relationship abruptly
+  (sacrificing the accumulated investment of time and trust).
+- **Urgency overrides procedure** -- the normal process of weighing
+  anchor is slow, methodical, and preserves the equipment. Cutting and
+  running is the emergency override. The metaphor implies that the
+  person who cuts and runs has decided that the normal process is too
+  dangerous or too slow -- that staying to do things properly is a
+  greater risk than the cost of abandoning. This maps onto any
+  situation where following proper procedure seems more dangerous
+  than breaking it.
+- **Irreversibility** -- once the cable is cut, you cannot reattach it
+  at sea. The anchor is gone. This maps onto the finality of certain
+  departures: you cannot un-quit, un-flee, or un-abandon. The metaphor
+  encodes the one-way nature of panicked or desperate exits.
+- **Judgment embedded in the phrase** -- "cut and run" carries negative
+  moral weight in modern usage. It implies cowardice, irresponsibility,
+  or betrayal. But the original nautical act was often the correct
+  tactical decision -- a captain who stayed to haul anchor under enemy
+  fire was a fool, not a hero. The metaphor has imported the structure
+  of the act while inverting its moral valence.
+
+## Where It Breaks
+
+- **The original was often rational; the metaphor implies it is not** --
+  a captain cutting the cable was making a calculated decision: the
+  anchor costs less than the ship. But "cut and run" in modern usage
+  almost always implies that the departure was rash, cowardly, or
+  premature. The metaphor has lost the cost-benefit analysis that
+  justified the original act. This can prevent clear thinking about
+  situations where rapid withdrawal is genuinely the best option --
+  the phrase shames what may be sound judgment.
+- **The metaphor hides what you are running from** -- in the nautical
+  case, the threat was specific and visible: an enemy fleet, a storm,
+  a dangerous shore. The metaphor preserves the running but not the
+  threat. When someone accuses another of "cutting and running," the
+  accusation focuses on the departure and ignores the conditions that
+  motivated it. This asymmetry makes the phrase a rhetorical weapon:
+  it frames any departure as flight rather than as a response to
+  intolerable conditions.
+- **It implies a single decisive moment** -- cutting a cable with an
+  axe is instantaneous. But most real departures are gradual: a slow
+  disengagement, a series of partial withdrawals, a growing distance.
+  The metaphor imposes a clean break onto processes that are usually
+  messy and extended. People accused of cutting and running may feel
+  they spent months trying to make things work.
+- **No return in the metaphor, but returns happen** -- the metaphor
+  encodes permanent departure. But people who "cut and run" from jobs,
+  relationships, and commitments often return, renegotiate, or
+  reconnect. The metaphor's finality overstates the irreversibility
+  of most social departures, which exist on a spectrum from temporary
+  withdrawal to permanent exit.
+
+## Expressions
+
+- "They cut and ran" -- the standard accusation of hasty, irresponsible
+  departure, used in personal, professional, and political contexts
+- "Cut and run from Iraq/Afghanistan" -- political usage, weaponized to
+  shame advocates of military withdrawal by framing strategic retreat
+  as cowardice
+- "Don't cut and run" -- the exhortation to stay and face difficulty
+  rather than flee, often used by managers, coaches, and political
+  leaders
+- "A cut-and-run strategy" -- used (usually pejoratively) for any plan
+  that involves rapid exit from a commitment
+- "Cut your losses and run" -- a variant that makes the cost-benefit
+  logic explicit, partially restoring the rationality of the original
+  nautical act
+
+## Origin Story
+
+The phrase is attested in nautical usage from the early 18th century.
+The practice itself is certainly older -- as old as anchored ships and
+axes. The transition to figurative usage happened gradually during the
+18th and 19th centuries, initially in military contexts (armies cutting
+and running from battle) before broadening to any form of hasty
+departure. The phrase gained particular political prominence during the
+Iraq War debates of the 2000s, when "cut and run" became a loaded term
+in American political discourse, used by war supporters to discredit
+withdrawal proposals. This political usage further cemented the negative
+moral valence that the phrase had accumulated over centuries.
+
+## References
+
+- Smyth, W.H. *The Sailor's Word-Book* (1867) -- documents the nautical
+  practice of cutting the anchor cable for emergency departure
+- OED, "cut and run" -- traces the nautical origin and figurative
+  development
+- Safire, W. *Safire's Political Dictionary* (2008) -- documents the
+  political weaponization of the phrase during the Iraq War era


### PR DESCRIPTION
## Summary

- Adds `cut-and-run` dead metaphor mapping (seafaring -> social-behavior)
- Includes `seafaring` source frame
- Resolves #1276 (sub-issue of #1226 nautical-terms project)

## Validator output

`All content valid.` (28 pre-existing dangling-reference warnings, zero errors)

## Test plan

- [ ] Frontmatter matches schema
- [ ] "Where It Breaks" section is substantive
- [ ] Expressions drawn from real usage
- [ ] Validator passes with zero errors

Generated with [Claude Code](https://claude.com/claude-code)