### PR TITLE
Add mapping: even-keel

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,32 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- natural-phenomena
+- travel
+roles:
+- vessel
+- crew
+- captain
+- anchor
+- keel
+- rigging
+- wind
+- current
+- port
+- cargo
+- heading
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of sailing and maritime navigation -- ships, crews, weather,
+rigging, anchors, and the sea itself. One of the oldest and richest source
+domains in English, dating to an era when oceanic travel was the dominant
+mode of long-distance movement and trade. Seafaring generated enormous
+specialized vocabulary, much of which has drifted into general usage as
+dead metaphor: people say "on an even keel" or "taken aback" with no
+awareness of the nautical origin. The domain is structurally rich because
+ships are complex systems operating in hostile, unpredictable environments
+with limited resources and no easy exit -- conditions that map readily
+onto business, psychology, and organizational life.

--- a/catalog/mappings/even-keel.md
+++ b/catalog/mappings/even-keel.md
@@ -1,0 +1,128 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Even Keel
+related:
+- in-the-doldrums
+slug: even-keel
+source_frame: seafaring
+target_frame: mental-experience
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+The keel is the central structural timber running the full length of a
+ship's bottom -- the spine from which the rest of the hull is built. A
+ship on an "even keel" sits level in the water: not listing to port or
+starboard (heeling), not pitched bow-up or stern-down (trimmed by the
+head or stern). This is the optimal resting state -- the ship is
+balanced, seaworthy, and ready to respond predictably to helm and sail.
+
+The mapping onto emotional and organizational steadiness is structurally
+rich:
+
+- **Stability from below the waterline** -- the keel is invisible. It
+  sits below the surface, and its work is structural rather than visible.
+  This maps onto the insight that emotional stability comes from deep
+  structures -- character, habits, self-knowledge -- rather than from
+  surface presentation. A person "on an even keel" is stable because of
+  what lies beneath, not because of what is displayed. The metaphor
+  encodes the idea that true steadiness is foundational, not performed.
+- **Level as default, not achievement** -- an even keel is the ship's
+  natural resting state when properly loaded and designed. It is not a
+  heroic accomplishment but a return to baseline. This maps onto a
+  specific understanding of emotional health: stability is not an
+  extraordinary state to be achieved but the natural condition to be
+  restored when disturbance passes. The metaphor normalizes steadiness.
+- **Balance as a dynamic condition** -- a ship on an even keel is not
+  motionless. It still responds to waves, wind, and current. But it
+  returns to level after each disturbance. This maps onto resilience
+  rather than rigidity: an emotionally even-keeled person is not
+  unfeeling but recovers quickly. The metaphor distinguishes between
+  being unmoved (which would be a rock, not a ship) and being
+  self-righting (which is what a well-designed hull does).
+- **Loading and trim as causes** -- a ship goes off its even keel when
+  cargo is unevenly distributed or when external forces (wind, waves)
+  overwhelm the hull's natural stability. This maps onto the causes of
+  emotional imbalance: uneven burdens, poorly distributed
+  responsibilities, or external pressures that exceed a person's
+  structural capacity to absorb them. The metaphor implies that
+  restoring the even keel is a matter of redistribution and design,
+  not just willpower.
+
+## Where It Breaks
+
+- **Ships are passive; people have agency** -- a ship's keel does not
+  choose to be even. The ship is designed and loaded to be level, and
+  physics does the rest. But human emotional stability involves will,
+  effort, medication, therapy, and conscious practice. The metaphor
+  can make emotional regulation seem automatic or constitutional
+  ("she's just an even-keeled person") when it is often hard-won and
+  actively maintained. It naturalizes what may be labor.
+- **The metaphor privileges calm over intensity** -- an even keel is
+  the ideal state for a ship. But the metaphor, applied to people,
+  imports a normative claim: that emotional flatness is better than
+  emotional intensity. This can pathologize passionate, volatile, or
+  deeply feeling people by measuring them against a standard of
+  nautical stability. Not all situations call for an even keel; some
+  call for heeling hard into the wind.
+- **It hides the cost of ballast** -- ships maintain an even keel
+  partly through ballast: heavy material carried low in the hull
+  specifically to provide stability. Ballast is dead weight; it
+  contributes nothing except stability and costs speed and cargo
+  capacity. The metaphor does not acknowledge that emotional
+  steadiness may similarly require carrying dead weight -- suppressed
+  feelings, unexpressed grief, avoided risks -- that keeps you level
+  at the cost of forward motion or capacity.
+- **Listing can be functional** -- in sailing, heeling (tilting) is
+  not always a problem. A ship under full sail heels into the wind as
+  a natural consequence of the force driving it forward. The heel is
+  the price of speed. The metaphor's insistence on "even" as ideal
+  can obscure situations where imbalance is a sign of productive
+  engagement rather than a problem to be corrected.
+
+## Expressions
+
+- "Keep on an even keel" -- the most common form, meaning to maintain
+  emotional or organizational stability through changing conditions
+- "She's very even-keeled" -- a character description implying
+  reliability, steadiness, and emotional predictability, almost always
+  intended as a compliment
+- "Get back on an even keel" -- recovery from disruption, whether
+  emotional, financial, or organizational
+- "Knock someone off their even keel" -- causing emotional
+  destabilization, implying that the person's normal state is stable
+  and the disruption is external
+- "The company is back on an even keel" -- organizational recovery
+  after a crisis, implying that operational stability has been restored
+
+## Origin Story
+
+The phrase emerges from the general vocabulary of shipbuilding and
+seamanship, where "keel" has been the foundational nautical term since
+Old Norse *kjolr*. The figurative use of "even keel" for emotional
+stability appears in English by the mid-19th century, though the
+concept of a ship being "on her keel" (upright and stable) is much
+older. The metaphor's longevity owes much to the physicality of the
+image: even people who have never seen a ship can intuit that a vessel
+should sit level in the water, making the metaphor accessible long
+after its technical context has faded. The phrase remains remarkably
+active for a dead metaphor -- it is used frequently in psychology,
+management literature, and everyday speech, always with the sense of
+steadiness as a desirable default.
+
+## References
+
+- Kemp, P. *The Oxford Companion to Ships and the Sea* (1976) --
+  technical definition of keel and trim
+- OED, "keel" and "even keel" -- traces the figurative development
+  from nautical to psychological usage
+- Jeans, P.D. *Ship to Shore: A Dictionary of Everyday Words and
+  Phrases Borrowed from the Sea* (2004) -- popular treatment of
+  "even keel" and related nautical idioms


### PR DESCRIPTION
## Summary

- Adds `even-keel` dead metaphor mapping (seafaring -> mental-experience)
- Includes `seafaring` source frame
- Resolves #1278 (sub-issue of #1226 nautical-terms project)

## Validator output

`All content valid.` (28 pre-existing dangling-reference warnings, zero errors)

## Test plan

- [ ] Frontmatter matches schema
- [ ] "Where It Breaks" section is substantive
- [ ] Expressions drawn from real usage
- [ ] Validator passes with zero errors

Generated with [Claude Code](https://claude.com/claude-code)