### PR TITLE
Add mappings: the-bridge-pattern, the-flyweight-pattern

### DIFF
--- a/catalog/frames/civil-engineering.md
+++ b/catalog/frames/civil-engineering.md
@@ -1,0 +1,26 @@
+---
+created: '2026-03-15'
+name: Civil Engineering
+related:
+- architecture-and-building
+- materials
+roles:
+- bridge
+- span
+- load
+- foundation
+- abutment
+- truss
+- stress
+- reinforcement
+slug: civil-engineering
+updated: '2026-03-15'
+---
+
+The design and construction of infrastructure that spans, supports, and
+connects -- bridges, roads, dams, tunnels. Unlike architecture's focus on
+enclosure and habitation, civil engineering emphasizes structural integrity
+under load, the spanning of gaps, and the management of forces. As a source
+domain, it provides metaphors of connection, load-bearing, and structural
+soundness that map naturally onto software's concerns with coupling,
+abstraction layers, and system reliability.

--- a/catalog/mappings/the-bridge-pattern.md
+++ b/catalog/mappings/the-bridge-pattern.md
@@ -1,0 +1,123 @@
+---
+author: agent:metaphorex-miner
+categories:
+- software-engineering
+contributors:
+- fshot
+created: '2026-03-15'
+kind: conceptual-metaphor
+name: The Bridge Pattern
+provenance: gang-of-four
+related:
+- the-adapter-pattern
+- the-facade-pattern
+slug: the-bridge-pattern
+source_frame: civil-engineering
+target_frame: object-oriented-design
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+A bridge connects two landmasses that would otherwise require a long detour
+or remain entirely separate. It spans a gap. The GoF Bridge pattern maps
+this onto software: it decouples an abstraction from its implementation so
+that the two can vary independently. The "bridge" is the composition
+relationship between the abstraction hierarchy and the implementation
+hierarchy -- two sides connected by a narrow crossing.
+
+Key structural parallels:
+
+- **A bridge connects two independent territories** -- in civil engineering,
+  each side of a bridge has its own geography, its own roads, its own
+  development trajectory. The pattern separates abstraction and
+  implementation into two class hierarchies that can evolve independently.
+  The metaphor makes this independence feel physical: they're different
+  landmasses, not different floors of the same building.
+- **The bridge itself is thin relative to what it connects** -- a bridge is
+  a narrow structure spanning between two large things. In the pattern, the
+  bridge is typically a single reference (a pointer from abstraction to
+  implementor). The metaphor correctly suggests that the coupling point
+  should be minimal -- a span, not a merger.
+- **Traffic flows across in both directions** -- a bridge enables movement
+  from either side. The abstraction delegates to the implementation, but
+  the choice of which implementation to use can be decided at runtime,
+  injected, or swapped. The metaphor implies bidirectional possibility
+  even though the pattern's delegation is typically one-directional.
+- **You can rebuild one side without demolishing the bridge** -- civil
+  engineers can renovate the roads on one bank without touching the
+  bridge structure. The pattern's promise is identical: you can add new
+  implementations without modifying abstractions, and vice versa. The
+  metaphor makes this maintenance story intuitive.
+
+## Where It Breaks
+
+- **Real bridges are fixed infrastructure; the software bridge is a
+  runtime decision** -- you don't choose which bridge to cross at the
+  last moment; the bridge is where it was built. In the pattern, the
+  "bridge" (the implementation reference) can be swapped at runtime via
+  dependency injection. The metaphor suggests permanence where the
+  pattern offers flexibility. This can mislead developers into thinking
+  the pattern is heavier and more architectural than it actually is.
+- **Civil engineering bridges span a physical gap; the pattern spans a
+  conceptual one** -- the gap between abstraction and implementation is
+  not a chasm that exists naturally. It's a gap the developer creates by
+  choosing to separate the hierarchies. The metaphor makes the separation
+  feel inevitable (of course you need a bridge between two landmasses),
+  when in practice most code gets by without it. The Bridge pattern solves
+  a problem that only exists if you've already decided to factor your
+  design into two dimensions.
+- **A bridge has no opinion about what crosses it** -- a civil engineering
+  bridge carries cars, trucks, pedestrians, all indifferently. The software
+  bridge is tightly typed: the abstraction calls specific methods on the
+  implementor interface. The metaphor suggests content-agnostic transport
+  where the pattern enforces a strict protocol.
+- **"Bridge" competes with "adapter" in the developer's mind** -- both
+  metaphors involve connecting things that don't directly fit together. The
+  distinction (adapter connects incompatible interfaces after the fact;
+  bridge separates them by design from the start) is subtle and the
+  metaphors don't help differentiate. If anything, "bridge" sounds more
+  like an after-the-fact connector than "adapter" does, which is the
+  opposite of the GoF intent.
+- **Bridges fail catastrophically** -- the Tacoma Narrows collapse, bridge
+  washouts, structural fatigue. The metaphor imports a sense of risk that
+  the pattern doesn't carry. A poorly implemented Bridge pattern leads to
+  confusing indirection, not catastrophic failure. But the engineering
+  connotation can make developers overly cautious about using the pattern,
+  or overly dramatic about its failure modes.
+
+## Expressions
+
+- "Bridge the gap between interface and implementation" -- the core
+  metaphor, spanning as connecting
+- "Decouple abstraction from implementation" -- the gap the bridge spans,
+  described as a deliberate separation
+- "Two hierarchies connected by a thin reference" -- the bridge as minimal
+  spanning structure
+- "Platform bridge" -- common usage in cross-platform code, where the
+  bridge connects application logic to OS-specific implementations
+- "Bridge layer" -- treating the pattern as an architectural stratum,
+  mixing bridge and geological metaphors
+
+## Origin Story
+
+The Bridge pattern was codified in *Design Patterns* (1994) by the Gang
+of Four. The civil engineering metaphor was chosen to emphasize the
+pattern's core idea: two things that vary independently, connected by a
+narrow structure. The pattern has antecedents in the Handle/Body idiom
+from C++ (Coplien, *Advanced C++ Programming Styles and Idioms*, 1992),
+where a "handle" class holds a pointer to a "body" class. The GoF
+reframed this as a bridge, elevating it from an implementation trick to
+a structural principle. The metaphor has aged well in contexts like
+cross-platform development, where "bridge" naturally describes the layer
+between portable abstractions and platform-specific code (React Native's
+"bridge" between JavaScript and native modules is a direct descendant).
+
+## References
+
+- Gamma, E. et al. *Design Patterns: Elements of Reusable Object-
+  Oriented Software* (1994), Chapter 4: Structural Patterns
+- Coplien, J. *Advanced C++ Programming Styles and Idioms* (1992) --
+  the Handle/Body idiom that preceded the Bridge pattern
+- Facebook/Meta. "React Native Architecture: The Bridge" -- modern
+  usage of the bridge metaphor in cross-platform mobile development

