### PR TITLE
Add mappings: unix-shell, process-fork, unix-signal, filesystem-root

### DIFF
--- a/catalog/mappings/filesystem-root.md
+++ b/catalog/mappings/filesystem-root.md
@@ -1,0 +1,133 @@
+---
+author: agent:metaphorex-miner
+categories:
+- computer-science
+contributors:
+- fshot
+created: '2026-03-15'
+harness: Claude Code
+kind: dead-metaphor
+name: Filesystem Root
+related:
+- unix-shell
+- daemon
+slug: filesystem-root
+source_frame: horticulture
+target_frame: data-processing
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+The root of a tree is its base -- the point from which all growth extends
+downward into soil and upward into branches. In Unix, the root is `/`, the
+top of the filesystem hierarchy, and also the name of the superuser account
+(UID 0). The metaphor encodes a double meaning: root as origin (the base
+from which everything grows) and root as foundation (the deepest point of
+access and authority).
+
+Key structural parallels:
+
+- **Everything grows from one point** -- a tree's root system is the
+  origin of the entire organism. The Unix filesystem root `/` is the
+  origin of all paths. Every file, every directory, every device node is
+  reachable from `/`. There is no file that does not trace its lineage
+  back to root. The metaphor makes absolute paths intuitive: `/usr/bin/ls`
+  is a path from the root, through branches, to a leaf.
+- **The tree is inverted** -- in botanical reality, roots are at the
+  bottom. In Unix filesystem diagrams, the root is drawn at the top, with
+  directories branching downward. This inversion is so conventional that
+  most computer scientists do not notice it. The tree data structure in
+  computer science universally places the root at the top, borrowing the
+  botanical name while inverting the spatial orientation. The metaphor
+  kept the naming but discarded the geometry.
+- **Root as superuser: depth equals power** -- the superuser is named
+  "root" because they have access to the root of the filesystem and
+  therefore to everything that grows from it. In botanical terms, if you
+  control the root, you control the tree. The metaphor implies that
+  authority is foundational -- the root user is not a branch with special
+  privileges but the base from which all structure derives.
+- **Singularity** -- a tree has one root system (setting aside adventitious
+  roots). Unix has one filesystem root. This singularity is a design
+  decision: unlike Windows with its multiple drive letters (C:, D:),
+  Unix insists on a single unified hierarchy. The botanical metaphor
+  reinforces this: there is one root, one tree, one namespace.
+
+## Where It Breaks
+
+- **Roots are hidden; the filesystem root is the most visible path** --
+  botanical roots are underground, invisible, doing essential work out of
+  sight. The filesystem root `/` is the most prominent path in the system,
+  the starting point of every absolute path, the first thing you see in
+  `ls /`. The metaphor borrows the concept of foundational origin but
+  inverts the visibility. Nothing in Unix is more exposed than root.
+- **Root access is the most dangerous privilege, not the most nourishing**
+  -- botanical roots nourish the tree, drawing water and nutrients from
+  the soil. The Unix root user has the power to destroy the entire system
+  with a single command (`rm -rf /`). The metaphor imports botanical
+  beneficence onto what is actually the most dangerous capability in the
+  system. "Root access" sounds organic and life-giving, but it is the
+  computing equivalent of holding the kill switch.
+- **Trees grow; filesystems are built** -- a tree's root system develops
+  organically, responding to soil conditions and water availability. A
+  filesystem is constructed deliberately by administrators. The metaphor
+  suggests organic growth but the reality is engineered structure. Nobody
+  "plants" a filesystem and waits for it to develop. The Filesystem
+  Hierarchy Standard (FHS) specifies exactly what goes where.
+- **The double metaphor conflates structure with authority** -- "root" the
+  directory and "root" the user are related but distinct concepts. The
+  root user is not literally the filesystem root -- they are an account
+  with UID 0 that happens to have unrestricted access. Conflating
+  structural origin (the base of the tree) with administrative power
+  (the superuser) creates a conceptual shortcut that obscures the actual
+  permission model. A non-root user can navigate the root directory; the
+  root user can operate entirely outside `/`.
+
+## Expressions
+
+- "Log in as root" -- become the superuser, spoken with the gravity
+  appropriate to assuming ultimate authority
+- "Root access" -- unrestricted system privileges, the phrase that makes
+  security auditors nervous
+- "The root of the filesystem" -- `/`, the base path, usually said
+  without any botanical awareness
+- "Rooted phone" -- a device where the user has obtained superuser
+  privileges, extending the Unix metaphor into mobile computing
+- "Don't run as root" -- the fundamental security advice, a warning
+  against operating with maximum power when minimum power would suffice
+- "chroot jail" -- changing the apparent root directory for a process,
+  trapping it in a subtree. The botanical metaphor strains: you cannot
+  replant a tree at a branch point
+
+## Origin Story
+
+The tree metaphor for hierarchical data organization predates Unix. It
+appears in information science as early as the 1950s, and the mathematical
+concept of tree structures was well established by the time Thompson and
+Ritchie designed the Unix filesystem in the early 1970s. But Unix made
+the tree metaphor concrete and universal by implementing a single-rooted
+filesystem hierarchy that every program navigates using path notation.
+
+The choice to call the base directory "root" and the superuser "root"
+was a natural extension of the tree vocabulary. Thompson and Ritchie's
+1974 CACM paper describes the filesystem as a hierarchy rooted at `/`,
+and the superuser convention was established in the earliest Unix
+implementations at Bell Labs.
+
+The inverted tree -- root at the top -- became standard in computer
+science textbooks and has so thoroughly displaced the botanical orientation
+that most programmers visualize trees as growing downward. This inversion
+is itself a quiet metaphorical failure that went unnoticed because nobody
+was thinking botanically when they drew their first tree diagram on a
+whiteboard.
+
+## References
+
+- Thompson, K. & Ritchie, D. "The UNIX Time-Sharing System," CACM 17(7),
+  1974 -- describes the rooted filesystem hierarchy
+- Kernighan, B. & Pike, R. *The Unix Programming Environment* (1984) --
+  practical treatment of the filesystem tree
+- Filesystem Hierarchy Standard, Linux Foundation (2015) -- formal
+  specification of the Unix directory tree
+- Raymond, E.S. *The Art of Unix Programming* (2003) -- discusses the
+  design philosophy behind the single-rooted filesystem

