### PR TITLE
Add mappings: filesystem-mount, file-permissions, c-pointer, null-pointer, c-string

### DIFF
--- a/catalog/mappings/c-pointer.md
+++ b/catalog/mappings/c-pointer.md
@@ -1,0 +1,146 @@
+---
+author: agent:metaphorex-miner
+categories:
+- computer-science
+contributors:
+- fshot
+created: '2026-03-15'
+harness: Claude Code
+kind: dead-metaphor
+name: C Pointer
+related:
+- null-pointer
+- c-string
+slug: c-pointer
+source_frame: embodied-experience
+target_frame: software-programs
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+The deictic gesture -- pointing a finger at something to indicate its
+location. A C pointer is a variable that holds the memory address of
+another value: it "points to" data stored elsewhere, just as a finger
+points toward an object across the room. The metaphor imports the
+entire structure of physical pointing: indirection, direction, the
+distinction between the finger and the thing it indicates.
+
+Key structural parallels:
+
+- **Indirection as the core concept** -- when someone points at a
+  painting, you look at the painting, not the finger. When you
+  dereference a pointer, you access the data at the address, not the
+  address itself. The metaphor captures the fundamental idea of
+  indirection: a pointer is not the thing; it is a reference to the
+  thing. C's `*p` operator ("follow the pointer") encodes this: go
+  where the finger is pointing.
+- **The pointer has a location and the thing has a location** -- a
+  pointing finger exists in space (attached to a hand, at a position)
+  and the indicated object exists elsewhere in space. A pointer
+  variable occupies memory at one address and the data it points to
+  occupies memory at another address. The metaphor preserves the
+  spatial separation between indicator and indicated, which is why
+  "pointer arithmetic" makes intuitive sense: you can move the finger
+  to point at adjacent things.
+- **Null as pointing at nothing** -- you can extend your finger without
+  pointing at anything. A null pointer holds a special address (zero)
+  that is defined to point nowhere. The metaphor handles absence
+  naturally: a pointer that points at nothing is the gestural
+  equivalent of an extended finger aimed at empty space.
+- **Dangling as pointing at something gone** -- you point at a chair;
+  someone removes the chair; your finger now points at empty space
+  where something used to be. A dangling pointer holds the address of
+  memory that has been freed. The metaphor captures the temporal
+  failure: the pointing was valid once, but the world changed and the
+  pointer did not update.
+- **Wild as pointing randomly** -- an uninitialized pointer contains
+  whatever bits happened to be in memory, which means it points
+  somewhere arbitrary. This is the gestural equivalent of a finger
+  waving around at random, indicating nothing meaningful. The metaphor
+  maps chaos onto a specific class of bugs.
+
+## Where It Breaks
+
+- **Fingers cannot do arithmetic** -- C allows pointer arithmetic:
+  `p + 3` means "the address three elements past where p points." You
+  cannot meaningfully add 3 to a pointed finger. The metaphor of
+  pointing provides no intuition for why adding an integer to a
+  direction should yield another meaningful direction. This is where
+  the pointer metaphor becomes a memory-address metaphor wearing a
+  pointing costume.
+- **Casting breaks the gesture entirely** -- `(int *)p` reinterprets
+  the bits at an address as a different type. There is no gestural
+  equivalent of "point at the same spot but decide it's a different
+  kind of thing." Casting reveals that a pointer is really just a
+  number -- an address -- and that the "pointing" metaphor is a
+  convenience layered on top of raw memory manipulation.
+- **Double pointers strain intuition** -- a pointer to a pointer
+  (`int **pp`) is a finger pointing at a finger pointing at the data.
+  Triple pointers (`int ***ppp`) are worse. The physical metaphor does
+  not scale: people do not chain deictic gestures in practice, and
+  the mental model breaks down rapidly past two levels of indirection.
+- **The metaphor hides the danger** -- pointing at something in the
+  physical world is safe. Dereferencing a pointer in C can crash the
+  program, corrupt memory, or create a security vulnerability. The
+  innocuous metaphor of pointing disguises the fact that pointers are
+  the single largest source of bugs and security holes in C programs.
+  The embodied familiarity of pointing makes pointers feel safer than
+  they are.
+- **Most languages have eliminated the gesture** -- Java, Python, Go,
+  and JavaScript all use references or managed pointers that the
+  programmer cannot directly manipulate. The pointing metaphor survives
+  in C (and C++) because the programmer still manually follows, moves,
+  and creates pointers. In most modern languages, the finger has been
+  amputated and replaced with an automatic mechanism. The metaphor is
+  alive in C and dead everywhere else.
+
+## Expressions
+
+- "Dereference the pointer" -- follow the finger to find the data,
+  using the `*` operator in C
+- "Null pointer dereference" -- attempting to follow a finger that
+  points at nothing, the most common pointer bug and the source of
+  countless crashes
+- "Pointer arithmetic" -- moving the finger through memory by adding
+  or subtracting offsets, a concept that has no gestural equivalent
+- "Dangling pointer" -- a finger that still points at where something
+  used to be, one of the hardest bugs to diagnose because the pointer
+  looks valid but the data is gone
+- "Pass by pointer" -- giving someone a finger-point instead of the
+  object itself, so they can find and modify the original
+- "Void pointer" -- a finger that points somewhere but refuses to say
+  what kind of thing it is pointing at, requiring a cast to interpret
+
+## Origin Story
+
+The pointing metaphor in programming predates C. BCPL (1967) and B
+(1969) had pointer-like constructs, and assembly language programmers
+had been using "address" and "indirect addressing" since the 1950s.
+But Dennis Ritchie's design of C (1972) cemented the pointer as a
+first-class language feature with a dedicated syntax: `*` for
+dereferencing, `&` for taking an address, and `->` for following a
+pointer to a struct member.
+
+Ritchie's 1993 retrospective "The Development of the C Language"
+describes how C's pointer model evolved from B's simpler treatment of
+memory. The choice to make pointers typed -- a pointer to `int` is
+different from a pointer to `char` -- added safety at the cost of
+complexity, and introduced the casting operation that strains the
+pointing metaphor.
+
+The enduring power of the metaphor is demonstrated by its persistence
+in C and C++ education. Every introductory C textbook explains pointers
+using the finger-pointing analogy or the "address on an envelope"
+variant. Kernighan and Ritchie's *The C Programming Language* (1978)
+uses the word "points to" throughout, naturalizing the gestural metaphor
+as if it were literal description.
+
+## References
+
+- Kernighan, B. & Ritchie, D. *The C Programming Language*, 1978/1988
+  -- the canonical treatment of C pointers
+- Ritchie, D. "The Development of the C Language," ACM SIGPLAN, 1993
+  -- historical context for pointer design decisions
+- Hoare, C.A.R. "Null References: The Billion Dollar Mistake," QCon
+  London, 2009 -- on the consequences of the null pointer

