### PR TITLE
Add mapping: in-the-offing

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,33 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- journeys
+- fluid-dynamics
+roles:
+- vessel
+- crew
+- captain
+- cargo
+- course
+- wind
+- current
+- anchor
+- rigging
+- port
+- depth
+- horizon
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of sailing and maritime navigation, encompassing the
+operation of wind-powered vessels, the reading of sea and sky, and the
+organizational structures of life aboard ship. Seafaring generated an
+enormous technical vocabulary -- much of it now dead metaphor in everyday
+English -- because it was for centuries the primary domain of complex,
+high-stakes, cooperative human endeavor conducted in an environment that
+could not be controlled, only read and responded to. The frame's
+richness comes from this combination: sophisticated technology, extreme
+risk, hierarchical organization, and constant negotiation with natural
+forces.

--- a/catalog/mappings/in-the-offing.md
+++ b/catalog/mappings/in-the-offing.md
@@ -1,0 +1,115 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+kind: dead-metaphor
+name: In the Offing
+related:
+- fathom
+slug: in-the-offing
+source_frame: seafaring
+target_frame: event-structure
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+The offing is the part of the open sea visible from shore, beyond the
+anchorage but before the horizon. A ship "in the offing" has been
+sighted -- it is visible, identifiable, clearly approaching -- but it
+has not yet arrived. It is neither here nor beyond sight. It occupies
+a specific zone: the space of the anticipated.
+
+The metaphor maps this visible-but-not-yet-arrived spatial position onto
+events that are imminent and expected.
+
+Key structural parallels:
+
+- **Visible but not present** -- the ship in the offing can be seen.
+  You know it is coming. But it has not docked, its cargo is not
+  unloaded, its passengers have not disembarked. In the target domain,
+  something "in the offing" is an event whose signs are already
+  apparent -- announced, leaked, strongly signaled -- but which has
+  not yet happened. The metaphor captures the specific experience of
+  seeing something coming and waiting for it to arrive.
+- **Spatial distance as temporal distance** -- the offing encodes time
+  as space. A ship closer to shore will arrive sooner; one near the
+  horizon will take longer. "In the offing" maps this spatial gradient
+  onto temporal proximity: the event is close in time because the
+  signal is close in view. This is a specific instance of the general
+  TIME IS SPACE metaphor, given a precise nautical calibration.
+- **The approach is inevitable** -- a ship in the offing, with
+  favorable wind, will arrive. The watcher on shore cannot stop it,
+  and rarely wants to. The metaphor carries an undertone of
+  inevitability: what is in the offing is coming whether you are
+  ready or not. This distinguishes "in the offing" from mere
+  possibility. Something in the offing is not speculative; it is
+  approaching.
+- **The watcher's perspective** -- the metaphor is framed from shore,
+  not from the ship. You are the one watching and waiting, not the
+  one arriving. This maps onto the experiential structure of
+  anticipation: you perceive the approaching event but do not control
+  its timing or trajectory.
+
+## Where It Breaks
+
+- **The offing implies a single direction of approach** -- ships arrive
+  from the sea toward shore along a roughly predictable path. But many
+  anticipated events do not approach from a single, identifiable
+  direction. A corporate restructuring, a technological disruption, or
+  a cultural shift may emerge from multiple vectors simultaneously. The
+  metaphor's clean single-axis approach oversimplifies the way complex
+  events materialize.
+- **Visibility does not guarantee arrival** -- a ship in the offing
+  might change course, be becalmed, or sink. The metaphor carries an
+  assumption of arrival that real events do not always honor.
+  "Restructuring is in the offing" implies it will happen, but
+  anticipated events frequently fail to materialize. The metaphor
+  offers no vocabulary for the ship that turns away.
+- **The temporal precision is false** -- in the nautical domain, an
+  experienced watcher can estimate arrival time from a ship's position
+  and the wind. In the metaphorical domain, "in the offing" conveys
+  imminence but no actual timeline. It might mean hours, weeks, or
+  months. The spatial precision of the source domain does not transfer
+  to the temporal vagueness of the target.
+- **The metaphor has lost its spatial specificity** -- the offing is a
+  particular zone of the sea: past the anchorage, before the horizon.
+  Most speakers do not know this. They use "in the offing" as a synonym
+  for "coming soon," without any sense of the spatial structure that
+  gave the expression its original precision. The loss of the source
+  domain collapses what was a carefully calibrated spatial-temporal
+  mapping into a generic temporal marker.
+
+## Expressions
+
+- "A deal is in the offing" -- an anticipated agreement as a ship
+  visible on approach
+- "Changes are in the offing" -- expected transformation as vessels
+  sighted from shore
+- "With elections in the offing" -- approaching political event as
+  ship nearing port
+- "There's a storm in the offing" -- anticipated trouble as weather
+  system visible on the horizon
+- "Relief is in the offing" -- expected improvement as approaching
+  vessel carrying needed supplies
+
+## Origin Story
+
+The word offing has been in English maritime vocabulary since at least
+the sixteenth century, referring to the more distant part of the sea
+as seen from shore. It derives from "off" -- the offing is the part
+of the sea that is "off" from the land. Sailors and shore-watchers
+used it as a precise navigational term: a ship "standing for the
+offing" was heading out to sea; a ship "in the offing" was visible
+at a distance, approaching.
+
+The figurative use -- meaning something likely to happen soon --
+appeared by the late eighteenth century and became common in the
+nineteenth. Unlike many nautical dead metaphors, "in the offing"
+retains a faint atmospheric charge: it still sounds slightly formal,
+slightly dramatic, slightly anticipatory. But the word "offing" itself
+has no meaning for most speakers outside this single fixed phrase,
+making it a lexical fossil -- a word preserved only inside the
+expression it helped create.


### PR DESCRIPTION
## Summary

- Adds `in-the-offing` dead-metaphor mapping (ship visible beyond anchorage -> imminent event)
- Includes `seafaring` source frame
- Resolves #1294

## Validator output

All content valid (0 errors, 0 new warnings besides expected dangling cross-ref).

## Test plan

- [ ] Validator passes
- [ ] Frontmatter matches schema
- [ ] Body sections substantive

Generated with [Claude Code](https://claude.com/claude-code)