### PR TITLE
fix: add --repo flag to auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,7 +19,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          files=$(gh pr diff "$PR_NUMBER" --name-only)
+          files=$(gh pr diff "$PR_NUMBER" --name-only --repo "$GITHUB_REPOSITORY")
           non_catalog=$(echo "$files" | grep -v '^catalog/' || true)
           if [ -n "$non_catalog" ]; then
             echo "PR touches non-catalog files — skipping auto-merge:"
@@ -35,5 +35,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr merge "$PR_NUMBER" --squash --auto
+          gh pr merge "$PR_NUMBER" --squash --auto --repo "$GITHUB_REPOSITORY"
           echo "Auto-merge enabled for PR #$PR_NUMBER"


### PR DESCRIPTION
## Summary
- The auto-merge workflow fails with "not a git repository" because `gh pr diff` and `gh pr merge` require either a git repo or an explicit `--repo` flag
- Added `--repo "$GITHUB_REPOSITORY"` to both `gh` commands so the workflow works without `actions/checkout`

## Test plan
- [ ] Verify the workflow triggers when a PR is labeled `approved`
- [ ] Confirm it correctly detects catalog-only PRs and enables auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)