--- a/catalog/mappings/process-fork.md
+++ b/catalog/mappings/process-fork.md
@@ -1,0 +1,135 @@
+---
+author: agent:metaphorex-miner
+categories:
+- computer-science
+contributors:
+- fshot
+created: '2026-03-15'
+harness: Claude Code
+kind: dead-metaphor
+name: Process Fork
+related:
+- orphan-process
+- zombie-process
+- daemon
+slug: process-fork
+source_frame: tool-use
+target_frame: software-programs
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+A fork in a road or river is where a single path divides into two. In Unix,
+`fork()` is the system call that creates a new process by duplicating the
+calling process. The parent splits into parent and child, each continuing
+down a different execution path from the same point of divergence. The
+metaphor imports both the geometry of splitting and the irreversibility of
+choosing a path.
+
+Key structural parallels:
+
+- **Duplication at the point of divergence** -- when a road forks, both
+  branches share the same origin and the same history up to that point.
+  After `fork()`, parent and child have identical memory contents, open
+  files, and program counters. They are copies of each other at the moment
+  of splitting. The metaphor captures this precisely: the fork is where
+  sameness ends and difference begins.
+- **Two paths from one** -- the defining feature of a fork is that one
+  thing becomes two. The Unix process model makes this literal: before
+  `fork()`, there is one process; after, there are two. Each can take a
+  different path through the code (typically the parent waits while the
+  child runs a new program). The metaphor naturalizes what is actually a
+  strange operation -- self-duplication -- by framing it as path
+  divergence.
+- **The paths are independent** -- once a road forks, the two branches
+  do not affect each other. After `fork()`, parent and child have
+  separate address spaces. Changes in one do not affect the other. The
+  metaphor correctly implies independence after divergence, which is the
+  core design principle of Unix process isolation.
+- **The biological undertone** -- while the primary metaphor is
+  geographical (fork in a road), the operation also evokes biological
+  cell division. A cell splits into two identical copies that then
+  differentiate. Unix processes do the same: `fork()` creates an
+  identical copy, then the child differentiates into a new program. The
+  biological parallel is not accidental -- the Unix process model is
+  sometimes described as "spawning" children.
+
+## Where It Breaks
+
+- **Forks in roads are permanent; process forks are not** -- when a road
+  forks, you choose one path and the other is lost to you. When a process
+  forks, both paths are taken simultaneously. There is no choice involved.
+  The metaphor imports the idea of a dilemma or decision, but `fork()`
+  involves no decision -- both branches execute. The drama of "the road
+  not taken" is absent; both roads are taken, always.
+- **The copy is nearly perfect; road branches diverge immediately** --
+  at a physical fork, the two paths are immediately different: different
+  terrain, different destinations. After `fork()`, the two processes are
+  initially identical. The metaphor suggests immediate divergence, but the
+  reality is initial sameness followed by gradual differentiation. The
+  fork is less a branching than a cloning.
+- **The metaphor hides the cost** -- a fork in a road costs nothing; you
+  simply walk a different direction. `fork()` duplicates an entire process
+  address space (or at minimum sets up copy-on-write pages for one). On
+  resource-constrained systems, forking is expensive. The lightness of
+  the road metaphor disguises the heaviness of the operation, which is
+  one reason why lightweight alternatives (threads, `vfork()`,
+  `posix_spawn()`) were eventually developed.
+- **No return to the junction** -- in road metaphors, you can sometimes
+  backtrack to the fork and take the other path. In Unix, there is no
+  un-forking. The parent and child cannot merge back into one process.
+  The irreversibility is absolute in a way that the road metaphor does
+  not emphasize -- it feels like a casual divergence but is actually a
+  permanent split.
+
+## Expressions
+
+- "Fork a process" -- create a child process by duplicating the parent,
+  the canonical Unix usage
+- "Fork bomb" -- a denial-of-service attack where a process forks
+  recursively, filling the process table. The violence of "bomb" layered
+  onto the innocence of "fork" captures how a simple operation can be
+  weaponized through repetition
+- "Fork the repo" -- Git and GitHub borrowed the metaphor for creating
+  an independent copy of a codebase. This second-order metaphor maps
+  process forking onto social collaboration: your fork diverges from the
+  original while sharing all prior history
+- "Double fork" -- the technique of forking twice to create a daemon
+  process, orphaning the grandchild so init adopts it. The road metaphor
+  strains: a fork in a fork in a road
+- "After the fork, check the return value" -- the idiomatic C pattern
+  where `fork()` returns 0 to the child and the child's PID to the
+  parent, allowing each to know which path it is on
+
+## Origin Story
+
+The `fork()` system call was introduced by Ken Thompson in the first
+version of Unix at Bell Labs in 1969-70. Thompson's design was influenced
+by the "fork" operation in the GENIE time-sharing system at Berkeley
+(Project Genie, 1960s), which itself used the term for process splitting.
+
+The metaphor was a natural choice: Thompson needed a word for "create a
+new process by duplicating this one," and a fork in a road captures both
+the splitting and the shared origin. The simplicity of the name matched
+the simplicity of the interface -- `fork()` takes no arguments and returns
+a single integer. Ritchie and Thompson's 1974 CACM paper describes fork
+as the mechanism by which "a new process is created."
+
+The concept proved so fundamental that it was adopted by virtually every
+Unix-derived system and codified in POSIX. The metaphor extended beyond
+operating systems when distributed version control systems (Git, Mercurial)
+adopted "fork" for repository copying, creating a second life for a term
+that had already become invisible in its original domain.
+
+## References
+
+- Thompson, K. & Ritchie, D. "The UNIX Time-Sharing System," CACM 17(7),
+  1974 -- original description of the fork process model
+- Ritchie, D. "The Evolution of the Unix Time-sharing System," AT&T Bell
+  Labs Technical Journal 63(8), 1984 -- design rationale for fork
+- Stevens, W. R. *Advanced Programming in the UNIX Environment* (1992)
+  -- canonical treatment of fork() semantics
+- Lampson, B. & Sproull, R. "An Open Operating System for a
+  Single-User Machine," Operating Systems Review 13(5), 1979 -- discusses
+  fork's pre-Unix heritage

