### PR TITLE
Add mapping: jury-rigged

### DIFF
--- a/catalog/frames/seafaring.md
+++ b/catalog/frames/seafaring.md
@@ -1,0 +1,34 @@
+---
+created: '2026-03-14'
+name: Seafaring
+related:
+- travel
+roles:
+- vessel
+- crew
+- mast
+- rigging
+- hull
+- sail
+- anchor
+- cargo
+- port
+- captain
+- compass
+- lee
+- bow
+- stern
+- fleet
+slug: seafaring
+updated: '2026-03-14'
+---
+
+The practice of navigating and operating ships at sea, encompassing
+everything from the physical structure of the vessel (hull, mast, rigging,
+sail) to the human hierarchy (captain, crew, fleet commander) to the
+environmental forces that constrain action (wind, current, lee shore).
+Seafaring is one of the richest source domains in English, having deposited
+dozens of dead metaphors into everyday language during the centuries when
+maritime trade and naval power dominated British economic and military life.
+Most speakers no longer recognize the nautical origins of words like
+"leeway," "flagship," or "first-rate."

--- a/catalog/mappings/jury-rigged.md
+++ b/catalog/mappings/jury-rigged.md
@@ -1,0 +1,116 @@
+---
+author: agent:metaphorex-miner
+categories:
+- linguistics
+contributors: []
+created: '2026-03-14'
+harness: Claude Code
+kind: dead-metaphor
+name: Jury-Rigged
+related: []
+slug: jury-rigged
+source_frame: seafaring
+target_frame: tool-use
+updated: '2026-03-14'
+---
+
+## What It Brings
+
+When a storm dismasted a ship or battle damaged the rigging beyond repair,
+the crew assembled a "jury mast" -- a temporary replacement fashioned from
+spare spars, cargo booms, or whatever long timber was available. The jury
+rig was not meant to be good; it was meant to get the ship to port alive.
+It was improvisation under conditions where failure meant death at sea,
+using only the materials at hand, with no access to proper supplies or
+a shipyard. The metaphor maps this emergency improvisation onto any
+makeshift solution assembled from inadequate materials under pressure.
+
+- **Improvisation from constraint, not choice** -- a jury rig was not
+  creative self-expression. It was the only option when the real rig
+  was destroyed and the nearest port was hundreds of miles away. The
+  metaphor carries this quality: a jury-rigged solution is not clever;
+  it is desperate. It exists because the proper solution is unavailable,
+  not because improvisation is preferred.
+- **Temporary by definition** -- the jury rig was meant to last only
+  until the ship reached port, where proper repairs could be made. No
+  sailor expected the jury mast to serve permanently; it was explicitly
+  a bridge between catastrophe and proper repair. The metaphor maps
+  this temporariness onto solutions that should be replaced as soon as
+  possible but often are not.
+- **Sufficiency over quality** -- the jury rig did not need to match
+  the performance of the original rig. It needed only to provide enough
+  sail area to make headway and maintain steerage. The standard was
+  survival, not excellence. The metaphor carries this reduced standard:
+  a jury-rigged solution works, but just barely, and nobody should
+  confuse it with a real solution.
+- **Life-or-death stakes** -- the crew jury-rigged the mast because the
+  alternative was drifting helplessly until supplies ran out. The
+  metaphor's emotional charge comes from this context of mortal
+  necessity, even when applied to situations with much lower stakes.
+
+## Where It Breaks
+
+- **The original jury rig was skilled work; the metaphor implies
+  incompetence** -- assembling a jury mast required deep seamanship.
+  The crew had to select the right spar, step it securely, rig stays
+  and shrouds from available rope, bend on a reduced sail, and get the
+  whole assembly to bear wind loads without collapsing. This was expert
+  improvisation, not amateur hacking. The metaphor has acquired a
+  connotation of clumsiness and incompetence ("it's just jury-rigged")
+  that dishonors the skill required in the source domain.
+- **"Jury-rigged" has merged with "jerry-built" in common usage** --
+  "jerry-built" (meaning cheaply or poorly constructed, possibly from
+  19th-century British slang) has no nautical origin. But the phonetic
+  similarity has caused the two expressions to blend. Many speakers say
+  "jerry-rigged," a hybrid that exists in neither source domain. This
+  contamination has shifted "jury-rigged" from its meaning of "expertly
+  improvised under emergency conditions" toward "shoddily constructed,"
+  a significant semantic drift.
+- **The metaphor has lost the emergency context** -- a jury rig was
+  assembled after a catastrophe, in conditions of immediate danger. The
+  metaphorical usage often applies to situations with no emergency at
+  all: "I jury-rigged the presentation slides" implies hastiness but
+  not mortal peril. Without the life-or-death stakes, the word becomes
+  just a synonym for "improvised" or "hacked together," losing the
+  specific meaning of improvisation born from desperate necessity.
+- **Jury rigs were always replaced; metaphorical ones often become
+  permanent** -- in the source domain, reaching port meant the jury rig
+  was immediately torn down and replaced with proper rigging. The
+  metaphorical usage acknowledges temporariness in principle but
+  describes a common reality: jury-rigged solutions persist for years
+  because the "proper repair" never materializes. The proverbial
+  "temporary fix that became permanent" is the norm, not the exception,
+  inverting the source domain's expectation.
+
+## Expressions
+
+- "Jury-rigged" -- the standard form, meaning assembled hastily from
+  whatever was available, carrying connotations of both ingenuity and
+  inadequacy
+- "Jerry-rigged" -- the common hybrid form blending "jury-rigged" and
+  "jerry-built," now so widespread that many dictionaries accept it
+- "Jury rig" (as noun) -- the improvised assembly itself, used in
+  technical and engineering contexts
+- "A jury-rigged solution" -- in software engineering and IT, a fix
+  assembled from available components that works but is not
+  production-quality
+- "Jury-rigged together" -- emphasizing the assembly aspect, the
+  cobbling together of mismatched parts
+
+## Origin Story
+
+The origin of "jury" in "jury mast" is disputed. The leading theories
+are: from the Old French *ajurie* (help, relief), from the Latin
+*adjutare* (to aid), or a corruption of "jour" (day) implying a
+temporary, day-by-day arrangement. The term was in use by the early
+17th century; Captain John Smith's 1627 *A Sea Grammar* describes
+jury masts as standard emergency procedure.
+
+The figurative extension to any makeshift solution appeared by the
+18th century. The contamination with "jerry-built" (attested from the
+1860s, origin also disputed) produced the hybrid "jerry-rigged" by
+the early 20th century. Today the three forms -- jury-rigged,
+jerry-rigged, and jerry-built -- exist in a state of semantic overlap
+that few speakers can untangle. The nautical origin survives mainly
+among sailors and historians; for most speakers, "jury-rigged" is
+simply a slightly more formal synonym for "hacked together."


### PR DESCRIPTION
## Summary

- Adds `jury-rigged` dead metaphor mapping (emergency mast replacement -> makeshift solution)
- Creates `seafaring` source frame
- Validator passes with zero errors

Closes #1306
Sub-issue of #1226

## Validator output

```
All content valid.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)