### PR TITLE
Add mapping: know-the-ropes

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,31 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- journeys
+- natural-phenomena
+roles:
+- vessel
+- crew
+- captain
+- rigging
+- anchor
+- cargo
+- harbor
+- course
+- wind
+- sea-state
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of sailing ships, navigation, and life at sea. Covers vessels and
+their anatomy (hull, deck, mast, rigging, hatches), crew roles and competence,
+harbor operations (anchoring, berthing, loading), weather response, and
+navigation. As a source domain it is extraordinarily productive in English
+because the British Empire's dependence on naval power saturated the language
+with maritime vocabulary. Dozens of everyday expressions -- "on board,"
+"taken aback," "in the offing," "cut and run" -- are dead nautical metaphors
+whose seafaring origins are invisible to most speakers. The domain's richness
+comes from the fact that a sailing ship is a complex, dangerous, self-contained
+system where competence is life-or-death and every component has a precise name.

--- a/catalog/mappings/know-the-ropes.md
+++ b/catalog/mappings/know-the-ropes.md
@@ -1,0 +1,108 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+kind: dead-metaphor
+name: Know the Ropes
+related:
+- above-board
+slug: know-the-ropes
+source_frame: seafaring
+target_frame: intellectual-inquiry
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+A square-rigged sailing ship carried miles of cordage -- halyards, sheets,
+braces, stays, shrouds, clew lines, buntlines -- each with a specific
+function and a specific location. A competent sailor could find and
+operate any line by feel, in darkness, in a gale, with the deck pitching
+under him. "Knowing the ropes" was not book learning; it was embodied
+expertise acquired through months of practice on a particular vessel,
+since rigging configurations varied from ship to ship.
+
+- **Competence as physical familiarity** -- the metaphor maps the
+  sailor's tactile, kinesthetic knowledge of a complex physical system
+  onto expertise in any domain. Knowing the ropes of a new job means
+  understanding not just what things are called but where they are, how
+  they feel, which ones matter in a crisis. The mapping preserves the
+  embodied, practical character of real expertise as opposed to
+  theoretical understanding.
+- **System complexity as a web of interdependencies** -- rigging is not
+  a list of ropes but a system where pulling one line affects the tension
+  on others. Knowing the ropes means understanding these relationships,
+  not just memorizing names. The metaphor imports this systemic quality:
+  knowing the ropes of an organization means understanding how its parts
+  connect, not just what they are called.
+- **The source domain is completely invisible** -- almost nobody who
+  says "learn the ropes" pictures a sailing ship. The expression has
+  been fully absorbed into general English with no residual nautical
+  flavor. It is a textbook dead metaphor: the vehicle has been
+  forgotten while the mapping persists.
+
+## Where It Breaks
+
+- **Ropes are static; organizational knowledge changes** -- a ship's
+  rigging, once set up, remains largely constant for the duration of a
+  voyage. The ropes are where they are. Organizational procedures,
+  personnel, tools, and norms change continuously. "Knowing the ropes"
+  implies a stable system that rewards one-time learning, but most
+  domains require continuous relearning. The metaphor underestimates
+  how much the ropes move.
+- **The metaphor flattens expertise into familiarity** -- a sailor who
+  knows the ropes can find and operate them, but the deeper expertise
+  of a sailing master includes judgment about when to reef, when to
+  tack, how to read weather. "Knowing the ropes" maps only the
+  procedural layer of expertise, not the strategic layer. In
+  organizational contexts, it can reduce competence to knowing where
+  the forms are kept rather than knowing why the forms exist.
+- **No distinction between good and bad ropes** -- the expression
+  treats all ropes as equally worth knowing. It carries no evaluative
+  content about which procedures are sound and which are dysfunction
+  calcified into habit. Someone who "knows the ropes" of a broken
+  bureaucracy has learned to navigate dysfunction, not excellence. The
+  metaphor cannot distinguish between mastering a good system and
+  accommodating a bad one.
+- **The metaphor implies a single learner, not collective knowledge** --
+  on a ship, each sailor individually learns the ropes. The metaphor
+  does not map onto institutional knowledge, documented procedures, or
+  shared understanding. It frames expertise as personal and
+  non-transferable, which may be accurate for tacit knowledge but
+  obscures the role of documentation, training programs, and
+  organizational memory.
+
+## Expressions
+
+- "Know the ropes" -- the standard form, meaning to understand how a
+  system works in practice
+- "Learn the ropes" -- the process of acquiring practical familiarity,
+  especially as a newcomer
+- "Show someone the ropes" -- to orient a newcomer by walking them
+  through procedures, implying that the knowledge is best transmitted
+  person-to-person rather than through documentation
+- "The ropes" -- used as a standalone noun for the procedures and
+  conventions of a domain: "the ropes of academic publishing," "the
+  ropes of the insurance industry"
+
+## Origin Story
+
+The expression originates in the age of sail, when the complexity of a
+ship's rigging made rope knowledge a fundamental marker of seamanship.
+Richard Henry Dana's *Two Years Before the Mast* (1840) uses the phrase
+in its literal nautical sense, and by the mid-nineteenth century it was
+already migrating into general usage. A competing but less well-supported
+etymology traces the phrase to the boxing ring or the theater (where
+ropes control scenery), but the nautical origin is the most widely
+accepted among etymologists and is consistent with the dozens of other
+dead nautical metaphors in English.
+
+## References
+
+- Dana, R. H. *Two Years Before the Mast* (1840) -- uses "know the
+  ropes" in its literal nautical context
+- Jeans, P. D. *Ship to Shore: A Dictionary of Everyday Words and
+  Phrases Borrowed from the Sea* (2004) -- comprehensive catalog of
+  nautical terms that entered general English


### PR DESCRIPTION
## Summary

- Adds `know-the-ropes` dead metaphor mapping (seafaring -> intellectual-inquiry)
- Creates `seafaring` source frame (shared by subsequent nautical-terms PRs)
- Resolves #1279

## Validator output

```
All content valid.
```

(28 pre-existing dangling-reference warnings, none introduced by this PR)

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors

Generated with [Claude Code](https://claude.com/claude-code)