--- a/catalog/mappings/c-string.md
+++ b/catalog/mappings/c-string.md
@@ -1,0 +1,152 @@
+---
+author: agent:metaphorex-miner
+categories:
+- computer-science
+contributors:
+- fshot
+created: '2026-03-15'
+harness: Claude Code
+kind: dead-metaphor
+name: C String
+related:
+- c-pointer
+- null-pointer
+slug: c-string
+source_frame: embodied-experience
+target_frame: data-processing
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+A string of beads, a string of pearls, a string of characters -- items
+threaded onto a line in fixed order. The metaphor maps the linear,
+sequential arrangement of physical objects on a cord onto the linear,
+sequential arrangement of characters in memory. In C, a string is an
+array of `char` values terminated by a null byte (`\0`), and the
+metaphor encodes both the ordering and the endpoint: beads on a thread,
+with a knot at the end.
+
+Key structural parallels:
+
+- **Linear ordering** -- beads on a string have a first, a second, a
+  third, and a last. Characters in a C string have an index: `s[0]`,
+  `s[1]`, `s[2]`. The metaphor maps physical sequence onto memory
+  sequence. You can traverse a string from beginning to end, just as
+  you can run your finger along a strand of beads.
+- **Contiguity** -- beads on a string touch their neighbors. Characters
+  in a C string occupy adjacent memory addresses. There are no gaps,
+  no jumps, no out-of-order elements. The metaphor imports the
+  physical constraint that a string holds its elements together in a
+  continuous run.
+- **The terminator as a knot** -- a physical string of beads needs
+  something at the end to prevent the beads from sliding off. In C,
+  the null terminator (`\0`) serves this role: it marks where the
+  string ends. Without it, functions like `strlen()` and `printf()`
+  would run past the end of the data, reading whatever happens to be
+  in adjacent memory. The knot metaphor is implicit but structurally
+  precise.
+- **The string itself is not the beads** -- a physical string is the
+  cord that holds the beads, not the beads themselves. Similarly, a C
+  "string" is the *arrangement* -- the convention of null-terminated
+  `char` array -- not the individual characters. You can remove beads
+  from a string and restring them; you can copy characters from one
+  array to another. The container and the contents are conceptually
+  separable.
+
+## Where It Breaks
+
+- **Strings are not a type in C** -- in the physical world, a string
+  of beads is a recognizable object. In C, there is no `string` type.
+  A "string" is a convention: a `char *` that happens to point to a
+  null-terminated sequence of bytes. The language provides no
+  enforcement of this convention. A `char *` might point to a
+  null-terminated string, a fixed-length buffer, a single character,
+  or freed memory. The metaphor names something that the type system
+  does not recognize.
+- **Buffer overflows betray the metaphor** -- a physical string has a
+  definite length and you can see where it ends. A C string's length
+  is discovered only by scanning for the null terminator, and if the
+  terminator is missing or the buffer is too small, functions will
+  read or write past the end. This is the buffer overflow, the most
+  exploited class of vulnerability in computing history. The string
+  metaphor implies a bounded, self-contained object; the reality is
+  an open-ended convention that trusts the programmer to get the
+  boundaries right.
+- **Encoding is invisible** -- beads on a string are what they appear
+  to be. Characters in a C string are bytes, and bytes can encode
+  different character sets. A C string of UTF-8 text looks identical
+  to a C string of ASCII text at the byte level, but `s[3]` might be
+  the fourth character (ASCII) or the middle of a multi-byte character
+  (UTF-8). The metaphor of beads-on-a-string implies that each
+  position holds one complete element, which is false for any
+  multi-byte encoding.
+- **The metaphor has been superseded** -- modern languages replace C
+  strings with string objects that know their own length (Python's
+  `str`, Rust's `String`, Go's `string`). These are closer to a
+  "rope" or "ribbon" metaphor: a managed, self-describing sequence
+  rather than a raw array with a sentinel. The bead-on-a-string
+  metaphor's reliance on a null terminator is now understood as a
+  design flaw, not a feature.
+- **Mutation is unrestricted** -- beads on a physical string are
+  fixed once strung. C strings are mutable: you can overwrite any
+  character at any index, change the length by moving the terminator,
+  or concatenate strings by copying bytes. The metaphor imports the
+  stability of a physical arrangement but the implementation allows
+  arbitrary modification, including modifications that silently
+  corrupt the string.
+
+## Expressions
+
+- "Null-terminated string" -- the canonical description, naming both
+  the metaphor (string) and the mechanism (null termination)
+- "String literal" -- a sequence of characters enclosed in double
+  quotes in C source code, like `"hello"`, which the compiler
+  automatically null-terminates
+- "String copy" -- `strcpy()`, which copies characters until it
+  encounters the null terminator, trusting that the destination buffer
+  is large enough (a frequent source of buffer overflows)
+- "String length" -- `strlen()`, which counts characters by scanning
+  for the null terminator, an O(n) operation that surprises
+  programmers accustomed to languages where strings know their own
+  length
+- "Empty string" -- a string whose first byte is the null terminator,
+  the string metaphor's representation of a cord with no beads
+- "String manipulation" -- the general category of operations on
+  strings, using "manipulation" (from Latin *manus*, hand) to
+  reinforce the tactile metaphor of handling a physical object
+
+## Origin Story
+
+The word "string" for a sequence of characters predates C by decades.
+It appears in ALGOL and FORTRAN documentation from the 1950s and 1960s,
+borrowed from the mathematical concept of a "string" as a finite
+sequence of symbols from an alphabet (formal language theory). The
+mathematical use itself likely derives from the physical image of
+symbols strung together in order.
+
+C's contribution was not the term but the implementation: the
+null-terminated character array. Dennis Ritchie inherited this from
+B and BCPL, which treated strings as packed byte arrays. The null
+termination convention was a pragmatic choice on the PDP-11: it
+avoided storing a separate length field and made string functions
+simple loops. This simplicity came at the cost of safety -- the
+missing length field is the root cause of buffer overflow
+vulnerabilities that have plagued C programs for fifty years.
+
+Kernighan and Ritchie's *The C Programming Language* (1978)
+established the conventions for C string handling that persist today,
+including the standard library functions `strlen`, `strcpy`, `strcat`,
+and `strcmp`. These functions all depend on null termination, and their
+unsafe behavior when given unterminated input has been the subject of
+innumerable security advisories.
+
+## References
+
+- Kernighan, B. & Ritchie, D. *The C Programming Language*, 1978/1988
+  -- defines C string conventions and standard library functions
+- Ritchie, D. "The Development of the C Language," ACM SIGPLAN, 1993
+  -- historical context for C's string implementation
+- One, A. "Smashing the Stack for Fun and Profit," Phrack 49, 1996
+  -- the canonical description of buffer overflow exploitation, which
+  depends on C string conventions

