### PR TITLE
Add mapping: by-and-large

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,32 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- natural-phenomena
+- travel
+roles:
+- vessel
+- crew
+- captain
+- anchor
+- keel
+- rigging
+- wind
+- current
+- port
+- cargo
+- heading
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of sailing and maritime navigation -- ships, crews, weather,
+rigging, anchors, and the sea itself. One of the oldest and richest source
+domains in English, dating to an era when oceanic travel was the dominant
+mode of long-distance movement and trade. Seafaring generated enormous
+specialized vocabulary, much of which has drifted into general usage as
+dead metaphor: people say "on an even keel" or "taken aback" with no
+awareness of the nautical origin. The domain is structurally rich because
+ships are complex systems operating in hostile, unpredictable environments
+with limited resources and no easy exit -- conditions that map readily
+onto business, psychology, and organizational life.

--- a/catalog/mappings/by-and-large.md
+++ b/catalog/mappings/by-and-large.md
@@ -1,0 +1,119 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: By and Large
+related: []
+slug: by-and-large
+source_frame: seafaring
+target_frame: language
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+In sailing, "by" means close-hauled -- sailing as near to the wind as
+possible, a demanding point of sail requiring constant attention to trim.
+"Large" means sailing with the wind behind or on the quarter, an easier
+and faster point of sail. A ship that sailed well "by and large" handled
+both the difficult upwind work and the easy downwind running. The phrase
+was a comprehensive assessment: this ship performs across the full range
+of conditions.
+
+The mapping onto general language is a compression of that range:
+
+- **Comprehensive assessment collapsed into hedge** -- the original
+  phrase encoded a specific technical judgment: tested under both the
+  hardest and easiest conditions, this thing performs. The modern
+  meaning retains the sense of overall assessment ("by and large, the
+  project succeeded") but has lost the structural logic of testing
+  across opposing conditions. What was a rigorous evaluation has become
+  a vague qualifier.
+- **Two opposite modes as totality** -- "by" and "large" were not
+  synonyms or intensifiers; they were antonyms (upwind vs. downwind).
+  The phrase worked because it named both poles of a spectrum and
+  implied everything between them. This is a common rhetorical
+  structure (alpha and omega, top to bottom, soup to nuts) but the
+  nautical version is invisible to modern speakers, who parse "by and
+  large" as a single indivisible idiom rather than as a conjunction of
+  opposites.
+- **Performance under constraint** -- sailing "by" (close to the wind)
+  is the constrained, effortful mode. Sailing "large" is the
+  unconstrained, easy mode. The original phrase implicitly acknowledged
+  that performance varies with conditions and that a fair assessment
+  must account for both. This nuance maps onto the modern usage as a
+  residual honesty: saying "by and large" signals that the speaker
+  knows there are exceptions and is choosing to generalize anyway.
+
+## Where It Breaks
+
+- **The technical structure is completely dead** -- unlike many dead
+  metaphors, where the source domain can be recovered with a moment's
+  thought (e.g., "in the doldrums" still evokes stagnation even without
+  knowing about equatorial calms), "by and large" has no recoverable
+  image for a non-sailor. The phrase is phonetically arbitrary to modern
+  speakers -- three monosyllables connected by "and" with no apparent
+  meaning. The metaphor is not just dead but decomposed beyond
+  recognition.
+- **It has become a filler word** -- in the original, "by and large"
+  was a precise judgment about a ship's capability. In modern English,
+  it functions as a discourse marker -- a hedge, a throat-clearing, a
+  way to say "mostly" with an extra syllable. It occupies the same
+  functional space as "on the whole," "generally speaking," or "all
+  things considered." The precision of the original has been replaced
+  by pure vagueness.
+- **The antonymic structure is invisible** -- the power of the original
+  phrase came from the tension between its two halves: "by" (hard) AND
+  "large" (easy). Without awareness that these name opposite
+  conditions, the phrase loses its logical backbone. No modern speaker
+  hears "by and large" as "under both the difficult and easy
+  conditions" -- they hear it as a single, unanalyzable chunk. The
+  conjunction "and" does no visible work.
+- **No residual image to misapply** -- many dead metaphors can be
+  reactivated (someone can say "literally in the doldrums" and the
+  nautical image strengthens the point). But "by and large" cannot be
+  reactivated because the components are too technical and too obscure.
+  This makes it one of the most thoroughly dead metaphors in English --
+  it has passed from dead metaphor to pure idiom, with no possibility
+  of resurrection.
+
+## Expressions
+
+- "By and large, it works" -- the default usage, meaning "on the whole"
+  or "with some exceptions that I am choosing not to enumerate"
+- "By and large, people agree" -- the generalizing form, used to smooth
+  over dissent by framing consensus as the dominant pattern
+- "By and large" as sentence opener -- functions as a discourse marker
+  signaling that a qualified generalization is about to follow
+- "Not by and large but specifically" -- the occasional contrast,
+  where a speaker rejects the vague hedge in favor of precision,
+  implicitly acknowledging that "by and large" is imprecise
+
+## Origin Story
+
+The phrase is attested in nautical contexts from the late 17th century.
+Samuel Sturmy's *The Mariner's Magazine* (1669) uses "by and large" in
+its technical sailing sense. The figurative meaning ("on the whole")
+appears by the early 18th century, suggesting a rapid drift from
+technical jargon to general idiom -- perhaps because the phrase was
+already being used loosely by sailors themselves to mean "taking
+everything into account." The speed of the metaphor's death is notable:
+within a generation or two, the sailing meaning was lost to non-mariners.
+The phrase is now so thoroughly integrated into English that it appears
+in every dialect and register, from academic writing to casual
+conversation, with no one pausing to wonder what "by" and "large"
+might mean individually.
+
+## References
+
+- Sturmy, S. *The Mariner's Magazine* (1669) -- early technical usage
+  of "by and large" in its sailing sense
+- OED, "by and large" -- traces the transition from nautical term to
+  general idiom
+- Jeans, P.D. *Ship to Shore: A Dictionary of Everyday Words and
+  Phrases Borrowed from the Sea* (2004) -- popular treatment of
+  nautical dead metaphors including "by and large"


### PR DESCRIPTION
## Summary

- Adds `by-and-large` dead metaphor mapping (seafaring -> language)
- Includes `seafaring` source frame
- Resolves #1277 (sub-issue of #1226 nautical-terms project)

## Validator output

`All content valid.` (27 pre-existing dangling-reference warnings, zero errors)

## Test plan

- [ ] Frontmatter matches schema
- [ ] "Where It Breaks" section is substantive
- [ ] Expressions drawn from real usage
- [ ] Validator passes with zero errors

Generated with [Claude Code](https://claude.com/claude-code)