### PR TITLE
Add mapping: over-a-barrel

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,33 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- journeys
+- fluid-dynamics
+roles:
+- vessel
+- crew
+- captain
+- cargo
+- course
+- wind
+- current
+- anchor
+- rigging
+- port
+- depth
+- horizon
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of sailing and maritime navigation, encompassing the
+operation of wind-powered vessels, the reading of sea and sky, and the
+organizational structures of life aboard ship. Seafaring generated an
+enormous technical vocabulary -- much of it now dead metaphor in everyday
+English -- because it was for centuries the primary domain of complex,
+high-stakes, cooperative human endeavor conducted in an environment that
+could not be controlled, only read and responded to. The frame's
+richness comes from this combination: sophisticated technology, extreme
+risk, hierarchical organization, and constant negotiation with natural
+forces.

--- a/catalog/mappings/over-a-barrel.md
+++ b/catalog/mappings/over-a-barrel.md
@@ -1,0 +1,108 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+kind: dead-metaphor
+name: Over a Barrel
+related:
+- fathom
+slug: over-a-barrel
+source_frame: seafaring
+target_frame: social-behavior
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+The most widely cited nautical origin: sailors being punished were bent
+over a cannon barrel or deck barrel for flogging. A competing etymology
+places the scene at rescue rather than punishment -- a near-drowned
+person draped over a barrel and rolled back and forth to expel water
+from the lungs. Both origins share the same structural core: a person
+bent over a barrel is physically helpless, unable to stand, move, or
+defend themselves. Their posture is imposed, not chosen.
+
+The metaphor maps this physical vulnerability and immobility onto being
+in a position where someone else holds complete leverage.
+
+Key structural parallels:
+
+- **Imposed posture as imposed terms** -- the person over the barrel
+  cannot choose their position. They are placed there by someone with
+  authority or superior force. In the target domain, "having someone
+  over a barrel" means you have structured the situation so they cannot
+  negotiate, resist, or walk away. Their position is not one they would
+  voluntarily assume.
+- **Exposure as vulnerability** -- bent over a barrel, the person's
+  back (or, in the punishment reading, buttocks) is exposed and
+  undefended. The metaphor maps bodily exposure onto strategic
+  vulnerability: being over a barrel means your weaknesses are exposed
+  and you cannot protect them.
+- **Immobility as lack of options** -- the barrel holds the person in
+  place. They cannot run, fight, or maneuver. In negotiation terms,
+  being over a barrel means having no alternative -- no BATNA, no exit,
+  no leverage of your own. The barrel is what pins you.
+- **The asymmetry is total** -- one party stands, the other is bent
+  over. One acts, the other receives. The metaphor captures situations
+  of radical power imbalance where one side has all the agency and the
+  other has none.
+
+## Where It Breaks
+
+- **The metaphor implies physical force; most leverage is structural**
+  -- being literally bent over a barrel involves bodily coercion. But
+  most real-world situations described as "over a barrel" involve
+  economic, legal, informational, or social leverage rather than
+  physical force. The bodily violence of the source domain can
+  overdramatize situations that are uncomfortable but not violent,
+  making proportionate responses harder to articulate.
+- **It erases the history of how the position was reached** -- the
+  metaphor captures a static moment of helplessness but says nothing
+  about the sequence of decisions, circumstances, or power dynamics
+  that led there. This can encourage fatalism ("I'm over a barrel,
+  nothing I can do") when in fact the path to vulnerability may have
+  involved choices that could have gone differently.
+- **The binary framing misses partial leverage** -- the metaphor
+  presents leverage as all-or-nothing: you are either over the barrel
+  or you are not. Real negotiations rarely involve such absolute
+  asymmetry. Even parties in weak positions usually retain some cards
+  to play. The metaphor's totality can blind people to the leverage
+  they actually have.
+- **Competing etymologies muddy the emotional register** -- the
+  punishment reading carries shame and subjugation. The rescue reading
+  carries helplessness and dependence but not humiliation. Most modern
+  users do not know which origin they are invoking, which means the
+  metaphor's emotional connotations are unstable. "They have us over
+  a barrel" might mean "they are punishing us" or "they are the only
+  ones who can save us" -- quite different framings of the same
+  powerlessness.
+
+## Expressions
+
+- "They've got us over a barrel" -- being in a position of no leverage
+  as being physically pinned
+- "He had her over a barrel in the negotiation" -- complete advantage
+  as physical dominance over a helpless person
+- "We're over a barrel on pricing" -- inability to negotiate terms as
+  immobility and exposure
+- "Don't put yourself over a barrel" -- warning against entering a
+  position of total vulnerability
+
+## Origin Story
+
+The exact origin is disputed. The punishment theory points to naval
+discipline: sailors flogged while bent over a gun barrel or cask, a
+practice documented in accounts of eighteenth- and nineteenth-century
+shipboard life. The rescue theory references the pre-modern method of
+resuscitating drowning victims by draping them face-down over a barrel
+and rolling it to force water from the lungs -- a technique predating
+mouth-to-mouth resuscitation. Both scenes were common enough in
+maritime life to be widely recognized.
+
+The phrase entered common English idiom by the late nineteenth century,
+and by the mid-twentieth century the nautical context was largely
+forgotten. Most contemporary users understand "over a barrel" as pure
+idiom, with no image of a barrel, a ship, or a sailor's exposed back.
+The source domain has gone fully dark.


### PR DESCRIPTION
## Summary

- Adds `over-a-barrel` dead-metaphor mapping (nautical punishment/rescue -> powerlessness)
- Includes `seafaring` source frame
- Addresses competing etymologies as noted in issue
- Resolves #1292

## Validator output

All content valid (0 errors, 0 new warnings besides expected dangling cross-ref).

## Test plan

- [ ] Validator passes
- [ ] Frontmatter matches schema
- [ ] Body sections substantive

Generated with [Claude Code](https://claude.com/claude-code)