### PR TITLE
Add mapping: above-board

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,31 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- journeys
+- natural-phenomena
+roles:
+- vessel
+- crew
+- captain
+- rigging
+- anchor
+- cargo
+- harbor
+- course
+- wind
+- sea-state
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of sailing ships, navigation, and life at sea. Covers vessels and
+their anatomy (hull, deck, mast, rigging, hatches), crew roles and competence,
+harbor operations (anchoring, berthing, loading), weather response, and
+navigation. As a source domain it is extraordinarily productive in English
+because the British Empire's dependence on naval power saturated the language
+with maritime vocabulary. Dozens of everyday expressions -- "on board,"
+"taken aback," "in the offing," "cut and run" -- are dead nautical metaphors
+whose seafaring origins are invisible to most speakers. The domain's richness
+comes from the fact that a sailing ship is a complex, dangerous, self-contained
+system where competence is life-or-death and every component has a precise name.

--- a/catalog/mappings/above-board.md
+++ b/catalog/mappings/above-board.md
@@ -1,0 +1,119 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+kind: dead-metaphor
+name: Above Board
+related:
+- know-the-ropes
+slug: above-board
+source_frame: seafaring
+target_frame: ethics-and-morality
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+Cargo and crew visible above the deck boards, not concealed below.
+Pirates hid armed fighters below decks to ambush merchant vessels;
+smugglers concealed contraband beneath the boards to evade customs
+inspection. What was "above board" was what you were willing to show
+to an inspector, a harbor master, or an approaching vessel. The
+metaphor maps physical visibility on a ship's deck onto moral
+transparency and honest dealing.
+
+- **The deck as a moral boundary** -- the board (deck) divides the
+  ship into two moral zones: what is visible and what is hidden. Above
+  is honest; below is suspect. This binary maps cleanly onto the moral
+  intuition that transparency equals integrity: if you have nothing to
+  hide, you keep it above board. The metaphor gives moral reasoning a
+  simple spatial architecture -- up is good, hidden is bad.
+- **Visibility as proof of honesty** -- the metaphor does not claim
+  that what is above board is intrinsically good, only that it can be
+  inspected. The moral claim is procedural rather than substantive: an
+  above-board transaction is one that can withstand scrutiny, not
+  necessarily one that is fair. This is a surprisingly precise mapping
+  that survives into modern usage -- "above board" means transparent
+  and auditable, not necessarily virtuous.
+- **Competing etymology strengthens the mapping** -- a rival derivation
+  traces "above board" to card players keeping their hands visible
+  above the table (the "board" being the gaming table). Whether the
+  source is nautical or ludic, the structural mapping is identical:
+  a flat surface separates the visible from the concealed, and moral
+  judgment attaches to which side your actions are on. The convergence
+  of two unrelated domains on the same metaphorical structure suggests
+  the mapping reflects a deep cognitive pattern rather than a historical
+  accident.
+
+## Where It Breaks
+
+- **Concealment is sometimes ethical** -- the metaphor treats everything
+  below the boards as suspect, but some concealment is morally required.
+  Whistleblower protections, anonymous donations, sealed court records,
+  medical privacy, and trade secrets all involve deliberate concealment
+  for good reasons. The metaphor's spatial logic makes all hiding look
+  dishonest, which is a serious distortion of moral reality. Sometimes
+  the ethical act is precisely to keep something below board.
+- **Transparency can be performative** -- the metaphor assumes that
+  what is shown above board is genuine. But display can be as deceptive
+  as concealment. A company that prominently publishes its diversity
+  statistics while hiding its pay equity data is performing
+  above-board-ness selectively. Pirates could put fake cargo above
+  board too. The metaphor has no resources for distinguishing genuine
+  transparency from strategic display.
+- **The binary erases degrees of disclosure** -- the metaphor creates
+  only two categories: above board (visible) and below board (hidden).
+  Real moral situations involve gradients of disclosure: partially
+  redacted documents, need-to-know access, tiered transparency,
+  confidential-but-legal arrangements. The metaphor forces a binary
+  judgment on what is usually a spectrum, making every incomplete
+  disclosure look like deception.
+- **The inspector's perspective is assumed legitimate** -- in the
+  nautical source, the customs inspector or harbor master has the
+  authority to demand visibility. The metaphor imports this assumption:
+  whoever is asking to see what is below board has the right to look.
+  But demands for transparency can be overreaching, invasive, or
+  politically motivated. The metaphor provides no framework for
+  questioning whether the demand for above-board-ness is itself
+  legitimate.
+
+## Expressions
+
+- "Above board" -- the standard form, meaning honest, transparent,
+  and open to inspection
+- "Everything above board" -- the assurance phrase, typically offered
+  preemptively: "I want to make sure everything is above board"
+- "Not entirely above board" -- the diplomatic accusation, implying
+  concealment without directly alleging fraud
+- "Open and above board" -- the emphatic form, doubling the
+  transparency claim with a near-synonym
+
+## Origin Story
+
+The phrase appears in English by the late sixteenth century. The
+nautical etymology -- cargo and crew visible above the deck boards --
+is the most widely cited origin and is consistent with the era's
+maritime commerce, piracy, and customs enforcement. The competing
+card-playing etymology (hands visible above the gaming table) is also
+attested from the same period and may represent parallel independent
+coinage rather than a single origin.
+
+The expression was well established in figurative use by the seventeenth
+century. By the nineteenth century it had fully separated from both
+nautical and gaming contexts and entered legal and business language as
+a standard term for transparent dealing. Today it appears routinely in
+regulatory, journalistic, and political discourse with no residual
+awareness of either source domain.
+
+## References
+
+- OED, "above board" -- traces figurative use to the 1590s, notes both
+  nautical and gaming etymologies without definitively choosing between
+  them
+- Jeans, P. D. *Ship to Shore: A Dictionary of Everyday Words and
+  Phrases Borrowed from the Sea* (2004) -- favors the nautical
+  etymology and provides maritime context
+- Quinion, M. *Port Out, Starboard Home* (2004) -- examines competing
+  etymologies of nautical phrases including "above board"


### PR DESCRIPTION
## Summary

- Adds `above-board` dead metaphor mapping (seafaring -> ethics-and-morality)
- Addresses competing nautical/card-playing etymologies as noted in issue
- Includes `seafaring` source frame
- Resolves #1281

## Validator output

```
All content valid.
```

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors

Generated with [Claude Code](https://claude.com/claude-code)