### PR TITLE
Add mapping: keelhauled

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,38 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- natural-phenomena
+- travel
+roles:
+- vessel
+- crew
+- captain
+- cargo
+- rigging
+- hull
+- keel
+- mast
+- sail
+- helm
+- port
+- anchor
+- tide
+- wind
+- current
+- storm
+- course
+- berth
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The domain of ships, sailors, and the sea. One of the most prolific dead-metaphor
+factories in the English language, rivaled only by agriculture and war. Centuries
+of maritime dominance embedded nautical vocabulary so deeply into everyday speech
+that most speakers have no idea they are using it. "Taken aback," "the bitter end,"
+"loose cannon," "three sheets to the wind," "overwhelmed," "on board" -- the sea
+is everywhere in English, and almost nobody notices. As a source domain it provides
+rich structure: the interplay of human skill and natural force, the isolation of a
+ship at sea, the hierarchy of command, the constant negotiation between intention
+and circumstance.

--- a/catalog/mappings/keelhauled.md
+++ b/catalog/mappings/keelhauled.md
@@ -1,0 +1,138 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Keelhauled
+related: []
+slug: keelhauled
+source_frame: seafaring
+target_frame: social-behavior
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+Keelhauling was a naval punishment in which a sailor was tied to a rope,
+thrown overboard, and dragged beneath the ship from one side to the other
+(or from bow to stern), scraping across the barnacle-encrusted hull and
+keel. The barnacles -- razor-sharp crustaceans cemented to the hull --
+would flay the skin. If the sailor was dragged slowly, the lacerations
+were severe but survivable. If dragged quickly, drowning was the greater
+risk. Either way, the punishment was public, sanctioned by the captain's
+authority, and meant to be witnessed by the entire crew.
+
+The metaphor maps this extreme, authorized punishment onto severe
+reprimand in modern life.
+
+- **Authority sanctions the punishment** -- keelhauling was not mob
+  violence. It was ordered by the captain, the ship's absolute authority,
+  as a formal disciplinary measure. The modern usage preserves this
+  structure: "getting keelhauled by the boss" or "keelhauled by the board"
+  implies that the punishment comes from someone with legitimate power
+  over the victim. This is not bullying; it is authorized discipline,
+  which makes it harder to resist or resent openly.
+- **The punishment is public and exemplary** -- the crew watched
+  keelhauling as a warning. The modern metaphor retains this: getting
+  keelhauled typically means being reprimanded in front of others, or
+  having one's failure made visible to the organization. The public
+  dimension is essential. A private scolding is not a keelhauling; a
+  dressing-down in front of the entire team is.
+- **The instrument of punishment is the institution itself** -- the keel
+  is the ship's structural backbone. The barnacles are the ship's
+  accumulated surface. The sailor is dragged across the very structure
+  that sustains him. The metaphor maps this onto organizations where the
+  institution's own apparatus -- performance reviews, public memos,
+  committee hearings -- becomes the instrument of punishment. You are
+  destroyed by the thing you serve.
+- **Disproportionate to the offense** -- keelhauling was reserved for
+  serious offenses, but its severity was wildly disproportionate by modern
+  standards. The metaphor carries this echo: "I got keelhauled" always
+  implies that the punishment exceeded what the situation warranted. Nobody
+  says they were keelhauled and means they received a proportionate
+  response.
+
+## Where It Breaks
+
+- **The severity gap is enormous** -- keelhauling was torture that
+  frequently resulted in death. "Getting keelhauled" in a modern office
+  means receiving a harsh email, a public criticism, or a poor performance
+  review. The metaphor works through hyperbole, but the hyperbole is so
+  extreme that it trivializes both the historical practice and the modern
+  complaint. Describing a stern meeting as a keelhauling borrows the
+  gravity of lethal punishment for the discomfort of professional
+  embarrassment. This is the defining characteristic of the dead metaphor:
+  the source domain's intensity has been bleached to near-zero.
+- **Keelhauling was physical; modern reprimand is social** -- the original
+  punishment worked on the body. The modern metaphorical usage describes
+  damage to reputation, status, or morale. The mapping from physical
+  destruction to social discomfort is structurally imprecise. A keelhauled
+  sailor could not "bounce back" or "learn from the experience." A
+  reprimanded employee usually can. The metaphor imports finality and
+  physical damage where the actual situation involves recoverable social
+  harm.
+- **The ship did not care about the sailor** -- keelhauling was an act of
+  institutional power exercised without concern for the individual. Modern
+  organizations (at least in principle) have HR departments, due process,
+  and norms against disproportionate punishment. Using "keelhauled" in a
+  corporate context implicitly compares one's employer to an 17th-century
+  naval vessel with absolute authority and no accountability. This
+  comparison is sometimes apt, which is why the metaphor survives.
+- **Nobody knows what keelhauling actually was** -- the metaphor is so
+  dead that most speakers could not describe the original practice. The
+  word has become a near-synonym for "severely reprimanded" with a vaguely
+  nautical flavor. The barnacles, the keel, the rope, the public
+  spectacle, the risk of drowning -- all the structural content that made
+  the original metaphor precise and horrifying -- have been replaced by a
+  generic sense of harsh treatment.
+
+## Expressions
+
+- "I got keelhauled" -- the standard modern usage, meaning a severe
+  reprimand, typically delivered by a superior
+- "Keelhauled by the boss" -- specifying the authority figure, preserving
+  the captain-to-sailor power dynamic
+- "They're going to keelhaul him" -- anticipatory, used when someone is
+  about to face severe consequences for a mistake
+- "A real keelhauling" -- intensified form, emphasizing that the reprimand
+  was particularly harsh or prolonged
+- "Dragged over the coals" -- a competing dead metaphor (from
+  ordeal-by-fire traditions) that occupies similar semantic territory and
+  has the same severity-bleaching problem
+
+## Origin Story
+
+Keelhauling was practiced primarily by Dutch and other European navies
+from the 15th through the 18th centuries. The Dutch term *kielhalen* is
+the direct source of the English word. It was formally abolished by most
+navies by the mid-18th century, though informal accounts suggest it
+persisted on some vessels into the 19th century.
+
+The punishment's severity varied with the ship. A small vessel meant a
+shorter drag but shallower depth (more barnacle contact). A large vessel
+meant a longer submersion (greater drowning risk). Some accounts describe
+weighted lines used to control depth, suggesting the punishment was
+calibrated rather than random. Contemporary illustrations, particularly
+from Dutch maritime art of the 17th century, depict keelhauling as a
+formal ceremony with the crew assembled as witnesses.
+
+The figurative usage appeared in English by the mid-19th century, initially
+retaining some of the original violence ("he'll keelhaul the man who did
+this"). By the 20th century, the word had been domesticated into
+professional and family contexts: a child keelhauled by a parent, an
+employee keelhauled by a manager. The trajectory from lethal torture to
+workplace complaint is one of the most extreme severity-bleaching arcs in
+English dead metaphor.
+
+## References
+
+- Smyth, W.H. *The Sailor's Word-Book* (1867) -- defines keelhauling as
+  a punishment and notes its decline
+- Jeans, P.D. *Ship to Shore: A Dictionary of Everyday Words and Phrases
+  Derived from the Sea* (1993) -- traces the metaphor's migration from
+  naval practice to common idiom
+- Cordingly, D. *Under the Black Flag* (2006) -- describes keelhauling
+  in the context of naval and pirate discipline


### PR DESCRIPTION
## Summary

- Adds dead-metaphor mapping for **keelhauled** (seafaring -> social-behavior)
- Creates new **seafaring** frame
- Naval punishment of dragging a sailor under the hull mapped onto severe authorized reprimand

Closes #1300 (sub-issue of #1226)

## Validation

✓ `uv run scripts/validate.py validate` — 0 errors

Generated with [Claude Code](https://claude.com/claude-code)
