### PR TITLE
Add mapping: dead-in-the-water

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,31 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- journeys
+- natural-phenomena
+roles:
+- vessel
+- crew
+- captain
+- rigging
+- anchor
+- cargo
+- harbor
+- course
+- wind
+- sea-state
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of sailing ships, navigation, and life at sea. Covers vessels and
+their anatomy (hull, deck, mast, rigging, hatches), crew roles and competence,
+harbor operations (anchoring, berthing, loading), weather response, and
+navigation. As a source domain it is extraordinarily productive in English
+because the British Empire's dependence on naval power saturated the language
+with maritime vocabulary. Dozens of everyday expressions -- "on board,"
+"taken aback," "in the offing," "cut and run" -- are dead nautical metaphors
+whose seafaring origins are invisible to most speakers. The domain's richness
+comes from the fact that a sailing ship is a complex, dangerous, self-contained
+system where competence is life-or-death and every component has a precise name.

--- a/catalog/mappings/dead-in-the-water.md
+++ b/catalog/mappings/dead-in-the-water.md
@@ -1,0 +1,117 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+kind: dead-metaphor
+name: Dead in the Water
+related:
+- batten-down-the-hatches
+slug: dead-in-the-water
+source_frame: seafaring
+target_frame: event-structure
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+A sailing vessel with no wind is "dead in the water" -- motionless, without
+steerage way, unable to maneuver. The ship is not damaged, not sinking,
+not under attack. It is structurally intact but powerless. Without wind
+filling the sails, the rudder has no effect because steerage requires
+water flowing past it, which requires the ship to be moving. The vessel
+sits inert, at the mercy of currents and drift, until the wind returns.
+The metaphor maps this specific condition -- intact but powerless -- onto
+any project, negotiation, or initiative that has lost all forward momentum.
+
+- **"Dead" means inert, not destroyed** -- the most precise structural
+  element of the metaphor. The ship is not wrecked; it is whole. Every
+  spar, every line, every sail is in place. But it cannot move. The
+  metaphor maps this distinction onto situations where all the
+  components exist but the driving force is absent: a startup with a
+  product but no customers, a bill with sponsors but no votes, a
+  negotiation where both parties have stopped talking. The metaphor
+  insists that the problem is not structural failure but absence of
+  the animating force.
+- **Loss of steerage as loss of control** -- a ship dead in the water
+  cannot steer. The rudder is useless without forward motion. This maps
+  a critical secondary consequence: when momentum stops, you lose not
+  just speed but direction. A stalled project does not merely pause;
+  it becomes uncontrollable. Decisions cannot be made, priorities
+  cannot be set, resources cannot be redirected, because there is no
+  motion for the rudder to act upon.
+- **The cause is external and impersonal** -- wind is not something the
+  crew controls. A ship goes dead in the water not because the crew
+  failed but because the environment stopped providing the force that
+  makes everything work. The metaphor maps this externality: a project
+  goes dead in the water because funding dried up, because the market
+  shifted, because political support evaporated -- forces beyond the
+  team's control.
+
+## Where It Breaks
+
+- **Most stalled projects have internal causes** -- the metaphor frames
+  the loss of momentum as an external event (the wind died). But most
+  projects that go dead in the water stall because of internal
+  problems: poor leadership, unresolved disagreements, technical debt,
+  loss of key personnel. The nautical framing externalizes blame by
+  making the animating force something that comes from outside the
+  system. This can be a convenient evasion: "the project is dead in
+  the water" avoids saying "the team stopped rowing."
+- **Sailing ships had oars; organizations have alternatives** -- many
+  historical vessels were not purely dependent on wind. Galleys had
+  oars. Ships carried boats that could tow them in calms. The metaphor
+  assumes pure sail dependence and maps it onto total helplessness,
+  but most organizations have alternative sources of momentum
+  available to them: different funding sources, pivoted strategies,
+  new leadership, restructured teams. The metaphor overstates the
+  helplessness by hiding the oars.
+- **The metaphor implies waiting is the correct response** -- when a
+  sailing ship is becalmed, the crew waits. There is no action that
+  brings the wind. But for stalled projects, waiting is almost never
+  the right strategy. The metaphor can license passivity by framing
+  the situation as one where the only option is to sit and hope for
+  changed conditions, when active intervention is usually both
+  possible and necessary.
+- **"Dead in the water" is binary; real stalls are gradual** -- the
+  nautical condition is stark: the ship is either moving or it is not.
+  But projects, negotiations, and initiatives usually slow gradually.
+  There are degrees of reduced momentum before full stoppage. The
+  metaphor's binary framing can be used to declare something dead
+  prematurely or to deny slowdown by insisting it is "still moving."
+  The nautical source has no concept of a ship moving very slowly;
+  "dead in the water" is an on-off state.
+
+## Expressions
+
+- "Dead in the water" -- the standard diagnostic form, declaring that
+  a project or initiative has completely stalled
+- "That proposal is dead in the water" -- the political form, meaning
+  a legislative or organizational initiative has no remaining support
+- "We're dead in the water without [X]" -- the dependency form,
+  identifying the missing animating force (funding, approval, a key
+  hire) without which progress is impossible
+- "Left dead in the water" -- the abandonment form, implying that
+  external actors withdrew support and left the initiative stranded
+
+## Origin Story
+
+The nautical phrase describes the condition of a becalmed vessel and
+has been used by sailors since at least the age of sail. "Dead" in
+nautical usage often means motionless or without useful effect -- a
+"dead reckoning" is navigation by calculation when celestial
+observation is not possible, and a "dead calm" is a complete absence
+of wind. The metaphorical extension to stalled undertakings was
+well established by the mid-twentieth century and is now the primary
+sense in which the phrase is used. Most speakers have no awareness of
+the nautical origin and would not spontaneously connect the expression
+to sailing.
+
+## References
+
+- Smyth, W. H. *The Sailor's Word-Book* (1867) -- defines "dead" in
+  its various nautical senses including motionless in the water
+- Jeans, P. D. *Ship to Shore: A Dictionary of Everyday Words and
+  Phrases Borrowed from the Sea* (2004) -- covers the migration of
+  "dead in the water" from nautical to general usage


### PR DESCRIPTION
## Summary

- Adds `dead-in-the-water` dead metaphor mapping (seafaring -> event-structure)
- Includes `seafaring` source frame
- Resolves #1284

## Validator output

```
All content valid.
```

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors

Generated with [Claude Code](https://claude.com/claude-code)