--- a/catalog/mappings/file-permissions.md
+++ b/catalog/mappings/file-permissions.md
@@ -1,0 +1,134 @@
+---
+author: agent:metaphorex-miner
+categories:
+- computer-science
+contributors:
+- fshot
+created: '2026-03-15'
+harness: Claude Code
+kind: dead-metaphor
+name: File Permissions
+related:
+- zombie-process
+- orphan-process
+slug: file-permissions
+source_frame: governance
+target_frame: data-processing
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+Social permission -- the granting or withholding of authority to act.
+Unix file permissions borrow the entire apparatus of governance: an
+owner who possesses the file, groups that confer membership, a
+tripartite division of the world into owner, group, and others, and
+a sovereign (root) who transcends all rules. The metaphor transforms
+bits into a political system.
+
+Key structural parallels:
+
+- **Ownership as sovereignty over property** -- every Unix file has an
+  owner, just as every piece of property has a title holder. The owner
+  can grant or revoke permissions at will, transfer ownership (with
+  sufficient privilege), and determine who may do what. The metaphor
+  imports the legal concept of property rights: the owner's authority
+  is not earned through use but assigned through creation or explicit
+  transfer.
+- **Group membership as social identity** -- the group permission tier
+  maps onto social group membership. You either belong to a group or
+  you do not; there is no partial membership, no probation, no guest
+  status. The metaphor imports the sharp boundaries of institutional
+  membership -- a club, a guild, a department -- where the binary of
+  in-group and out-group determines access.
+- **Three verbs of action** -- read, write, execute. These map onto
+  three kinds of interaction with the world: observing (read), modifying
+  (write), and performing (execute). The metaphor reduces all possible
+  interactions with a file to three atomic permissions, just as
+  governance reduces complex civic life to enumerable rights.
+- **The superuser as absolute monarch** -- root bypasses all permission
+  checks. This is not a bug or an override; it is a designed role in
+  the system. The metaphor imports the concept of sovereignty: one
+  entity that stands above the law, whose authority is not constrained
+  by the rules that bind everyone else. The analogy to absolute
+  monarchy is structurally precise.
+
+## Where It Breaks
+
+- **The three-tier model is socially impoverished** -- real governance
+  involves nuanced hierarchies: roles, delegated authority, temporary
+  privileges, contextual permissions. Unix's owner/group/others model
+  is a blunt instrument. You cannot express "this person can read on
+  weekdays" or "members of group A can write only if approved by a
+  member of group B." The metaphor imports the *language* of governance
+  but not its complexity. ACLs (Access Control Lists) were bolted on
+  later precisely because the original metaphor was too simple.
+- **Ownership is not authority** -- in governance, authority flows from
+  legitimacy, law, and consent. In Unix, ownership flows from whoever
+  ran `chown` last with root privileges. The metaphor borrows the
+  gravitas of property rights but the underlying mechanism is
+  arbitrary assignment by a superuser. There is no due process, no
+  appeal, no constitutional constraint on root's power.
+- **Execute permission is metaphorically orphaned** -- "read" and
+  "write" are intuitive verbs that map cleanly onto observing and
+  modifying. "Execute" is less clear: on a file, it means "run this as
+  a program"; on a directory, it means "traverse this." The same
+  permission bit means fundamentally different things depending on
+  context, which no governance metaphor would tolerate. A license to
+  practice law does not also mean a license to enter courtrooms.
+- **The metaphor hides the mechanism** -- permissions feel like social
+  agreements, but they are enforced by the kernel through bit masks.
+  There is no negotiation, no discretion, no judgment. A process either
+  has the right bits set or it does not. The governance metaphor implies
+  a richness of enforcement (courts, police, norms, shame) that the
+  actual mechanism lacks entirely. Enforcement is absolute and
+  instantaneous, with no gray area.
+- **Permission denial feels like a moral judgment** -- "Permission
+  denied" reads like a rebuke. The system is not merely preventing an
+  action; it is *denying permission*, as if the user has asked for
+  something they should not have. This imports social shame into a
+  mechanical check, which is why "Permission denied" is one of the
+  most frustrating error messages in computing -- it feels personal.
+
+## Expressions
+
+- "Permission denied" -- the canonical error message, importing the
+  language of social refusal into a bit-mask check
+- "chmod 755" -- granting the owner full rights and everyone else
+  read-and-execute, expressed as an octal incantation that encodes
+  the governance metaphor in three digits
+- "Who owns this file?" -- using property-rights language to ask about
+  a metadata field
+- "The file is world-readable" -- "world" as the set of all possible
+  actors, a governance term for the public sphere
+- "Elevate to root" -- ascending in the social hierarchy to gain the
+  sovereign's unrestricted authority
+- "Run as root" -- assuming the identity of the absolute monarch to
+  bypass all permission checks
+
+## Origin Story
+
+Unix file permissions were designed by Ken Thompson and Dennis Ritchie
+at Bell Labs in the early 1970s. The rwx/owner/group/others model
+was a simplification of Multics' more elaborate access control system.
+Multics had ACLs from the start; Unix deliberately chose a simpler
+model that could be encoded in a few bits of the inode. The choice
+was pragmatic -- PDP-11 memory was scarce -- but the resulting
+permission model proved remarkably durable.
+
+The octal notation (e.g., 0755) became the standard shorthand, and
+`chmod`, `chown`, and `chgrp` became the commands for managing the
+governance metaphor. The fact that these commands read as imperative
+verbs -- *change mode*, *change owner*, *change group* -- reinforces
+the governance frame: an authority is issuing decrees about who may
+do what.
+
+## References
+
+- Thompson, K. & Ritchie, D. "The UNIX Time-Sharing System," CACM
+  17(7), 1974 -- describes the protection mechanism
+- Ritchie, D. "The Evolution of the Unix Time-sharing System," 1984 --
+  discusses design decisions including the permission model
+- Kernighan, B. & Pike, R. *The Unix Programming Environment*, 1984 --
+  practical treatment of permissions from the user's perspective
+- `chmod(2)` man page, man7.org -- current Linux documentation