--- a/catalog/mappings/the-flyweight-pattern.md
+++ b/catalog/mappings/the-flyweight-pattern.md
@@ -1,0 +1,124 @@
+---
+author: agent:metaphorex-miner
+categories:
+- software-engineering
+contributors:
+- fshot
+created: '2026-03-15'
+kind: conceptual-metaphor
+name: The Flyweight Pattern
+provenance: gang-of-four
+related:
+- the-singleton-pattern
+- the-prototype-pattern
+slug: the-flyweight-pattern
+source_frame: competition
+target_frame: object-oriented-design
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+In boxing, flyweight is the lightest competitive weight class -- fighters
+who weigh no more than 112 pounds. The name imports an entire vocabulary
+of deliberate minimization: cutting weight, stripping down to essentials,
+competing by being lean. The GoF Flyweight pattern maps this onto memory
+optimization: share as much state as possible among similar objects to
+minimize the memory footprint of large populations.
+
+Key structural parallels:
+
+- **Flyweights succeed by being light** -- a flyweight boxer's advantage
+  is agility earned through low mass. A flyweight object's advantage is
+  efficiency earned through shared state. The metaphor frames memory
+  optimization not as deprivation but as competitive advantage: being
+  light is a strategy, not a compromise.
+- **The weight class is defined by what you leave out** -- a flyweight
+  boxer qualifies by keeping their weight below a threshold. A flyweight
+  object qualifies by externalizing its variable state (extrinsic state)
+  and retaining only what can be shared (intrinsic state). The metaphor
+  correctly suggests that classification depends on what's absent, not
+  what's present.
+- **Many fighters can compete in the same class** -- flyweight isn't
+  one boxer; it's a category that many individuals fit into. The pattern
+  similarly allows many logical objects to share the same physical
+  flyweight instance, distinguished only by the extrinsic state passed
+  in at each use. The metaphor captures the one-to-many relationship
+  between the template and its uses.
+- **Weight management is ongoing discipline** -- a boxer doesn't cut
+  weight once; they maintain it throughout their career. The pattern
+  requires ongoing architectural discipline: every time you add state
+  to a flyweight, you must ask whether it's intrinsic (shareable) or
+  extrinsic (per-context). The metaphor frames this as athletic
+  maintenance rather than one-time design.
+
+## Where It Breaks
+
+- **Boxing flyweights are independent fighters; software flyweights are
+  shared instances** -- a flyweight boxer competes alone. A software
+  flyweight is shared among hundreds or thousands of clients
+  simultaneously. The metaphor suggests individual identity where the
+  pattern's whole point is the erasure of individual identity in favor
+  of shared structure.
+- **The sports metaphor doesn't explain the intrinsic/extrinsic split**
+  -- the pattern's key insight is the separation of shared state from
+  per-context state. Nothing in boxing maps onto this distinction. A
+  boxer doesn't separate their "shareable" muscles from their
+  "per-fight" muscles. The metaphor names the goal (be light) but not
+  the mechanism (externalize variable state), which is the actually
+  difficult part.
+- **"Flyweight" sounds trivial; the pattern is not** -- in boxing, the
+  flyweight class is sometimes seen as less prestigious than heavyweight.
+  The naming can make developers underestimate the pattern's complexity.
+  Implementing flyweight correctly requires careful analysis of which
+  state is intrinsic versus extrinsic, plus a factory to manage the
+  shared pool. It's one of the GoF's more subtle patterns, despite its
+  diminutive name.
+- **The competition frame is misleading** -- boxing is about fighting
+  opponents. The Flyweight pattern has no adversary. It's a pure
+  optimization technique. The competitive connotation suggests the
+  flyweight is competing against something (larger objects? memory
+  limits?) when it's really just sharing resources cooperatively. The
+  metaphor imports struggle where the pattern provides sharing.
+- **Flyweights in boxing are complete athletes; software flyweights are
+  deliberately incomplete** -- a flyweight boxer lacks nothing; they're
+  a fully capable fighter. A software flyweight is missing its extrinsic
+  state -- it's incomplete by design, requiring context to function. The
+  metaphor suggests wholeness where the pattern relies on partiality.
+
+## Expressions
+
+- "Flyweight pool" -- the collection of shared instances, managed like
+  a stable of fighters
+- "Intrinsic versus extrinsic state" -- the weight cut: what stays in
+  the object, what gets moved outside
+- "Shared instances" -- many contexts using the same lightweight object,
+  fighters sharing a weight class
+- "Memory footprint" -- the weight being minimized, borrowing from
+  physical measurement
+- "Lightweight objects" -- the direct translation: objects that weigh
+  less in memory
+
+## Origin Story
+
+The Flyweight pattern was codified in *Design Patterns* (1994) by the
+Gang of Four. The boxing metaphor is an unusual choice in a catalog
+dominated by architecture, manufacturing, and military metaphors -- it's
+the only GoF pattern named after a sports weight class. The pattern
+addresses a problem that was acute in the early 1990s: representing
+large numbers of similar objects (characters in a document editor,
+graphical elements in a CAD system) in systems with limited memory. The
+GoF's own example -- a document editor where each character could be a
+flyweight sharing font and style data -- remains one of the most
+frequently cited illustrations of the pattern. The name "flyweight"
+was chosen to evoke the feeling of minimal weight, and it succeeds:
+developers immediately understand that a flyweight should be small,
+even if the mechanism for achieving smallness requires further study.
+
+## References
+
+- Gamma, E. et al. *Design Patterns: Elements of Reusable Object-
+  Oriented Software* (1994), Chapter 4: Structural Patterns
+- Weinand, A., Gamma, E., & Marty, R. "ET++ -- An Object-Oriented
+  Application Framework in C++" (1988) -- early work on shared
+  graphical objects that informed the Flyweight pattern


### PR DESCRIPTION
## Summary

- Adds **The Bridge Pattern** mapping (closes #18): civil engineering's bridge metaphor applied to the GoF structural pattern that decouples abstraction from implementation
- Adds **The Flyweight Pattern** mapping (closes #21): boxing weight-class metaphor applied to the GoF memory optimization pattern
- Creates the **civil-engineering** frame (needed by bridge pattern)

Both entries follow the design-patterns playbook extraction strategy from project #3.

## Validator output

```
All content valid.
```

(26 pre-existing dangling reference warnings, zero errors, zero new warnings)

## Notes on issues #24, #25, #26

Issues #24 (Command), #25 (Interpreter), and #26 (Iterator) were also assigned to this batch, but their mappings already exist on main from previous mining runs. Those issues should be closed separately.

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors
- [ ] Reviewer confirms mapping quality and tone match existing design-pattern entries
- [ ] Frames referenced by mappings exist in catalog

Generated with [Claude Code](https://claude.com/claude-code)