### PR TITLE
Add mapping: mainstay

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,34 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- travel
+roles:
+- vessel
+- crew
+- mast
+- rigging
+- hull
+- sail
+- anchor
+- cargo
+- port
+- captain
+- compass
+- lee
+- bow
+- stern
+- fleet
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The practice of navigating and operating ships at sea, encompassing
+everything from the physical structure of the vessel (hull, mast, rigging,
+sail) to the human hierarchy (captain, crew, fleet commander) to the
+environmental forces that constrain action (wind, current, lee shore).
+Seafaring is one of the richest source domains in English, having deposited
+dozens of dead metaphors into everyday language during the centuries when
+maritime trade and naval power dominated British economic and military life.
+Most speakers no longer recognize the nautical origins of words like
+"leeway," "flagship," or "first-rate."

--- a/catalog/mappings/mainstay.md
+++ b/catalog/mappings/mainstay.md
@@ -1,0 +1,95 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Mainstay
+related:
+- flagship
+slug: mainstay
+source_frame: seafaring
+target_frame: physical-objects
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+The mainstay was the heavy rope or cable running from the top of the
+mainmast forward to the bow of a ship. It was the single most critical
+piece of standing rigging: without it, the mainmast -- the tallest mast,
+carrying the largest sails -- would fall backward under wind pressure and
+bring the entire rig down with it. The mainstay was not one support among
+many; it was the one that prevented catastrophic structural failure.
+
+- **Singular criticality** -- the mainstay was not a general-purpose rope.
+  It had one job, and nothing else could do that job. The metaphor maps
+  this irreplaceability onto people, institutions, or resources that are
+  the chief support of a system. Calling someone "the mainstay of the
+  department" claims that the department would collapse without them,
+  just as the rig would collapse without the stay.
+- **Invisible until absent** -- standing rigging does not move. Unlike
+  running rigging (halyards, sheets) that sailors actively handle, the
+  mainstay was a fixed structural element. It did its work silently by
+  being present. The metaphor carries this quality: a mainstay is
+  someone or something whose contribution is noticed only when
+  threatened with removal. The word honors unglamorous, structural
+  support.
+- **Connection between two points** -- the mainstay ran from the top of
+  the mast to the bow, connecting the highest point to the foremost
+  point. It was a tension member, holding two parts of the ship in
+  correct relationship. The metaphor preserves this bridging function:
+  a mainstay connects what would otherwise drift apart.
+
+## Where It Breaks
+
+- **The original mainstay was replaceable; the metaphorical one is not**
+  -- ships carried spare cordage, and a broken mainstay could be replaced
+  at sea with skill and time. The metaphorical usage implies
+  irreplaceability -- "she is the mainstay of the organization" suggests
+  there is no substitute. The nautical reality was less dramatic: the
+  stay was vital, but it was still a rope, and ropes can be spliced.
+- **The metaphor flattens a complex rigging system** -- a ship's standing
+  rigging included forestays, backstays, shrouds, and multiple stays per
+  mast. The mainstay was the most important, but it functioned within a
+  redundant system of mutual support. The metaphorical usage strips away
+  this context, implying a single point of support rather than a network.
+  Real organizations, like real rigging, depend on many interconnected
+  elements.
+- **"Mainstay" now implies permanence, but stays were consumable** --
+  hemp rope deteriorated in salt air and needed regular replacement.
+  The mainstay was a maintenance item, not a permanent fixture. The
+  metaphor has acquired a sense of enduring reliability that the
+  original object did not possess. Calling something a "mainstay" today
+  implies it has always been there and always will be; the real article
+  rotted and had to be renewed.
+
+## Expressions
+
+- "The mainstay of the economy" -- the most common contemporary usage,
+  applied to industries, exports, or sectors considered indispensable to
+  national prosperity
+- "A mainstay of the community" -- used for institutions (churches,
+  schools, local businesses) or individuals whose long service is being
+  honored
+- "Has been a mainstay since..." -- the temporal formula, emphasizing
+  duration and reliability over dynamism
+- "Mainstay of the lineup" -- in sports, a player who is consistently
+  selected and around whom the team is built
+- "Dietary mainstay" -- a food item that forms the foundation of a
+  cuisine or nutritional pattern, as in "rice is the mainstay of the
+  diet"
+
+## Origin Story
+
+The word "mainstay" entered English from nautical usage in the Middle
+English period. "Main" designated the principal mast (the mainmast), and
+"stay" referred to a heavy rope supporting a mast from fore or aft.
+The compound "mainstay" -- the stay of the mainmast -- was in use by
+the 15th century. The figurative sense ("the chief support") appeared
+by the mid-17th century and had fully displaced the nautical meaning
+in common usage by the 19th century. Today, almost no speaker who uses
+"mainstay" is thinking of rigging. The word has become a dead metaphor
+so thoroughly that dictionaries list the figurative meaning first.


### PR DESCRIPTION
## Summary

- Adds `mainstay` dead metaphor mapping (nautical rigging -> chief support)
- Creates `seafaring` source frame
- Validator passes with zero errors

Closes #1301
Sub-issue of #1226

## Validator output

```
All content valid.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)