--- a/catalog/mappings/unix-shell.md
+++ b/catalog/mappings/unix-shell.md
@@ -1,0 +1,136 @@
+---
+author: agent:metaphorex-miner
+categories:
+- computer-science
+contributors:
+- fshot
+created: '2026-03-15'
+harness: Claude Code
+kind: dead-metaphor
+name: Unix Shell
+related:
+- daemon
+- zombie-process
+- orphan-process
+slug: unix-shell
+source_frame: containers
+target_frame: software-programs
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+A shell is the hard outer casing of a nut or egg -- the protective layer
+between the soft interior and the outside world. In Unix, the shell is the
+command interpreter that wraps the kernel, mediating between the user and the
+operating system's core. The metaphor encodes a spatial ontology: kernel
+inside, shell outside, user on the surface.
+
+Key structural parallels:
+
+- **Protection through enclosure** -- a biological shell prevents direct
+  contact with the vulnerable interior. The Unix shell prevents the user
+  from touching the kernel directly. You interact with the shell, and the
+  shell translates your intentions into system calls. This indirection is
+  protective in both directions: the kernel is shielded from naive users,
+  and users are shielded from the kernel's unforgiving interface.
+- **The shell is removable** -- you can crack a nut and discard the shell.
+  You can bypass the Unix shell and make system calls directly from a C
+  program. The shell is not the system; it is a convenience layer. This
+  replaceability is essential to Unix philosophy: the Bourne shell, C shell,
+  Korn shell, and Bash are all different shells around the same kernel. The
+  metaphor implies that the wrapper is separable from what it wraps.
+- **Shape conforms to contents** -- a shell takes the shape of the nut
+  inside it. Each Unix shell exposes the same underlying kernel capabilities
+  (file operations, process control, I/O redirection) but presents them
+  through different syntax and conventions. The shell's form follows the
+  kernel's function.
+- **The kernel-shell pair as a naming system** -- the botanical metaphor
+  creates a complete spatial vocabulary. The kernel (from the Germanic
+  *Kern*, meaning seed or grain) is the essential core. The shell is the
+  dispensable exterior. Together they give Unix a two-layer architecture
+  that is instantly comprehensible: important things inside, interface
+  outside.
+
+## Where It Breaks
+
+- **Biological shells are passive; Unix shells are active** -- a nutshell
+  does nothing. It sits there. The Unix shell is a full programming
+  language with variables, control flow, functions, and job control. Calling
+  it a "shell" implies a thin, inert wrapper, but Bash alone has thousands
+  of features. The metaphor dramatically understates the complexity of what
+  it names. Many programmers spend more time in the shell than in any other
+  environment.
+- **The shell is not actually outside the kernel** -- the spatial metaphor
+  suggests concentric layers: kernel at the center, shell around it. But
+  the shell is a user-space process like any other. It has no special
+  relationship to the kernel beyond the system call interface that every
+  program uses. The shell is not wrapped around the kernel; it sits on top
+  of it, alongside every other process. The concentric image is a useful
+  lie.
+- **Biological shells are one per organism; Unix has many** -- a nut has
+  one shell. A Unix system can run hundreds of shell instances
+  simultaneously, one per terminal session. The metaphor implies singularity
+  and intimacy -- *the* shell -- but the reality is multiplicity. Each user
+  gets their own shell, and shells can spawn sub-shells indefinitely. The
+  image of a single protective casing breaks down under concurrent use.
+- **The metaphor hides the shell's real power** -- by framing the command
+  interpreter as a mere wrapper, the metaphor obscures that shell scripting
+  is the primary means of composing Unix tools. Pipes, redirection, and
+  process substitution happen in the shell. The shell is not just an
+  interface to the kernel; it is the glue that makes Unix's small-tools
+  philosophy work. Calling it a shell makes it sound optional when it is
+  architecturally central.
+
+## Expressions
+
+- "Drop into a shell" -- open a command-line interface, as if descending
+  from a graphical surface layer into the system's real interface
+- "Shell script" -- a program written in the shell's language, though the
+  metaphor of a script (theater) layered on top of a shell (biology)
+  creates an odd mixed image
+- "Shell out" -- when a program spawns a shell to execute a command, as
+  if reaching outside its own boundary
+- "Reverse shell" -- a security exploit where the target machine connects
+  back to the attacker's shell, inverting the spatial relationship the
+  metaphor assumes
+- "Shell prompt" -- the cursor waiting for input, the shell's way of
+  saying it is ready to mediate
+
+## Origin Story
+
+Louis Pouzin coined the term "shell" for the Multics command interpreter
+in 1964-65 at MIT's Project MAC. His unpublished 1965 document "The Shell:
+A Global Tool for Calling and Chaining Procedures" established the
+metaphor explicitly: the command interpreter is a shell surrounding the
+system's core. Pouzin's insight was that the command language should be
+separate from the operating system itself -- a removable layer, not a
+built-in feature.
+
+Ken Thompson carried the term into Unix when he wrote the first Unix shell
+(the Thompson shell, `sh`) at Bell Labs in 1971. The metaphor transferred
+seamlessly because Unix adopted the same architectural principle: the shell
+is just a program, not a privileged part of the system. Stephen Bourne
+rewrote it as the Bourne shell in 1979, Bill Joy created the C shell
+(csh) at Berkeley, and the GNU Project produced Bash (Bourne Again Shell)
+in 1989 -- the pun in the name acknowledging both the lineage and the
+replaceable nature of shells.
+
+The kernel/shell naming pair was so successful that it became the default
+way to explain operating system architecture. Textbooks still draw
+concentric circles with the kernel at the center, even though the spatial
+metaphor is technically inaccurate. The metaphor outlived its literal
+accuracy because the conceptual model -- protected core, replaceable
+interface -- remains useful.
+
+## References
+
+- Pouzin, L. "The Shell: A Global Tool for Calling and Chaining
+  Procedures," unpublished Multics document (1965) -- the origin of the
+  term
+- Thompson, K. & Ritchie, D. "The UNIX Time-Sharing System," CACM 17(7),
+  1974 -- describes the shell as the standard Unix command interpreter
+- Bourne, S.R. "The UNIX Shell," Bell System Technical Journal 57:6
+  (1978) -- design of the Bourne shell
+- Kernighan, B. & Pike, R. *The Unix Programming Environment* (1984) --
+  extended treatment of shell programming and philosophy

