### PR TITLE
Add mapping: first-rate

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,34 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- travel
+roles:
+- vessel
+- crew
+- mast
+- rigging
+- hull
+- sail
+- anchor
+- cargo
+- port
+- captain
+- compass
+- lee
+- bow
+- stern
+- fleet
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The practice of navigating and operating ships at sea, encompassing
+everything from the physical structure of the vessel (hull, mast, rigging,
+sail) to the human hierarchy (captain, crew, fleet commander) to the
+environmental forces that constrain action (wind, current, lee shore).
+Seafaring is one of the richest source domains in English, having deposited
+dozens of dead metaphors into everyday language during the centuries when
+maritime trade and naval power dominated British economic and military life.
+Most speakers no longer recognize the nautical origins of words like
+"leeway," "flagship," or "first-rate."

--- a/catalog/mappings/first-rate.md
+++ b/catalog/mappings/first-rate.md
@@ -1,0 +1,109 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: First-Rate
+related:
+- flagship
+slug: first-rate
+source_frame: seafaring
+target_frame: measurement
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+The Royal Navy classified warships by "rating" -- a formal taxonomy based
+on the number of guns a ship carried. A first-rate ship of the line
+mounted 100 or more guns on three gun decks, required a crew of over
+800 men, and cost a fortune to build and maintain. The rating system ran
+from first-rate (the most powerful) down through sixth-rate (the smallest
+warships). The metaphor maps this precise military classification system
+onto a vague quality judgment: "first-rate" now means simply "excellent."
+
+- **Taxonomic precision collapsed into superlative** -- the original
+  rating system was precise and measurable. A first-rate had 100+ guns;
+  a second-rate had 90-98; a third-rate had 64-80. You could count the
+  gun ports and know the rating. The metaphor has stripped away the
+  quantitative basis entirely. "A first-rate restaurant" makes no claim
+  about countable features. The precision of the original taxonomy has
+  been replaced by subjective enthusiasm.
+- **Expense and rarity** -- first-rate ships were extremely expensive
+  and few in number. The Royal Navy typically had fewer than ten
+  first-rates in service at any time, compared to dozens of third-rates.
+  The metaphor carries a faint echo of this exclusivity: calling
+  something "first-rate" implies it belongs to a small elite, not
+  the common run.
+- **A system of rates implies the existence of lower rates** -- the
+  word "first-rate" only makes sense within a ranking system. It implies
+  second-rate, third-rate, and so on. The metaphor has preserved this
+  structure asymmetrically: "second-rate" survives as a pejorative
+  ("second-rate imitation"), but "third-rate" through "sixth-rate"
+  have vanished from common usage. The lower end of the taxonomy died
+  while the top and its immediate neighbor survived.
+
+## Where It Breaks
+
+- **The rating system measured destructive power, not quality** -- a
+  first-rate ship was not "better" in any general sense. It was slower
+  than frigates, harder to maneuver, more expensive to maintain, and
+  often sat in port because it was too valuable to risk. Third-rates
+  were the actual workhorses of the fleet, forming the line of battle
+  in most engagements. The metaphor equates "first-rate" with
+  unqualified excellence, but the original classification measured a
+  single variable (firepower) that came with severe trade-offs.
+- **"Second-rate" has become an insult, but second-rates were formidable
+  warships** -- a second-rate ship of the line carried 90+ guns and
+  could dominate any engagement that did not involve a first-rate. In
+  the metaphor, "second-rate" means inferior, shoddy, or mediocre. The
+  collapse of a precise ranking system into a binary (first-rate = good,
+  second-rate = bad) eliminates the graduated middle ground where most
+  useful things actually fall.
+- **The system was bureaucratic, not qualitative** -- the rating system
+  was an administrative tool for pay scales, crew sizes, and fleet
+  organization. A ship's rating determined how many men and officers it
+  carried and how much they were paid. Calling it "first-rate" was a
+  payroll classification, not a compliment. The metaphor imports an
+  evaluative judgment that the original system did not intend.
+- **Most speakers have no idea this is nautical** -- "first-rate" is so
+  dead as a metaphor that it functions as a plain adjective. Speakers
+  who say "first-rate" are not making a nautical comparison; they are
+  using a word that sounds vaguely formal and British. The metaphor
+  preserves nothing of ships, guns, or fleets. It is a fossil embedded
+  in the language.
+
+## Expressions
+
+- "First-rate" -- as a standalone adjective meaning excellent, used
+  across all domains with no nautical awareness
+- "Second-rate" -- the surviving pejorative, meaning inferior or
+  mediocre, carrying all the original rating system's downward
+  connotation
+- "A first-rate mind" -- an intellectual compliment popularized in
+  F. Scott Fitzgerald's formulation about holding two opposed ideas
+- "First-rate job" -- workplace approval, pure superlative with zero
+  naval content
+- "Rate" (as verb) -- "how do you rate this?" descends from the same
+  classification impulse, though the connection is no longer felt
+
+## Origin Story
+
+The Royal Navy's rating system emerged in the mid-17th century under
+Samuel Pepys, who as Secretary to the Admiralty Commission formalized the
+classification of warships by armament. The system underwent several
+revisions between the 1650s and the 1810s, adjusting gun-count
+thresholds as ship design evolved. By the end of the Age of Sail,
+first-rates like HMS Victory (104 guns, launched 1765) were floating
+fortresses displacing over 3,500 tons.
+
+The figurative use of "first-rate" to mean "excellent" appeared in
+English by the late 17th century -- remarkably quickly after the
+classification system was formalized. By the 19th century, the
+figurative sense was dominant. "Second-rate" followed the same
+trajectory but acquired a negative connotation that the naval meaning
+never carried. The deeper rates (third through sixth) dropped out of
+figurative use entirely, leaving only the top two as everyday words.


### PR DESCRIPTION
## Summary

- Adds `first-rate` dead metaphor mapping (Royal Navy gun-count rating -> quality judgment)
- Creates `seafaring` source frame
- Validator passes with zero errors

Closes #1304
Sub-issue of #1226

## Validator output

```
All content valid.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)