### PR TITLE
Add mapping: fathom

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,33 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- journeys
+- fluid-dynamics
+roles:
+- vessel
+- crew
+- captain
+- cargo
+- course
+- wind
+- current
+- anchor
+- rigging
+- port
+- depth
+- horizon
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of sailing and maritime navigation, encompassing the
+operation of wind-powered vessels, the reading of sea and sky, and the
+organizational structures of life aboard ship. Seafaring generated an
+enormous technical vocabulary -- much of it now dead metaphor in everyday
+English -- because it was for centuries the primary domain of complex,
+high-stakes, cooperative human endeavor conducted in an environment that
+could not be controlled, only read and responded to. The frame's
+richness comes from this combination: sophisticated technology, extreme
+risk, hierarchical organization, and constant negotiation with natural
+forces.

--- a/catalog/mappings/fathom.md
+++ b/catalog/mappings/fathom.md
@@ -1,0 +1,103 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+kind: dead-metaphor
+name: Fathom
+related:
+- a-problem-is-a-body-of-water
+slug: fathom
+source_frame: seafaring
+target_frame: intellectual-inquiry
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+To fathom was to measure water depth by lowering a weighted line (a
+sounding line) marked at intervals of one fathom -- six feet, roughly
+the span of a man's outstretched arms. The sailor paid out line until
+the lead hit bottom, then read the depth from the markings. If the
+bottom was too deep for the line to reach, the depth was unfathomable.
+
+The metaphor maps the physical act of measuring hidden depth onto the
+intellectual act of comprehending something not immediately accessible.
+
+Key structural parallels:
+
+- **Hidden depth as hidden meaning** -- water conceals what lies beneath
+  its surface, just as a difficult idea or situation conceals its full
+  significance. To fathom something is to send your understanding down
+  into it and find the bottom. The metaphor presumes that comprehension
+  has a vertical structure: surface understanding is shallow, real
+  understanding goes deep.
+- **The measuring instrument as the mind** -- the sounding line is the
+  sailor's instrument for reaching what the eye cannot see. The mind is
+  the thinker's instrument for grasping what intuition cannot immediately
+  access. Both are tools deployed deliberately into an opaque medium.
+- **Unfathomable as beyond reach** -- when the sounding line runs out
+  before hitting bottom, the depth is literally beyond measurement. "I
+  can't fathom it" preserves this structure precisely: the thing exceeds
+  the capacity of my instrument. It is not that the depth does not exist,
+  only that I cannot reach it.
+- **The body as unit of measure** -- a fathom is an arm-span, grounding
+  the measurement in the human body. This embodied origin reinforces the
+  metaphor's intuitive feel: understanding is reaching, and what you
+  cannot reach you cannot measure.
+
+## Where It Breaks
+
+- **Depth is one-dimensional; understanding is not** -- the sounding
+  line measures a single quantity: how deep. But understanding a complex
+  situation involves grasping multiple dimensions simultaneously --
+  causes, consequences, motivations, contexts. The metaphor flattens
+  comprehension into a single axis of depth, which can obscure the
+  difference between understanding something deeply along one dimension
+  and understanding it broadly across many.
+- **Fathoming is passive reception; understanding is active construction**
+  -- the sounding line drops and reports a number. Understanding
+  typically requires active work: forming hypotheses, testing them,
+  revising mental models. The metaphor makes comprehension feel like
+  something that either happens or doesn't when you lower the line,
+  rather than something you build through effort and iteration.
+- **The metaphor implies a fixed bottom** -- the ocean floor is there
+  whether you measure it or not. But many things we try to fathom --
+  another person's motivations, the implications of a complex system --
+  do not have a fixed, discoverable bottom. The "depth" may be
+  indeterminate, not merely deep. Unfathomable gets used for both "too
+  deep for me" and "has no bottom," but these are structurally different
+  situations.
+- **Precision is lost** -- the nautical fathom gave a number. You could
+  report twelve fathoms, mark it on a chart, and another sailor could
+  use that information. The metaphorical "fathom" preserves no such
+  precision. You either fathom something or you don't. The graduated
+  measurement that made the original term useful has been replaced by a
+  binary.
+
+## Expressions
+
+- "I can't fathom why she did that" -- comprehension failure as inability
+  to reach the bottom
+- "Unfathomable grief" -- emotion beyond the capacity of understanding
+  to measure
+- "Fathom the depths of the problem" -- investigating hidden complexity
+  as sounding water depth
+- "Unfathomable mystery" -- something whose depth exceeds any instrument
+  of understanding
+- "Hard to fathom" -- difficulty of comprehension as difficulty of
+  measurement
+
+## Origin Story
+
+The word fathom derives from Old English faethm, meaning "embrace" or
+"the span of outstretched arms." As a unit of measurement it was
+standardized at six feet and used primarily for measuring water depth
+and the length of rope and cable. The metaphorical sense -- to
+understand or get to the bottom of something -- appeared in English by
+the late sixteenth century. Shakespeare used it in both senses. By the
+twentieth century, most English speakers had lost contact with the
+nautical meaning entirely, making this a textbook dead metaphor: the
+source domain has become invisible while the mapping remains fully
+active.


### PR DESCRIPTION
## Summary

- Adds `fathom` dead-metaphor mapping (nautical sounding -> comprehension)
- Creates `seafaring` source frame (shared by all nautical-terms mappings)
- Resolves #1290

## Validator output

All content valid (0 errors, 0 new warnings).

## Test plan

- [ ] Validator passes
- [ ] Frontmatter matches schema
- [ ] Body sections substantive

Generated with [Claude Code](https://claude.com/claude-code)