### PR TITLE
Add mapping: hand-over-fist

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,38 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- natural-phenomena
+- travel
+roles:
+- vessel
+- crew
+- captain
+- cargo
+- rigging
+- hull
+- keel
+- mast
+- sail
+- helm
+- port
+- anchor
+- tide
+- wind
+- current
+- storm
+- course
+- berth
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of ships, sailors, and the sea. One of the most prolific dead-metaphor
+factories in the English language, rivaled only by agriculture and war. Centuries
+of maritime dominance embedded nautical vocabulary so deeply into everyday speech
+that most speakers have no idea they are using it. "Taken aback," "the bitter end,"
+"loose cannon," "three sheets to the wind," "overwhelmed," "on board" -- the sea
+is everywhere in English, and almost nobody notices. As a source domain it provides
+rich structure: the interplay of human skill and natural force, the isolation of a
+ship at sea, the hierarchy of command, the constant negotiation between intention
+and circumstance.

--- a/catalog/mappings/hand-over-fist.md
+++ b/catalog/mappings/hand-over-fist.md
@@ -1,0 +1,118 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Hand Over Fist
+related: []
+slug: hand-over-fist
+source_frame: seafaring
+target_frame: economics
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+Hauling a rope aboard a sailing ship required a specific technique: one
+hand grips the rope (making a fist), the other hand reaches past it to
+grab higher, then pulls down while the first hand releases and reaches
+above in turn. Hand over fist, hand over fist -- a continuous, rapid,
+alternating motion that moves the rope (or the sailor, when climbing
+rigging) at maximum speed. The original nautical phrase was "hand over
+hand," and the shift to "hand over fist" emphasizes the grip, the
+clenching, the physicality of the labor.
+
+The metaphor maps the visible speed and rhythm of this motion onto rapid
+accumulation, especially of money.
+
+- **Speed without pause** -- the hand-over-fist technique works because
+  there is no dead time. One hand is always gripping while the other is
+  reaching. The economic mapping preserves this: "making money hand over
+  fist" implies continuous, uninterrupted accumulation. Not a windfall or
+  a single lucky break, but a sustained rate of gain that does not let up.
+- **Physical effort made visible** -- hauling rope is hard work, and the
+  hand-over-fist motion makes that effort legible to an observer. The
+  metaphor carries a trace of this: the phrase implies that the money-making
+  is vigorous, active, and visible. It is not passive income or quiet
+  compounding. Someone making money hand over fist is visibly hustling.
+- **The rhythm implies inevitability** -- once the hand-over-fist motion
+  starts, each pull naturally leads to the next. The motion has momentum.
+  The economic mapping imports this: rapid accumulation, once underway,
+  seems to feed on itself. Each sale funds the next investment, each
+  success brings more customers. The phrase describes acceleration as
+  much as speed.
+- **The direction is always up** -- whether hauling rope or climbing
+  rigging, hand-over-fist motion goes upward (or brings something upward).
+  The dead metaphor retains this orientation: you always make money hand
+  over fist, never lose it. The phrase has a built-in directionality that
+  maps onto the assumption that accumulation is always positive, always
+  ascending.
+
+## Where It Breaks
+
+- **Rope-hauling is labor; money-making may not be** -- the nautical
+  source is pure physical effort. A sailor hauling rope earns nothing from
+  the act itself; it is work in service of the ship's operation. The
+  economic usage often describes money flowing to people whose effort is
+  far removed from physical labor: hedge fund managers, tech founders,
+  landlords. The metaphor borrows the legitimacy of hard physical work
+  and drapes it over forms of accumulation that involve no rope, no sweat,
+  and no calluses. This is the metaphor's most ideologically interesting
+  distortion.
+- **The original motion is zero-sum** -- hauling a rope moves a fixed
+  length of rope from one side to another. There is a finite amount of
+  rope. The economic usage implies the opposite: money being generated,
+  apparently without limit. "Making money hand over fist" suggests
+  abundance, not redistribution. The metaphor's source domain is about
+  moving something; its target domain pretends to be about creating
+  something.
+- **Nobody pictures the sailor** -- this is one of English's most
+  thoroughly dead nautical metaphors. In surveys of idiom comprehension,
+  speakers consistently interpret "hand over fist" as meaning "rapidly"
+  without any image of rope, rigging, or sailing. The physical specificity
+  that made the original metaphor vivid -- the alternating grip, the
+  forward-leaning posture, the burn of hemp rope -- has been completely
+  replaced by an abstract sense of speed.
+- **The phrase is almost exclusively about money** -- the nautical
+  original applied to any hauling or climbing. The modern usage has
+  narrowed drastically: "hand over fist" collocates almost exclusively
+  with "making money," "spending money," or "losing money." A metaphor
+  that once described a general physical technique has been captured by
+  a single target domain.
+
+## Expressions
+
+- "Making money hand over fist" -- the dominant modern usage, meaning
+  rapid and sustained financial accumulation
+- "Losing money hand over fist" -- the less common negative variant,
+  preserving the speed but reversing the direction
+- "Spending hand over fist" -- rapid expenditure, carrying a note of
+  disapproval absent from the earning version
+- "Growing hand over fist" -- applied to companies, markets, or
+  populations, the phrase has begun to detach from money entirely and
+  attach to any rapid growth
+- "Hand over hand" -- the older form, still used in some dialects and
+  in literal descriptions of rope-pulling, now perceived as a variant
+  rather than the original
+
+## Origin Story
+
+The phrase "hand over hand" appears in English nautical writing by the
+early 18th century, describing the technique of hauling rope or climbing
+rigging. The variant "hand over fist" emerged in the late 18th or early
+19th century, likely as a more emphatic form that foregrounded the grip
+rather than just the motion. Early figurative uses applied the phrase to
+any rapid, steady progress -- not only financial. A ship could gain on
+another "hand over fist."
+
+The restriction to financial contexts appears to have solidified in
+American English during the 19th century, as the phrase migrated from
+maritime communities into general commercial vocabulary. By the early
+20th century, "hand over fist" was overwhelmingly associated with money,
+and the nautical origin was forgotten by most speakers. The phrase's
+survival is partly due to its phonetic appeal -- the hard consonants and
+monosyllables give it a percussive rhythm that mimics the action it
+once described.


### PR DESCRIPTION
## Summary

- Adds dead-metaphor mapping for **hand-over-fist** (seafaring -> economics)
- Creates new **seafaring** frame
- Rapid rope-hauling technique mapped onto fast, sustained financial accumulation

Closes #1299 (sub-issue of #1226)

## Validation

✓ `uv run scripts/validate.py validate` — 0 errors

Generated with [Claude Code](https://claude.com/claude-code)