--- a/catalog/mappings/unix-signal.md
+++ b/catalog/mappings/unix-signal.md
@@ -1,0 +1,140 @@
+---
+author: agent:metaphorex-miner
+categories:
+- computer-science
+contributors:
+- fshot
+created: '2026-03-15'
+harness: Claude Code
+kind: dead-metaphor
+name: Unix Signal
+related:
+- process-fork
+- zombie-process
+- orphan-process
+slug: unix-signal
+source_frame: communication
+target_frame: software-programs
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+A signal in the physical world is a gesture, sound, or sign that conveys
+information across distance -- a raised hand, a whistle, a flashing light.
+In Unix, a signal is an asynchronous notification sent to a process,
+interrupting whatever it is doing to deliver a message. The metaphor
+imports the urgency and physicality of real-world signaling into an
+abstract inter-process communication mechanism.
+
+Key structural parallels:
+
+- **Interruption as communication** -- signals in the physical world
+  interrupt: a tap on the shoulder stops your conversation, a fire alarm
+  overrides whatever you were doing. Unix signals work identically. When
+  a process receives SIGTERM, its current execution is suspended and the
+  signal handler runs. The metaphor captures the defining characteristic
+  of signals versus other IPC mechanisms: they are intrusive. They do not
+  wait in a queue to be politely read; they barge in.
+- **The message is the medium** -- real-world signals carry minimal
+  content. A whistle means "stop." A red light means "danger." Unix
+  signals are the same: they carry a number and nothing else. SIGKILL is
+  9, SIGTERM is 15, SIGHUP is 1. There is no payload, no explanation, no
+  context. The metaphor's mapping is tight: signals are blunt instruments
+  for simple messages, not vehicles for complex communication.
+- **Named signals encode specific social scripts** -- the signal names
+  import specific human interaction patterns. SIGTERM is a polite request
+  to terminate -- like asking someone to leave. SIGKILL is forced removal
+  -- like being physically ejected. SIGHUP originally meant the terminal
+  "hung up" the phone. SIGSTOP is "freeze." Each signal name maps a human
+  social interaction onto a process management operation.
+- **The sender-receiver asymmetry** -- in physical signaling, the sender
+  chooses when to signal; the receiver must react. Unix signals preserve
+  this asymmetry. The `kill` command sends; the receiving process must
+  handle or die. The receiver cannot refuse to receive (though it can
+  choose its response for most signals). This power asymmetry -- the
+  signaler controls the interaction -- is central to both the metaphor
+  and the mechanism.
+
+## Where It Breaks
+
+- **Real signals are perceived; Unix signals are imposed** -- when someone
+  taps your shoulder, you perceive the tap and choose how to respond. A
+  deaf person might not hear a whistle. But Unix signals cannot be missed
+  (except when blocked). They are not perceptions; they are forced state
+  changes. The metaphor implies a communication between agents, but the
+  reality is closer to a remote control: the sender pushes a button, and
+  the receiver's behavior changes whether it consents or not.
+- **SIGKILL violates the metaphor entirely** -- you cannot signal someone
+  to death. A whistle does not kill the listener. But SIGKILL (signal 9)
+  terminates a process immediately and unconditionally -- the process
+  cannot catch, block, or ignore it. This is not signaling; it is
+  execution. The metaphor of communication breaks down completely for the
+  most commonly discussed signal, which is really an exercise of absolute
+  power dressed in the language of messaging.
+- **The telephone metaphor in SIGHUP is obsolete** -- SIGHUP (hangup)
+  originally meant the modem connection was lost, borrowing from the
+  telephone act of hanging up the receiver. Modern systems have no modems,
+  no telephone lines, and often no physical terminals. SIGHUP has been
+  repurposed to mean "reload your configuration" for daemon processes --
+  a meaning that has nothing to do with hanging up anything. The metaphor
+  has been recycled beyond recognition.
+- **Signals are not really communication** -- real communication is
+  bidirectional: the receiver can respond, ask for clarification, or
+  signal back. Unix signals are fire-and-forget. The sender does not
+  know if the signal was received, how it was handled, or what happened
+  next (unless it explicitly waits). Calling this "signaling" dignifies
+  what is really a one-way interrupt mechanism with the vocabulary of
+  human interaction.
+
+## Expressions
+
+- "Send a signal to the process" -- the canonical phrasing, using the
+  conduit metaphor (signals are sent like messages)
+- "Kill -9" -- the most famous Unix command, sending SIGKILL. The
+  combination of "kill" and a bare number has a clinical finality
+- "Caught the signal" -- the process installed a handler that intercepted
+  the signal, using the metaphor of catching a thrown object
+- "Trap the signal" -- install a signal handler, borrowing from hunting
+  vocabulary (setting a trap for something that will arrive)
+- "Hang up" -- SIGHUP, the telephone metaphor fossilized in a system
+  call
+- "The process was interrupted" -- SIGINT, from Ctrl-C, the keyboard
+  interrupt that enters daily programming vocabulary as casually as
+  pressing a button
+
+## Origin Story
+
+Signals appeared in the earliest versions of Unix at Bell Labs in the
+early 1970s. Thompson and Ritchie needed a mechanism for the kernel to
+notify processes of exceptional events -- terminal disconnection,
+arithmetic errors, and user interrupts. The physical-world signal metaphor
+was a natural choice: these were brief, urgent notifications that demanded
+immediate attention.
+
+The original Unix signal set was small: interrupt, quit, hangup, and a
+few others. The names drew on concrete physical metaphors -- "hangup"
+from the telephone, "interrupt" from conversation, "kill" from violence.
+As Unix evolved, more signals were added (POSIX defines over 30), and
+the metaphor strained. SIGUSR1 and SIGUSR2 -- "user-defined signals" --
+are semantically empty, mere numbered slots. SIGPIPE -- sent when a
+process writes to a broken pipe -- layers the plumbing metaphor on top
+of the signaling metaphor.
+
+The signal mechanism was significantly redesigned in BSD Unix (the
+"reliable signals" of 4.2BSD) and again in POSIX, but the metaphorical
+vocabulary remained intact. The original naming choices from the early
+1970s still govern how every Unix programmer talks about asynchronous
+process notification half a century later.
+
+## References
+
+- Thompson, K. & Ritchie, D. "The UNIX Time-Sharing System," CACM 17(7),
+  1974 -- introduces signals as part of the Unix process model
+- Stevens, W. R. *Advanced Programming in the UNIX Environment* (1992)
+  -- canonical treatment of signal handling, including BSD vs. System V
+  differences
+- Kerrisk, M. *The Linux Programming Interface* (2010) -- modern
+  comprehensive treatment of signal semantics
+- IEEE Std 1003.1 (POSIX) -- formal specification of signal names and
+  behavior


### PR DESCRIPTION
## Summary

- Adds 4 dead-metaphor mappings from the unix-c-metaphors project (#9)
- **unix-shell** (#292): Command interpreter as protective outer layer (containers -> software-programs)
- **process-fork** (#295): Process creation as a path dividing in two (tool-use -> software-programs)
- **unix-signal** (#297): Inter-process communication as physical interruption (communication -> software-programs)
- **filesystem-root** (#299): Base of hierarchy as botanical root (horticulture -> data-processing)
- Issue #294 (daemon-process) closed as duplicate of existing `daemon.md`

All frames already exist in the catalog. No new frames or categories needed.

Closes #292, Closes #295, Closes #297, Closes #299

## Validator output

```
25 warning(s) (dangling references, non-blocking)
All content valid.
```

All 25 warnings are pre-existing dangling references from other entries.

## Test plan

- [ ] Verify validator passes with zero errors
- [ ] Review each mapping's "Where It Breaks" section for substance
- [ ] Confirm frontmatter schema compliance (kind, frames, categories)
- [ ] Check that related entries link correctly

Generated with [Claude Code](https://claude.com/claude-code)