### PR TITLE
Add mapping: batten-down-the-hatches

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,31 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- journeys
+- natural-phenomena
+roles:
+- vessel
+- crew
+- captain
+- rigging
+- anchor
+- cargo
+- harbor
+- course
+- wind
+- sea-state
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of sailing ships, navigation, and life at sea. Covers vessels and
+their anatomy (hull, deck, mast, rigging, hatches), crew roles and competence,
+harbor operations (anchoring, berthing, loading), weather response, and
+navigation. As a source domain it is extraordinarily productive in English
+because the British Empire's dependence on naval power saturated the language
+with maritime vocabulary. Dozens of everyday expressions -- "on board,"
+"taken aback," "in the offing," "cut and run" -- are dead nautical metaphors
+whose seafaring origins are invisible to most speakers. The domain's richness
+comes from the fact that a sailing ship is a complex, dangerous, self-contained
+system where competence is life-or-death and every component has a precise name.

--- a/catalog/mappings/batten-down-the-hatches.md
+++ b/catalog/mappings/batten-down-the-hatches.md
@@ -1,0 +1,118 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+kind: dead-metaphor
+name: Batten Down the Hatches
+related:
+- dead-in-the-water
+slug: batten-down-the-hatches
+source_frame: seafaring
+target_frame: event-structure
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+Before a storm, a ship's crew secured the hatch covers -- the openings
+in the deck that provided access to cargo holds and living quarters
+below. Tarpaulins were stretched over the hatch coamings and fastened
+with wooden battens (strips nailed or wedged into place) to create a
+watertight seal. If the hatches were not secured, waves breaking over
+the deck would flood the hold and potentially sink the ship. The
+metaphor maps this specific pre-storm procedure onto any act of
+preparation for an anticipated crisis.
+
+- **Seal the openings before the threat arrives** -- the critical
+  structural insight is temporal: battening happens before the storm
+  hits, not during. Once heavy seas are running, it is too late to
+  secure the hatches safely. The metaphor maps this timing constraint
+  onto crisis preparation generally: the time to prepare is when you
+  can still see the storm coming, not when it is already upon you.
+  This is a more precise mapping than generic "prepare for trouble"
+  because it specifies the relationship between the preparation
+  window and the threat arrival.
+- **Vulnerability is at the openings** -- a ship's hull is strong,
+  but its hatches are weak points. The danger is not that the storm
+  will destroy the ship but that water will enter through designed
+  openings that serve a purpose in calm weather. The metaphor maps
+  this onto organizational crisis preparation: the vulnerabilities
+  are not random but are the same features that provide access and
+  flexibility in normal conditions. Open communication channels,
+  accessible systems, porous boundaries -- the things that make an
+  organization functional in fair weather are exactly what must be
+  secured in a crisis.
+- **The action is defensive, not offensive** -- battening hatches does
+  not fight the storm; it merely prevents the storm from getting in.
+  The crew cannot change the weather, only reduce their exposure to
+  it. The metaphor preserves this defensive posture: to batten down
+  the hatches is to accept that the crisis is coming and shift from
+  growth mode to survival mode.
+
+## Where It Breaks
+
+- **Most organizational crises do not arrive like weather** -- storms
+  are external, impersonal, and uncontrollable. They come from outside
+  the system and cannot be negotiated with. But most organizational
+  crises are at least partly internal: financial mismanagement,
+  product failures, leadership conflicts, regulatory violations. The
+  metaphor frames all crises as external threats to be weathered,
+  which can discourage examination of internal causes. You cannot
+  batten down the hatches against a problem that is already inside
+  the ship.
+- **Battening is temporary; organizational lockdown can become
+  permanent** -- a ship battens hatches for the duration of the storm,
+  then opens them again. The procedure has a defined endpoint. But
+  organizational crisis measures -- hiring freezes, spending cuts,
+  restricted access, centralized decision-making -- often outlast the
+  crisis that triggered them. The metaphor implies that the battened
+  state is temporary, but organizations frequently normalize their
+  crisis posture.
+- **The metaphor validates inaction as preparation** -- battening
+  hatches is a form of hunkering down: close the openings and wait.
+  But many crises require active response, not passive fortification.
+  A company facing a competitor's disruptive product cannot simply
+  seal its hatches and wait for the storm to pass. The metaphor can
+  license defensive paralysis by framing retreat as seamanship.
+- **Not all openings should be closed** -- on a ship, every hatch gets
+  battened. The procedure is comprehensive and undiscriminating. But
+  in organizational crisis response, some openings need to stay open:
+  communication with customers, transparency with regulators,
+  information flow to employees. The metaphor's logic of total
+  sealing can encourage overcorrection -- shutting down communication
+  precisely when it is most needed.
+
+## Expressions
+
+- "Batten down the hatches" -- the standard form, meaning to prepare
+  for an anticipated crisis by securing vulnerable points
+- "Time to batten down the hatches" -- the announcement form, signaling
+  that a threat has been identified and defensive measures should begin
+- "Battening down" -- the shortened progressive form, describing the
+  process of crisis preparation underway
+- "Hatches battened" -- the completion form, indicating that
+  preparations are finished and the organization is in defensive posture
+
+## Origin Story
+
+"Batten" as a verb meaning to fasten with battens dates to the early
+nineteenth century in nautical usage, though the noun "batten" (a strip
+of wood) is older. The full phrase "batten down the hatches" was a
+standard order aboard sailing vessels and appears in nautical manuals
+and sea narratives throughout the 1800s. The figurative usage -- prepare
+for any kind of trouble -- was established by the late nineteenth century
+and is now the dominant sense. The nautical specificity (tarpaulins,
+coamings, wooden strips) has been completely lost; most speakers
+understand "batten" only as a vaguely archaic word meaning "secure"
+and may not realize that "hatches" refers to deck openings rather than
+doors.
+
+## References
+
+- Smyth, W. H. *The Sailor's Word-Book* (1867) -- defines battens and
+  hatch-securing procedures in technical detail
+- Jeans, P. D. *Ship to Shore: A Dictionary of Everyday Words and
+  Phrases Borrowed from the Sea* (2004) -- traces the phrase from
+  nautical procedure to general English idiom


### PR DESCRIPTION
## Summary

- Adds `batten-down-the-hatches` dead metaphor mapping (seafaring -> event-structure)
- Includes `seafaring` source frame
- Resolves #1283

## Validator output

```
All content valid.
```

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors

Generated with [Claude Code](https://claude.com/claude-code)