### PR TITLE
Add mapping: give-wide-berth

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,31 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- journeys
+- natural-phenomena
+roles:
+- vessel
+- crew
+- captain
+- rigging
+- anchor
+- cargo
+- harbor
+- course
+- wind
+- sea-state
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of sailing ships, navigation, and life at sea. Covers vessels and
+their anatomy (hull, deck, mast, rigging, hatches), crew roles and competence,
+harbor operations (anchoring, berthing, loading), weather response, and
+navigation. As a source domain it is extraordinarily productive in English
+because the British Empire's dependence on naval power saturated the language
+with maritime vocabulary. Dozens of everyday expressions -- "on board,"
+"taken aback," "in the offing," "cut and run" -- are dead nautical metaphors
+whose seafaring origins are invisible to most speakers. The domain's richness
+comes from the fact that a sailing ship is a complex, dangerous, self-contained
+system where competence is life-or-death and every component has a precise name.

--- a/catalog/mappings/give-wide-berth.md
+++ b/catalog/mappings/give-wide-berth.md
@@ -1,0 +1,108 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+kind: dead-metaphor
+name: Give Wide Berth
+related: []
+slug: give-wide-berth
+source_frame: seafaring
+target_frame: social-behavior
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+Berth is the space a ship needs to swing at anchor without striking
+other vessels, docks, or shoals. The calculation is not trivial: a
+ship on a single anchor rode describes an arc whose radius depends on
+the length of the rode, the wind, and the current. Giving a wide berth
+means anchoring far enough away that even the worst-case swing arc
+leaves a safe margin. The metaphor maps this spatial safety calculation
+onto social avoidance.
+
+- **Danger as unpredictable arc, not fixed position** -- the deepest
+  structural insight the metaphor carries is that the hazard is not
+  the other vessel's current position but its potential range of
+  movement. You give wide berth not because the ship is dangerous
+  where it sits but because you cannot predict where it will swing.
+  The social mapping preserves this: you avoid someone not because of
+  what they are doing now but because of what they might do. The
+  metaphor imports uncertainty as the reason for avoidance.
+- **Distance as the only available safety measure** -- in a crowded
+  anchorage, the only tool you have is space. You cannot change the
+  other vessel's behavior, cannot shorten its rode, cannot control the
+  wind. All you can do is position yourself far enough away. The social
+  mapping carries this constraint: giving someone a wide berth is an
+  acknowledgment that you cannot control the other person's behavior,
+  only your own proximity to it.
+- **The source domain is nearly invisible** -- most speakers understand
+  "give wide berth" as simply meaning "stay away from." The nautical
+  technicality of berth as swing room at anchor is forgotten. The
+  expression survives as a general idiom for avoidance with a slightly
+  formal register.
+
+## Where It Breaks
+
+- **Social avoidance is usually about known behavior, not uncertainty** --
+  the nautical berth is about unpredictable movement: you do not know
+  which way the ship will swing. But when people give someone a wide
+  berth socially, it is usually because they know exactly what the
+  person does -- they are rude, volatile, or demanding. The metaphor
+  imports an uncertainty model where the social reality is often
+  certainty about undesirable behavior.
+- **The metaphor frames avoidance as prudent, never as cowardly** --
+  in harbor, giving wide berth is unambiguously good seamanship. There
+  is no nautical virtue in anchoring close to a hazard. But social
+  avoidance can be cowardice, conflict avoidance, or passive aggression.
+  The metaphor's nautical framing always makes the avoidance seem
+  sensible, borrowing the authority of seamanship to validate what may
+  be a failure of engagement.
+- **Berth is temporary; social avoidance can be permanent** -- a ship
+  gives wide berth while passing or while anchored, then moves on.
+  The avoidance is situational and time-bound. Social "wide berth"
+  can mean years or a lifetime of avoidance. The metaphor's transient
+  nautical framing can trivialize the permanence and cost of severed
+  relationships.
+- **No concept of the avoided party's experience** -- the metaphor is
+  entirely from the perspective of the vessel taking evasive action.
+  The ship being given wide berth has no feelings about it. But social
+  avoidance is a two-party interaction: the person being avoided often
+  notices and is hurt by it. The metaphor erases the experience of the
+  avoided person by treating them as an obstacle rather than an agent.
+
+## Expressions
+
+- "Give a wide berth" -- the standard form, meaning to avoid someone
+  or something by maintaining distance
+- "Give [someone/something] a wide berth" -- the personal form,
+  typically applied to people known to be difficult or situations
+  known to be problematic
+- "Steer clear" -- a closely related nautical dead metaphor with
+  overlapping meaning, though "steer clear" implies active navigation
+  while "wide berth" implies calculated positioning
+
+## Origin Story
+
+"Berth" in nautical usage originally referred to a safe space for a
+ship to maneuver, whether at anchor or underway. The term dates to at
+least the early seventeenth century, with "wide berth" appearing in
+nautical contexts by the mid-1600s. The metaphorical extension to
+social avoidance was established by the eighteenth century.
+
+The word "berth" itself may derive from "bear" (as in the direction a
+ship bears), though the etymology is disputed. The modern sleeping
+berth on a ship or train is a separate but related sense -- the space
+allocated to a person, derived from the same root concept of allocated
+room. The social metaphor draws exclusively on the navigational sense.
+
+## References
+
+- Smyth, W. H. *The Sailor's Word-Book* (1867) -- defines berth as
+  "the station in which a ship rides at anchor" and notes the
+  importance of sufficient swinging room
+- Jeans, P. D. *Ship to Shore: A Dictionary of Everyday Words and
+  Phrases Borrowed from the Sea* (2004) -- traces the metaphorical
+  migration from harbor to general English


### PR DESCRIPTION
## Summary

- Adds `give-wide-berth` dead metaphor mapping (seafaring -> social-behavior)
- Includes `seafaring` source frame
- Resolves #1280

## Validator output

```
All content valid.
```

(27 pre-existing dangling-reference warnings, none introduced by this PR)

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors

Generated with [Claude Code](https://claude.com/claude-code)