### PR TITLE
Add mapping: at-loggerheads

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,33 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- journeys
+- fluid-dynamics
+roles:
+- vessel
+- crew
+- captain
+- cargo
+- course
+- wind
+- current
+- anchor
+- rigging
+- port
+- depth
+- horizon
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of sailing and maritime navigation, encompassing the
+operation of wind-powered vessels, the reading of sea and sky, and the
+organizational structures of life aboard ship. Seafaring generated an
+enormous technical vocabulary -- much of it now dead metaphor in everyday
+English -- because it was for centuries the primary domain of complex,
+high-stakes, cooperative human endeavor conducted in an environment that
+could not be controlled, only read and responded to. The frame's
+richness comes from this combination: sophisticated technology, extreme
+risk, hierarchical organization, and constant negotiation with natural
+forces.

--- a/catalog/mappings/at-loggerheads.md
+++ b/catalog/mappings/at-loggerheads.md
@@ -1,0 +1,115 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+kind: dead-metaphor
+name: At Loggerheads
+related:
+- fathom
+slug: at-loggerheads
+source_frame: seafaring
+target_frame: argumentation
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+A loggerhead was a long-handled iron instrument with a ball or cup at
+the end, heated in a fire and used to melt pitch for caulking a ship's
+seams. It was an essential tool of ship maintenance -- heavy, blunt, and
+always close at hand. When disputes erupted aboard ship, loggerheads
+were reportedly seized as improvised weapons. Two men "at loggerheads"
+were facing each other with these heated iron tools raised to strike.
+
+The metaphor maps the weaponization of work tools onto fierce, locked
+disagreement.
+
+Key structural parallels:
+
+- **Escalation from work to conflict** -- the loggerhead is a work
+  tool turned weapon. The metaphor captures something specific about
+  the nature of the dispute: it arises within a shared enterprise.
+  These are not strangers fighting; they are crewmates whose
+  collaboration has broken down. The tools of their common work have
+  become instruments of their conflict. This structural parallel
+  applies well to organizational disputes, political deadlocks, and
+  professional disagreements.
+- **Proximity and entanglement** -- sailors aboard ship cannot walk
+  away from each other. They are confined to a shared space with shared
+  responsibilities. Being "at loggerheads" implies a conflict between
+  parties who are stuck together -- who must continue to coexist and
+  cooperate even as they fight. The metaphor encodes the particular
+  intensity of disputes between people who cannot disengage.
+- **Symmetry of position** -- two men at loggerheads are in a
+  symmetrical standoff. Neither has a clear advantage. Both hold the
+  same kind of weapon. The metaphor maps this onto disputes where
+  neither side can overpower the other and neither will yield -- a
+  deadlock rather than a one-sided domination.
+- **Heat as anger** -- the loggerhead is literally heated in fire. The
+  metaphor inherits this: being at loggerheads implies not just
+  disagreement but heated, angry disagreement. The temperature of the
+  tool maps onto the temperature of the conflict.
+
+## Where It Breaks
+
+- **The source object is completely forgotten** -- almost no
+  contemporary English speaker knows what a loggerhead is. The
+  metaphor has no felt connection to its source domain, which means
+  the structural parallels described above are linguistically present
+  but cognitively absent. When people say "at loggerheads," they
+  experience it as a unit meaning "in fierce disagreement," not as an
+  image of two sailors with heated iron tools. This makes it a
+  particularly pure dead metaphor.
+- **The improvised-weapon structure is lost** -- the most interesting
+  feature of the original image -- that work tools become weapons when
+  collaboration breaks down -- is invisible to modern users. The
+  metaphor could teach something about the relationship between
+  cooperation and conflict, but it no longer does because the source
+  domain has gone dark.
+- **Loggerheads implies violence; most disagreements do not** -- the
+  original scene involves the threat of physical harm with heavy metal
+  implements. Using "at loggerheads" for a policy disagreement or a
+  contract negotiation imports a register of violence that may
+  overdramatize the actual stakes. The metaphor has no natural way to
+  calibrate intensity.
+- **The symmetry assumption is often wrong** -- the metaphor frames
+  the dispute as balanced: two equal parties in a standoff. But many
+  real disagreements involve significant power asymmetries --
+  employer vs. employee, government vs. citizen, majority vs.
+  minority. "At loggerheads" flattens these asymmetries, potentially
+  obscuring the fact that one party has far more at stake or far fewer
+  options than the other.
+
+## Expressions
+
+- "The two sides are at loggerheads" -- locked in fierce disagreement
+  as facing each other with raised weapons
+- "They've been at loggerheads for months" -- prolonged dispute as
+  sustained standoff
+- "Congress and the White House are at loggerheads over the budget" --
+  institutional deadlock as symmetrical confrontation
+- "The unions and management are at loggerheads" -- workplace conflict
+  as crewmates turned adversaries
+
+## Origin Story
+
+The word loggerhead has been in English since at least the sixteenth
+century. "Logger" likely derives from "log" (a block of wood) plus
+the augmentative "-er," and "loggerhead" originally meant a stupid
+person -- a blockhead. The nautical tool sense is documented from the
+seventeenth century onward: an iron instrument heated for melting
+pitch, also used for heating liquids (a loggerhead was plunged into
+a tankard to warm beer or flip).
+
+The phrase "at loggerheads" meaning "in fierce dispute" appears in
+print by the late seventeenth century. Whether the expression derives
+from the tool-as-weapon usage or from the "stupid person" sense (two
+stubborn blockheads butting against each other) is debated by
+etymologists. The nautical-tool origin is more widely cited and
+provides the richer structural mapping, but the competing etymology
+is a reminder that dead metaphors often carry unresolved histories.
+Loggerhead sea turtles, named for their disproportionately large
+heads, are a separate derivation that further muddies the word's
+semantic field.


### PR DESCRIPTION
## Summary

- Adds `at-loggerheads` dead-metaphor mapping (heated iron tools as weapons -> fierce disagreement)
- Includes `seafaring` source frame
- Resolves #1293

## Validator output

All content valid (0 errors, 0 new warnings besides expected dangling cross-ref).

## Test plan

- [ ] Validator passes
- [ ] Frontmatter matches schema
- [ ] Body sections substantive

Generated with [Claude Code](https://claude.com/claude-code)