### PR TITLE
Add mapping: try-different-tack

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,33 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- journeys
+- fluid-dynamics
+roles:
+- vessel
+- crew
+- captain
+- cargo
+- course
+- wind
+- current
+- anchor
+- rigging
+- port
+- depth
+- horizon
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of sailing and maritime navigation, encompassing the
+operation of wind-powered vessels, the reading of sea and sky, and the
+organizational structures of life aboard ship. Seafaring generated an
+enormous technical vocabulary -- much of it now dead metaphor in everyday
+English -- because it was for centuries the primary domain of complex,
+high-stakes, cooperative human endeavor conducted in an environment that
+could not be controlled, only read and responded to. The frame's
+richness comes from this combination: sophisticated technology, extreme
+risk, hierarchical organization, and constant negotiation with natural
+forces.

--- a/catalog/mappings/try-different-tack.md
+++ b/catalog/mappings/try-different-tack.md
@@ -1,0 +1,102 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+kind: dead-metaphor
+name: Try a Different Tack
+related:
+- fathom
+slug: try-different-tack
+source_frame: seafaring
+target_frame: intellectual-inquiry
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+Tacking is the maneuver a sailing vessel uses to make progress into the
+wind. Because no square-rigged or fore-and-aft-rigged vessel can sail
+directly upwind, the crew must zigzag -- sailing at an angle to the wind
+on one tack (say, starboard), then turning the bow through the wind to
+sail at an angle on the other tack (port). Each tack is a deliberate,
+oblique approach to a destination that cannot be reached head-on.
+
+The metaphor maps this indirect navigation strategy onto changing one's
+method or approach to a problem.
+
+Key structural parallels:
+
+- **Direct approach is impossible** -- the structural foundation of the
+  metaphor is that some destinations cannot be reached by going straight
+  at them. The wind -- an external constraint you cannot change -- forces
+  you to approach obliquely. In the target domain, "trying a different
+  tack" implies that the current approach has hit a structural constraint,
+  not merely a temporary obstacle. The problem requires indirection.
+- **Each tack is a complete strategy** -- a tack is not a random
+  deviation. It is a coherent course with its own heading, sail trim,
+  and crew coordination. Changing tack is not abandoning your plan; it
+  is switching to an equally disciplined alternative approach. The
+  metaphor thus distinguishes between strategic redirection and
+  flailing.
+- **The destination stays fixed** -- the point of tacking is to reach
+  the same destination by a different route. "Try a different tack"
+  preserves this: you are not changing your goal, only your method.
+  The metaphor encodes persistence of purpose combined with flexibility
+  of means.
+- **Progress is not linear** -- a tacking vessel appears to be going
+  sideways. Its track on the water is a zigzag, not a straight line. But
+  each leg makes real progress toward the destination. The metaphor
+  validates non-linear approaches and reframes apparent lateral movement
+  as genuine advance.
+
+## Where It Breaks
+
+- **The wind is a known constraint; many problems have unknown
+  constraints** -- a sailor knows exactly where the wind is coming from
+  and can calculate the optimal tack angle. Many real-world problems
+  involve constraints that are poorly understood, shifting, or invisible.
+  The metaphor imports a certainty about the nature of the obstacle that
+  may not apply.
+- **Tacking has a fixed repertoire** -- you can go port tack or starboard
+  tack. There are exactly two options, and the geometry of wind and sail
+  determines the angle. Real problem-solving often involves a much larger
+  and less well-defined set of possible approaches. "Try a different
+  tack" sounds like there are only two alternatives, when in practice
+  there may be dozens or none.
+- **The metaphor is often confused with "tact"** -- many English speakers
+  write "try a different tact," revealing that the nautical source domain
+  has been fully lost. This confusion is itself evidence of dead-metaphor
+  status: the expression survives while the structural mapping that
+  generated it has become invisible.
+- **Tacking assumes the destination is reachable** -- a sailor tacks
+  because the destination exists and is known. But "trying a different
+  tack" is sometimes used in situations where the goal itself may be
+  unreachable or ill-defined. The metaphor does not naturally accommodate
+  the possibility that no combination of approaches will work.
+
+## Expressions
+
+- "Let's try a different tack" -- adopting a new approach as changing
+  the angle of sail
+- "She took a different tack in the negotiations" -- strategic
+  redirection as changing sailing angle
+- "On that tack, we'll never get there" -- current approach as a
+  heading that cannot reach the destination
+- "Tacking back and forth" -- alternating between approaches as
+  zigzagging upwind
+- "Change tack" -- shift strategy as turn the vessel through the wind
+
+## Origin Story
+
+Tack in the nautical sense referred originally to the rope holding
+down the lower windward corner of a sail, then metonymically to the
+course a vessel sails relative to the wind. The maneuver of tacking --
+turning the bow through the wind to change which side receives it --
+has been fundamental to sailing since antiquity, though the terminology
+solidified in English around the sixteenth century. The metaphorical
+use ("take a different tack") appeared by the early nineteenth century
+and was already common enough to be noted in dictionaries by mid-century.
+The widespread misspelling as "tact" in contemporary usage confirms that
+for most speakers, the sailing origin has been completely forgotten.


### PR DESCRIPTION
## Summary

- Adds `try-different-tack` dead-metaphor mapping (tacking upwind -> changing approach)
- Includes `seafaring` source frame
- Resolves #1291

## Validator output

All content valid (0 errors, 0 new warnings besides expected dangling cross-ref to `fathom` on separate branch).

## Test plan

- [ ] Validator passes
- [ ] Frontmatter matches schema
- [ ] Body sections substantive

Generated with [Claude Code](https://claude.com/claude-code)