### PR TITLE
Add mapping: copper-bottomed

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,34 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- travel
+roles:
+- vessel
+- crew
+- mast
+- rigging
+- hull
+- sail
+- anchor
+- cargo
+- port
+- captain
+- compass
+- lee
+- bow
+- stern
+- fleet
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The practice of navigating and operating ships at sea, encompassing
+everything from the physical structure of the vessel (hull, mast, rigging,
+sail) to the human hierarchy (captain, crew, fleet commander) to the
+environmental forces that constrain action (wind, current, lee shore).
+Seafaring is one of the richest source domains in English, having deposited
+dozens of dead metaphors into everyday language during the centuries when
+maritime trade and naval power dominated British economic and military life.
+Most speakers no longer recognize the nautical origins of words like
+"leeway," "flagship," or "first-rate."

--- a/catalog/mappings/copper-bottomed.md
+++ b/catalog/mappings/copper-bottomed.md
@@ -1,0 +1,109 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Copper-Bottomed
+related: []
+slug: copper-bottomed
+source_frame: seafaring
+target_frame: economics
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+From the 1760s onward, the Royal Navy sheathed the underwater hulls of
+its warships in copper plates. Copper sheathing prevented two serious
+problems: teredo worms boring through the wooden hull, and barnacle
+growth that slowed the ship. The process was expensive -- hundreds of
+copper sheets, each individually nailed to the hull -- and only the
+best-funded ships received it. A copper-bottomed ship was faster,
+more durable, and more reliable than an unsheathed one. The metaphor
+maps this expensive, proven protection technology onto financial
+guarantees or promises considered completely trustworthy.
+
+- **Reliability through material investment** -- copper sheathing
+  worked. It demonstrably prevented worm damage and fouling. The
+  metaphor maps this proven effectiveness onto financial instruments
+  or promises that are backed by something tangible and tested, not
+  merely by good intentions. A "copper-bottomed guarantee" is one
+  backed by real assets or demonstrated track record.
+- **Expense as evidence of commitment** -- copper sheathing was costly,
+  and the decision to apply it signaled that the ship was worth the
+  investment. The metaphor carries this: calling something
+  "copper-bottomed" implies that someone has spent real resources to
+  ensure its reliability. The expense itself is part of the guarantee.
+  Cheap promises are not copper-bottomed.
+- **Hidden protection** -- the copper sheathing was below the waterline,
+  invisible during normal operation. You could not see it, but it was
+  doing its work constantly, preventing damage that would otherwise
+  accumulate silently. The metaphor maps this invisible-but-essential
+  quality onto guarantees that protect against risks people do not
+  normally think about until disaster strikes.
+
+## Where It Breaks
+
+- **Copper sheathing caused its own problems** -- the copper reacted
+  galvanically with the iron bolts holding the hull together, corroding
+  them and weakening the ship's structure. The Navy had to replace iron
+  bolts with copper alloy bolts at additional expense. The metaphor
+  imports only the reliability, ignoring the fact that the protection
+  itself introduced new failure modes. "Copper-bottomed" implies no
+  trade-offs, but the original technology had serious ones.
+- **The metaphor implies permanence, but copper wore away** -- copper
+  sheathing was a consumable. It thinned over time and needed
+  replacement during dry-dock maintenance. A ship that was
+  copper-bottomed in 1780 needed re-sheathing by 1785. The metaphorical
+  usage implies a permanent, unchanging guarantee, but the original
+  protection was temporary and required ongoing investment.
+- **The word is primarily British and primarily financial** --
+  "copper-bottomed" as a metaphor is far more common in British English
+  than American English, and it clusters heavily in financial and
+  political discourse. American speakers often do not recognize the
+  expression at all. The metaphor's geographic and domain limitations
+  make it a less universal dead metaphor than "flagship" or "leeway."
+- **Not all copper-bottomed ships were trustworthy** -- the sheathing
+  protected the hull, but said nothing about the competence of the
+  captain, the morale of the crew, or the quality of the navigation.
+  A copper-bottomed ship could still be poorly commanded and run
+  aground. The metaphor conflates one dimension of reliability (hull
+  protection) with total trustworthiness, a logical leap that the
+  source domain does not support.
+
+## Expressions
+
+- "A copper-bottomed guarantee" -- the most common usage, especially
+  in British financial and political language, meaning a guarantee
+  considered absolutely reliable
+- "Copper-bottomed investment" -- a financial commitment regarded as
+  safe and certain to return value
+- "Copper-bottomed certainty" -- an assertion of complete confidence,
+  used in journalism and political commentary
+- "Copper-bottomed deal" -- a transaction in which the terms are
+  considered completely secure
+- "Not exactly copper-bottomed" -- the ironic negative, used to express
+  polite doubt about the reliability of a promise or plan
+
+## Origin Story
+
+The Royal Navy began experimenting with copper sheathing in the 1760s.
+HMS Alarm was one of the first ships to be fully coppered, in 1761. The
+practice became standard after the American Revolutionary War
+demonstrated the speed advantage of coppered hulls: British coppered
+ships could outrun and outmaneuver uncoppered French and Spanish vessels.
+By the 1780s, the Admiralty had committed to coppering the entire fleet,
+a massive industrial undertaking that consumed a significant fraction
+of Britain's copper production.
+
+The figurative use of "copper-bottomed" to mean "thoroughly reliable"
+appeared in British English by the early 19th century, initially in
+commercial and financial contexts. The expression remained primarily
+British, never gaining wide currency in American English. By the 20th
+century, most British speakers using "copper-bottomed" had no awareness
+of its naval origins. The expression persists mainly in financial
+journalism and parliamentary debate, where it serves as a slightly
+archaic intensifier for "guaranteed."


### PR DESCRIPTION
## Summary

- Adds `copper-bottomed` dead metaphor mapping (copper hull sheathing -> trustworthy guarantee)
- Creates `seafaring` source frame
- Validator passes with zero errors

Closes #1305
Sub-issue of #1226

## Validator output

```
All content valid.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)