--- a/catalog/mappings/filesystem-mount.md
+++ b/catalog/mappings/filesystem-mount.md
@@ -1,0 +1,129 @@
+---
+author: agent:metaphorex-miner
+categories:
+- computer-science
+contributors:
+- fshot
+created: '2026-03-15'
+harness: Claude Code
+kind: dead-metaphor
+name: Filesystem Mount
+related:
+- data-flow-is-fluid-flow
+slug: filesystem-mount
+source_frame: tool-use
+target_frame: data-processing
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+Mounting -- physically lifting a heavy object and fixing it into place
+on a prepared surface. In the 1960s and 1970s, this was literal: an
+operator would mount a disk pack onto a drive spindle, a reel of tape
+onto a tape drive, or a cartridge into a slot. The physical act required
+human hands, mechanical alignment, and a satisfying click. Unix
+inherited this language and abstracted it: `mount` attaches a filesystem
+to a point in the directory tree, making its contents accessible as if
+they had always been there.
+
+Key structural parallels:
+
+- **Physical attachment to a prepared location** -- a disk pack mounts
+  onto a specific drive; a filesystem mounts onto a specific directory
+  (the mount point). Both require a receptor: the drive spindle, the
+  empty directory. The metaphor preserves the idea that attachment is
+  not arbitrary -- you mount *onto* something that was designed to
+  receive.
+- **Seamless integration after attachment** -- once a disk pack was
+  mounted, the operator interacted with its data, not with the physical
+  medium. Once a filesystem is mounted, programs access files through
+  the directory tree with no awareness that the data lives on a
+  separate device. The metaphor captures the disappearing act: the
+  mount point absorbs the mounted thing, and the seam vanishes.
+- **Explicit detachment required** -- you cannot yank a spinning disk
+  pack off a drive without damage. You cannot safely remove a mounted
+  filesystem without unmounting it first (flushing buffers, releasing
+  locks). The metaphor imports the discipline of orderly removal:
+  `umount` exists because the physical act of dismounting required care.
+- **The operator as physical agent** -- mounting was something a person
+  did with their body. The metaphor preserves the sense of deliberate
+  human action, even though modern systems auto-mount devices with no
+  human intervention. The command still reads as an imperative directed
+  at a person: *mount this here*.
+
+## Where It Breaks
+
+- **The physical act has vanished** -- nobody mounts disk packs anymore.
+  The metaphor refers to a piece of hardware most programmers have never
+  seen and an action most have never performed. It survives purely as
+  jargon, disconnected from its source. A developer typing `mount -t
+  nfs server:/share /mnt/data` is not thinking about spindles, and the
+  command's name provides no hint of its physical origins. This is
+  classic dead-metaphor territory: the word persists after the world it
+  described has disappeared.
+- **Mount points are invisible** -- in the physical world, you can see
+  where the disk pack sits on the drive. In a Unix filesystem, the mount
+  point is invisible to casual inspection. A directory that serves as a
+  mount point looks identical to any other directory. You need `mount`
+  or `df` to discover the seams. The metaphor imports the idea of a
+  visible attachment point, but the reality is architectural concealment.
+- **Naming inconsistency betrays the strain** -- the inverse operation
+  is variously called `umount` (Unix, missing the 'n' due to a
+  historical typo or character limit), `unmount` (macOS GUI), `eject`
+  (removable media), and `dismount` (VMS, Windows). The metaphor could
+  not settle on whether detachment is un-mounting, dis-mounting, or
+  ejecting, because the physical analogy fractures: you unmount a
+  painting from a wall, dismount from a horse, and eject a cassette.
+  Each verb implies a different physical source.
+- **Plan 9 pushed the metaphor past its limits** -- in Plan 9 from Bell
+  Labs, you can mount a network connection onto the namespace, making
+  remote resources appear local. At this point "mount" no longer maps
+  onto any physical act. You are not attaching a physical object to a
+  physical receptor; you are binding an abstract protocol endpoint to
+  an abstract namespace location. The metaphor has been fully
+  appropriated by its target domain.
+
+## Expressions
+
+- "Mount the drive" -- the original physical action, now used for any
+  filesystem attachment regardless of physical medium
+- "Mount point" -- the directory where a filesystem is grafted into the
+  tree, preserving the spatial metaphor of a specific attachment location
+- "The filesystem is mounted read-only" -- combining the attachment
+  metaphor with the permissions metaphor, as if the mounted object
+  can be looked at but not touched
+- "Unmount before removing the USB drive" -- the safety ritual,
+  descended from the real danger of pulling a spinning disk pack off
+  its spindle
+- "Automount" -- the system mounts filesystems without human
+  intervention, eliminating the operator from a metaphor that was
+  originally about a person performing a physical action
+
+## Origin Story
+
+The term traces directly to the physical operation of mounting disk
+packs on IBM-compatible disk drives in the 1960s. The IBM 2311 and 2314
+drives required an operator to physically place a disk pack onto the
+drive spindle and close the housing. The same term applied to mounting
+tape reels on tape drives. When Thompson and Ritchie designed the Unix
+filesystem in the early 1970s, they used `mount` for the system call
+that attached a filesystem to the directory tree, because the primary
+use case was exactly the physical act: an operator had just mounted a
+disk pack and now needed to make its filesystem accessible.
+
+The `umount` spelling (rather than `unmount`) in Unix is often
+attributed to the 6-character filename limit in early Unix filesystems,
+though this has been disputed. Regardless, the truncated spelling became
+canonical and persists in Linux and BSD systems to this day.
+
+## References
+
+- Thompson, K. & Ritchie, D. "The UNIX Time-Sharing System," CACM
+  17(7), 1974 -- introduces mount as a filesystem operation
+- Ritchie, D. & Thompson, K. "The UNIX Time-Sharing System," Bell
+  System Technical Journal, 1978 -- expanded treatment
+- `mount(2)` man page, man7.org -- current Linux system call
+  documentation
+- Pike, R. et al. "The Use of Name Spaces in Plan 9," 1992 -- the
+  generalization of mount beyond physical media

