### PR TITLE
Add mapping: sailing-close-to-the-wind

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,38 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- natural-phenomena
+- travel
+roles:
+- vessel
+- crew
+- captain
+- cargo
+- rigging
+- hull
+- keel
+- mast
+- sail
+- helm
+- port
+- anchor
+- tide
+- wind
+- current
+- storm
+- course
+- berth
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of ships, sailors, and the sea. One of the most prolific dead-metaphor
+factories in the English language, rivaled only by agriculture and war. Centuries
+of maritime dominance embedded nautical vocabulary so deeply into everyday speech
+that most speakers have no idea they are using it. "Taken aback," "the bitter end,"
+"loose cannon," "three sheets to the wind," "overwhelmed," "on board" -- the sea
+is everywhere in English, and almost nobody notices. As a source domain it provides
+rich structure: the interplay of human skill and natural force, the isolation of a
+ship at sea, the hierarchy of command, the constant negotiation between intention
+and circumstance.

--- a/catalog/mappings/sailing-close-to-the-wind.md
+++ b/catalog/mappings/sailing-close-to-the-wind.md
@@ -1,0 +1,114 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Sailing Close to the Wind
+related: []
+slug: sailing-close-to-the-wind
+source_frame: seafaring
+target_frame: ethics-and-morality
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+Sailing "close to the wind" (also "close-hauled") means pointing the bow
+as near to the wind direction as possible. This extracts maximum forward
+progress from the available wind, but it is the most precarious point of
+sail. Steer a few degrees too close and the sails luff -- they lose shape,
+flap uselessly, and the boat stalls. In the worst case the wind catches
+the sails from the wrong side ("taken aback"), slamming the boom across
+the deck and potentially capsizing the vessel.
+
+The metaphor maps this risk-reward calculus onto ethical and legal behavior.
+
+- **Maximum gain at maximum risk** -- the close-hauled point of sail is the
+  most efficient angle for sailing upwind, but it demands constant attention
+  and skill. The ethical mapping preserves this exactly: someone sailing
+  close to the wind in business or politics is extracting the maximum
+  advantage from the rules while staying technically within them. Tax
+  avoidance rather than evasion. Aggressive but not illegal.
+- **The line is invisible** -- a sailor sailing close-hauled cannot see the
+  exact angle at which the sails will luff. It is felt through the helm,
+  heard in the rigging, sensed through experience. The ethical parallel:
+  the boundary between acceptable and unacceptable behavior is rarely a
+  bright line. It is a zone of increasing risk, and the person sailing
+  close to it may not know exactly when they have crossed it until the
+  consequences arrive.
+- **Skill determines survival** -- an expert helmsman can sail closer to the
+  wind than a novice. The metaphor imports this: experienced operators
+  (lawyers, traders, politicians) can work closer to the ethical edge than
+  amateurs. This is descriptively accurate and morally ambiguous -- the
+  metaphor neither condemns nor celebrates the skill, though the tone of
+  usage is usually a mild warning.
+- **The helmsman is always adjusting** -- close-hauled sailing requires
+  continuous small corrections. One cannot set the course and walk away.
+  The ethical mapping: operating near the boundary of acceptable behavior
+  requires constant vigilance and adjustment. A policy that was safely
+  close to the wind in one regulatory environment may cross the line when
+  rules change.
+
+## Where It Breaks
+
+- **Wind is not morality** -- the wind is a neutral physical force with no
+  opinion about which direction you sail. Ethical boundaries are not neutral;
+  they exist because of real harms to real people. The metaphor aestheticizes
+  rule-skirting by framing it as skillful navigation of natural forces rather
+  than as a choice to approach the boundary of harm. "Sailing close to the
+  wind" sounds adventurous and competent; "nearly breaking the law" does not.
+- **The consequences are asymmetric** -- if a sailor misjudges the wind, the
+  penalty is a stalled boat or, at worst, a capsize. The sailor is the one
+  who suffers. Ethical boundary-riding typically imposes costs on others:
+  the employees, customers, taxpayers, or communities who bear the
+  consequences of behavior that proved to be over the line. The metaphor's
+  self-contained risk model (the helmsman takes the gamble, the helmsman
+  takes the fall) does not match social reality.
+- **The source domain rewards the behavior** -- in sailing, going close to
+  the wind is often necessary and admirable. It is how you make progress
+  upwind. The metaphor imports this admiration into the ethical domain,
+  subtly praising the skill of the boundary-rider. But the ethical
+  equivalent of "making progress upwind" might be "enriching yourself at
+  others' expense while technically complying with regulations."
+- **Nobody thinks about sails** -- the expression has been in English since
+  at least the early 19th century and is now used by people who have never
+  been on a sailboat. The structural content (the specific aerodynamics of
+  close-hauled sailing, the feel of the helm, the sound of the luff) has
+  been replaced by a vague sense of "pushing your luck" or "nearly going
+  too far." The dead metaphor retains the judgment -- mild disapproval
+  mixed with grudging respect -- but not the source domain knowledge.
+
+## Expressions
+
+- "He's sailing close to the wind" -- the standard form, usually a warning
+  that someone's behavior is approaching but has not yet crossed an ethical
+  or legal boundary
+- "Sailing too close to the wind" -- the escalated variant, implying the
+  line has been crossed or is about to be
+- "Close to the wind" -- used adjectivally, as in "that tax scheme is a
+  bit close to the wind"
+- "Sailing close to the line" -- a hybrid that replaces the nautical "wind"
+  with the spatial "line," evidence of the metaphor's death: the source
+  domain is being overwritten by a more generic spatial frame
+- "On the edge" -- the fully dead version, where the sailing imagery has
+  been replaced entirely by generic spatial metaphor
+
+## Origin Story
+
+The expression appears in English by the early 19th century, when
+close-hauled sailing was a critical skill for both naval warfare and
+commerce. Sailing close to the wind allowed ships to make progress against
+headwinds, a capability that could mean the difference between reaching
+port and being blown off course. The figurative sense -- behaving in a
+way that risks transgression -- was established by mid-century.
+
+The expression's survival long after the age of sail reflects how
+precisely the source domain maps onto the ethical structure it describes.
+The specific combination of skill, risk, continuous adjustment, and the
+invisible boundary between success and failure has no better analogy in
+common experience. Unlike many nautical dead metaphors that survive through
+sheer linguistic inertia, "sailing close to the wind" retains some
+structural vitality because the mapping is so apt.


### PR DESCRIPTION
## Summary

- Adds dead-metaphor mapping for **sailing-close-to-the-wind** (seafaring -> ethics-and-morality)
- Creates new **seafaring** frame
- Close-hauled sailing's risk-reward calculus mapped onto behavior skirting ethical/legal boundaries

Closes #1296 (sub-issue of #1226)

## Validation

✓ `uv run scripts/validate.py validate` — 0 errors

Generated with [Claude Code](https://claude.com/claude-code)