--- a/catalog/mappings/null-pointer.md
+++ b/catalog/mappings/null-pointer.md
@@ -1,0 +1,150 @@
+---
+author: agent:metaphorex-miner
+categories:
+- computer-science
+- philosophy
+contributors:
+- fshot
+created: '2026-03-15'
+harness: Claude Code
+kind: dead-metaphor
+name: Null Pointer
+related:
+- c-pointer
+- c-string
+slug: null-pointer
+source_frame: embodied-experience
+target_frame: software-programs
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+A pointer that points at nothing -- absence encoded as a special kind
+of presence. From Latin *nullus* (none, not any). In C, NULL is
+typically defined as `((void *)0)`, the zero address, a pointer that
+has been deliberately set to indicate "I point nowhere." The metaphor
+takes the deictic gesture of pointing and applies it to emptiness: the
+finger is extended, but there is nothing at the end of it.
+
+Key structural parallels:
+
+- **Absence as a value** -- in human experience, pointing at nothing is
+  a meaningful gesture. It communicates "there is nothing there" or
+  "I have nothing to show you." NULL serves the same function: it is
+  not the absence of a pointer but a pointer whose value is absence.
+  This distinction matters enormously. A variable that has not been
+  initialized has no defined value. A variable set to NULL has a
+  defined value that means "nothing." The metaphor encodes the
+  philosophical difference between *no answer* and *the answer is
+  nothing*.
+- **The sentinel at the boundary** -- NULL serves as a boundary marker
+  in data structures. A linked list ends when a node's `next` pointer
+  is NULL. A tree's leaves have NULL children. The metaphor maps onto
+  the idea of a sentinel or terminus: a sign that says "nothing beyond
+  this point." The pointing gesture, directed at void, becomes a stop
+  signal.
+- **The trap for the unwary** -- following a null pointer (dereferencing
+  it) crashes the program. The metaphor of a pointer that points at
+  nothing carries an implicit warning: if you follow a finger into the
+  void, you fall. This is why null pointer dereference is the most
+  common crash in C programs and among the most common in any language
+  that allows null references.
+- **The optional value** -- NULL encodes "this might not exist."
+  A function that returns a pointer might return NULL to indicate
+  failure. A struct field might be NULL to indicate "not yet assigned."
+  The metaphor maps optionality onto the pointing gesture: sometimes
+  the finger has something to point at, sometimes it does not.
+
+## Where It Breaks
+
+- **Nothing is not a place** -- in the physical world, pointing at
+  nothing means your finger is extended into empty space. In C, NULL
+  is a specific value (zero) stored in a specific memory location.
+  "Nothing" has a concrete representation, which is philosophically
+  incoherent. The metaphor says "this points nowhere" but the
+  implementation says "this points at address zero." The map and the
+  territory diverge: nowhere has an address.
+- **Null is not safe to follow, but the type system does not prevent
+  it** -- in the physical world, pointing at nothing is harmless. In C,
+  dereferencing NULL causes undefined behavior -- typically a
+  segmentation fault that terminates the program. The metaphor imports
+  the innocuousness of an empty gesture but hides the lethality of
+  the implementation. This mismatch is the source of Tony Hoare's
+  famous regret: he introduced null references in ALGOL W (1965) and
+  later called them his "billion-dollar mistake" because the metaphor
+  made them seem benign.
+- **Null conflates multiple kinds of absence** -- NULL means "not
+  initialized," "not found," "not applicable," "error occurred," and
+  "end of data structure" depending on context. The pointing-at-nothing
+  metaphor provides no way to distinguish between these. In human
+  communication, there is a vast difference between "I have nothing to
+  show you" (empty result), "I refuse to show you" (error), and "I
+  have not looked yet" (uninitialized). NULL collapses all of these
+  into a single value.
+- **Modern languages are abandoning the metaphor** -- Rust has no null;
+  it uses `Option<T>`. Kotlin has nullable types with compile-time
+  checks. Swift has optionals. These languages reject the idea that a
+  pointer can point at nothing, replacing it with an explicit container
+  that either holds a value or does not. The shift from null to
+  `Option` is a shift from "a pointer to nothing" to "a box that might
+  be empty" -- a different metaphor entirely, and one that the type
+  system can enforce.
+- **The zero address is an arbitrary convention** -- NULL is typically
+  zero, but there is no deep reason why the absence of a referent
+  should be represented by the number zero. Some historical systems
+  used different null representations. The metaphor of "pointing at
+  nothing" is clean and intuitive, but it is implemented by a numeric
+  convention that has no metaphorical justification.
+
+## Expressions
+
+- "Null pointer exception" -- the most common runtime error in C-family
+  languages, caused by following a pointer that points at nothing
+  (Java uses NullPointerException, though Java does not have pointers
+  in the C sense)
+- "Check for null" -- the defensive programming ritual of verifying
+  that a pointer actually points at something before following it
+- "The billion-dollar mistake" -- Tony Hoare's name for his invention
+  of null references, measuring the cumulative cost of null-related
+  bugs across the history of software
+- "Null-terminated" -- using NULL as an end-of-data marker, as in C
+  strings, where the pointing-at-nothing metaphor becomes a stop sign
+- "Nullable" -- a type system annotation indicating that a value might
+  be null, making the possibility of absence explicit in the type
+- "Segfault on null deref" -- the terse diagnostic for the most
+  common consequence of following a pointer into the void
+
+## Origin Story
+
+Tony Hoare introduced null references in ALGOL W in 1965, describing
+the decision decades later in his 2009 QCon talk: "I call it my
+billion-dollar mistake. It was the invention of the null reference in
+1965. At that time, I was designing the first comprehensive type system
+for references in an object oriented language (ALGOL W). My goal was to
+ensure that all use of references should be absolutely safe, with
+checking performed automatically by the compiler. But I couldn't resist
+the temptation to put in a null reference, simply because it was so
+easy to implement."
+
+C inherited the concept through its lineage from BCPL and B. In C, NULL
+is a macro defined in `<stddef.h>`, typically expanding to `((void *)0)`.
+The choice of address zero as the null value was pragmatic: on most
+systems, address zero is not a valid data location, so dereferencing it
+reliably produces a fault rather than silent corruption.
+
+The metaphor has proven so problematic that the history of programming
+language design since the 1990s can partly be read as a series of
+attempts to eliminate null: option types in ML (1973), Maybe in Haskell
+(1990), Optional in Java 8 (2014), Option in Rust (2015). Each
+represents a rejection of the "pointer to nothing" metaphor in favor of
+an explicit "presence or absence" container.
+
+## References
+
+- Hoare, C.A.R. "Null References: The Billion Dollar Mistake," QCon
+  London, 2009 -- the creator's retrospective on null
+- Kernighan, B. & Ritchie, D. *The C Programming Language*, 1978/1988
+  -- defines NULL and its conventions in C
+- Ritchie, D. "The Development of the C Language," ACM SIGPLAN, 1993
+  -- the lineage from BCPL through B to C


### PR DESCRIPTION
## Summary

- **filesystem-mount** (dead-metaphor): Physical disk pack mounting mapped onto filesystem attachment. Closes #300
- **file-permissions** (dead-metaphor): Social permission-granting mapped onto Unix rwx/owner/group/others access control. Closes #301
- **c-pointer** (dead-metaphor): The deictic gesture (pointing a finger) mapped onto memory addresses in C. Closes #302
- **null-pointer** (dead-metaphor): Absence encoded as a pointer to nothing, with Hoare's "billion-dollar mistake" context. Closes #303
- **c-string** (dead-metaphor): Beads on a string mapped onto null-terminated character arrays. Closes #304

All five are sub-issues of project #9 (Unix design philosophy and C language metaphors). Covers parts of Batch 2 (filesystem: mount, permissions) and Batch 5 (C language: pointer, null-pointer, string) from the playbook.

No new frames or categories needed -- all referenced frames and categories already exist in the catalog.

## Validator output

```
All content valid.
```

24 pre-existing dangling-reference warnings (unrelated to this PR).

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors
- [ ] Review "Where It Breaks" sections for substance
- [ ] Verify expressions come from real usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)