### PR TITLE
Add 5 Unix/C mappings: plumbing, environment, process family

### DIFF
--- a/catalog/mappings/environment-variable.md
+++ b/catalog/mappings/environment-variable.md
@@ -1,0 +1,142 @@
+---
+author: agent:metaphorex-miner
+categories:
+- computer-science
+contributors: []
+created: '2026-03-15'
+harness: Claude Code
+kind: dead-metaphor
+name: Environment Variable
+related:
+- process-parent-child
+slug: environment-variable
+source_frame: embodied-experience
+target_frame: software-programs
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+An environment is the surroundings in which an organism lives -- the
+air, temperature, terrain, and conditions that shape its behavior
+without being part of the organism itself. In Unix, a process's
+environment is a set of key-value pairs -- `PATH`, `HOME`, `LANG`,
+`EDITOR` -- that provide context for execution without being part of
+the program's code. The ecological metaphor maps precisely: the
+program adapts to its environment, different environments produce
+different behaviors from the same program, and the environment exists
+independently of the organism that inhabits it.
+
+- **Context that shapes behavior** -- an organism behaves differently
+  in different environments: a plant grows toward light, an animal
+  migrates with temperature. A program reads `PATH` to find executables,
+  `HOME` to find configuration, `LANG` to choose a language. The
+  metaphor imports the idea that behavior is a function of context, not
+  just code. The same binary, placed in a different environment, will
+  behave differently -- just as the same species, placed in a different
+  habitat, will develop differently.
+- **Inheritance as a biological given** -- organisms inherit their
+  environment from their parents in two senses: genetically (nature)
+  and spatially (they are born into the parent's habitat). Unix
+  processes inherit their environment from their parent process via
+  `fork()`. The child gets a copy of the parent's environment
+  variables, just as a child organism is born into the parent's
+  ecological niche. The metaphor layers a biological inheritance model
+  on top of a spatial one: the child "lives in" the same environment
+  the parent established.
+- **Exporting to the surroundings** -- the `export` command makes a
+  shell variable part of the environment, available to child processes.
+  The metaphor frames this as placing something into the shared
+  surroundings rather than passing it directly. The variable is not
+  sent to a specific recipient; it is published into the environment
+  where any process that looks for it can find it. This is structurally
+  different from function arguments or message passing, and the
+  ecological metaphor captures the distinction: environment is ambient,
+  not targeted.
+- **The environment is mutable but inherited as a snapshot** -- a
+  parent process can modify its environment, and children forked after
+  the modification inherit the updated version. But the child gets a
+  copy, not a reference. Changes the child makes do not affect the
+  parent, and changes the parent makes after forking do not reach the
+  child. This is like an organism that develops in the environment it
+  was born into: the world changes around it, but the organism's
+  formative conditions are fixed at birth.
+
+## Where It Breaks
+
+- **Real environments are continuous and complex; process environments
+  are flat key-value stores** -- an ecological environment is a rich,
+  interconnected web of factors: temperature gradients, predator-prey
+  relationships, nutrient cycles, weather patterns. A Unix process
+  environment is a flat list of strings. There is no structure, no
+  interaction between variables, no gradients. The metaphor imports the
+  richness and complexity of "environment" but the actual mechanism is
+  closer to a configuration file than to an ecosystem.
+- **Organisms sense their environment; programs must be told what to
+  look for** -- an organism continuously monitors its environment
+  through evolved senses. A program only reads the specific variables
+  it was coded to check. If a program does not look for `LANG`, the
+  locale setting has no effect on it. There is no general-purpose
+  "sensing" of the environment -- only explicit lookups of known keys.
+  The metaphor suggests an ambient awareness that does not exist.
+- **The metaphor hides a security surface** -- because "environment"
+  sounds natural and benign, programmers often treat environment
+  variables as safe. But the environment is inherited by all child
+  processes, which means secrets placed in environment variables
+  (database passwords, API keys) propagate to every subprocess,
+  including ones that might log them or pass them to untrusted code.
+  The ecological metaphor frames the environment as a neutral context,
+  obscuring the fact that it is a broadcast channel with no access
+  control.
+- **There is no environment outside the process tree** -- in ecology,
+  the environment exists independently of the organisms in it. The
+  ocean does not cease to exist when the fish die. But a Unix
+  environment exists only within the process tree. When the root
+  process terminates, its environment is gone. Environment variables
+  are not properties of the system; they are properties of the process.
+  The metaphor's suggestion of an independent, persistent context is
+  misleading.
+
+## Expressions
+
+- "Set the environment" -- configure the context in which a process
+  will run, borrowing the ecological idea of preparing a habitat
+- "Export the variable" -- make a shell variable available to child
+  processes, using trade/commerce language layered on the ecological
+  base metaphor
+- "The program reads from the environment" -- describing variable
+  lookup as sensory perception of surroundings
+- "Clean environment" -- an execution context stripped of inherited
+  variables, as if the habitat had been sanitized
+- "Environment pollution" -- too many or conflicting environment
+  variables contaminating the execution context, extending the
+  ecological metaphor to environmental science
+
+## Origin Story
+
+The concept of a process environment was introduced in early Unix at
+Bell Labs in the 1970s. The `environ` variable (an array of strings in
+the format `KEY=VALUE`) was part of the C runtime from the earliest
+versions. The 1978 Seventh Edition of Unix formalized environment
+variables as part of the process model, and the Bourne shell's `export`
+built-in gave users a direct way to manage them.
+
+The ecological metaphor was implicit in the naming: "environment" was
+chosen because these variables provide the context -- the surroundings
+-- in which a program operates. The term was not controversial or
+novel; it felt obvious. That very obviousness is what makes it a dead
+metaphor: programmers use "environment variable" as a purely technical
+term without ever thinking about ecological habitats, organisms, or
+adaptation. The metaphor succeeded so thoroughly that it became
+invisible.
+
+## References
+
+- Kernighan, B. & Ritchie, D. *The C Programming Language* (1978/1988)
+  -- documents the `environ` interface
+- Thompson, K. & Ritchie, D. "The UNIX Time-Sharing System," CACM
+  17(7), 1974 -- the foundational paper on Unix's process model
+- Bourne, S.R. "The UNIX Shell," Bell System Technical Journal 57(6),
+  1978 -- introduces the `export` mechanism for environment variables
+- Stevens, W. R. *Advanced Programming in the UNIX Environment* (1992)
+  -- canonical treatment of process environments and inheritance

--- a/catalog/mappings/memory-leak.md
+++ b/catalog/mappings/memory-leak.md
@@ -1,0 +1,144 @@
+---
+author: agent:metaphorex-miner
+categories:
+- computer-science
+- systems-thinking
+contributors: []
+created: '2026-03-15'
+harness: Claude Code
+kind: dead-metaphor
+name: Memory Leak
+related:
+- data-flow-is-fluid-flow
+- unix-pipe
+- zombie-process
+slug: memory-leak
+source_frame: fluid-dynamics
+target_frame: software-programs
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+A leak is a failure of containment. A pipe, a bucket, a roof -- the
+container is supposed to hold or channel fluid, but a flaw lets it
+escape, dripping away unnoticed until the vessel is empty or the floor
+is flooded. In software, a memory leak is a program that allocates
+memory and never releases it, so the available pool gradually drains
+away. The fluid metaphor maps the structure precisely: memory "leaks
+out" of the program's control, the system slowly "runs dry," and the
+damage is proportional to time -- a small leak is harmless for minutes
+but fatal over days.
+
+- **Gradual, invisible loss** -- a plumbing leak is dangerous because
+  it is small enough to go unnoticed. You do not see the water seeping
+  into the wall; you see the mold months later. A memory leak has the
+  same temporal signature: the program works fine at first. Hours or
+  days later, it slows, swaps, and eventually crashes or is killed by
+  the operating system's out-of-memory handler. The metaphor imports
+  the crucial idea that the damage is cumulative and silent.
+- **The container is at fault, not the fluid** -- water does not choose
+  to leak; the pipe has a crack. Memory does not choose to be lost; the
+  program has a bug. The metaphor correctly places blame on the
+  container (the code that should have called `free()` or released the
+  reference) rather than on the resource itself. This is structurally
+  important because it frames memory leaks as engineering failures, not
+  as inherent properties of the system.
+- **Draining a shared pool** -- a leaking pipe does not just empty
+  itself; it depletes the water supply or floods the neighbor's ceiling.
+  A leaking program depletes system memory, degrading performance for
+  every other process. The metaphor imports the externality: your leak
+  is everyone's problem. This maps onto real system administration
+  scenarios where one leaking service gradually starves unrelated
+  processes of memory.
+- **The vocabulary extends naturally** -- once you have "leak," the rest
+  of the plumbing vocabulary follows. You "plug" leaks. You use leak
+  "detectors" (Valgrind, AddressSanitizer). You check for leaks by
+  "pressure testing" (running the program under load). A program that
+  leaks is "dripping" resources. The metaphor is not a single mapping
+  but a productive system that generates diagnostic language.
+
+## Where It Breaks
+
+- **Memory does not go anywhere** -- a real leak moves fluid from one
+  place to another. Water that leaks from a pipe ends up on the floor.
+  But leaked memory does not leave the system; it is still there in
+  RAM, allocated to the process, just unreachable by the program that
+  allocated it. The "leak" is a failure of bookkeeping, not a failure
+  of containment. Nothing is escaping; something is being forgotten.
+  The metaphor imports the image of substance flowing away, but the
+  actual problem is lost references, not lost memory.
+- **The metaphor obscures the mechanism** -- plumbing leaks have a
+  physical location: the crack in the pipe, the worn gasket, the loose
+  fitting. Memory leaks have no spatial location. They are failures in
+  control flow -- a code path that allocates without freeing, a
+  reference cycle that prevents garbage collection, an event handler
+  that registers but never unregisters. The plumbing metaphor encourages
+  thinking about "where" the leak is, but the real question is "when" --
+  at what point in the program's execution does the allocation outlive
+  its usefulness.
+- **Not all resource exhaustion is a leak** -- the metaphor has expanded
+  to cover any situation where a program uses more memory over time. But
+  some of these are not leaks in any structural sense. A program that
+  caches results indefinitely is not leaking; it is hoarding. A program
+  whose data set genuinely grows is not leaking; it is filling up. The
+  "leak" metaphor frames all memory growth as pathological, when some of
+  it is intentional and correct. This leads to false diagnoses: calling
+  something a "leak" when the real problem is that the container is too
+  small for the legitimate contents.
+- **Garbage-collected languages changed the plumbing** -- in C, memory
+  leaks are literally about forgetting to call `free()`. The plumbing
+  metaphor was coined for this world. In garbage-collected languages
+  (Java, Python, Go), memory leaks happen when objects remain reachable
+  but are no longer needed -- the garbage collector cannot reclaim them
+  because something still holds a reference. The "leak" is now about
+  unintended references, not about missing deallocation calls. The
+  plumbing metaphor survived this transition but fits less well: it is
+  not a crack in a pipe but a hose that nobody thought to disconnect.
+
+## Expressions
+
+- "You've got a memory leak" -- the standard diagnostic, delivered with
+  the same tone a plumber uses to tell you your pipes are leaking
+- "Leaking file handles / connections / sockets" -- the metaphor
+  extended from memory to any resource that is allocated but not
+  released, all described with the same plumbing vocabulary
+- "Plug the leak" -- fix the code path that fails to deallocate
+- "Slow leak" -- a memory leak that accumulates gradually enough that
+  the program can run for hours or days before the effects become
+  visible, directly borrowing the plumbing distinction between a
+  dripping faucet and a burst pipe
+- "Leak detector" -- a tool like Valgrind or LeakSanitizer, named as
+  though it were a physical instrument for finding cracks in pipes
+
+## Origin Story
+
+The term "memory leak" emerged from C programming culture in the 1970s
+and 1980s, when manual memory management with `malloc()` and `free()`
+was the only option. C's memory model made leaks easy to create and hard
+to find: every allocation required a corresponding deallocation, and
+any code path that skipped the `free()` call created a leak. The term
+was well established by the time W. Richard Stevens and other Unix
+systems programming authors codified it in the late 1980s and early
+1990s.
+
+The plumbing metaphor was natural because Unix's broader vocabulary
+already drew heavily on fluid dynamics -- pipes, streams, filters,
+drains, sinks. "Leak" extended this existing metaphorical system to
+describe a failure mode. The term survived the transition to garbage-
+collected languages, where it was repurposed to describe a different
+mechanism (retained references rather than missing `free()` calls) with
+the same observable symptom (growing memory usage over time).
+
+## References
+
+- Kernighan, B. & Ritchie, D. *The C Programming Language* (1978/1988)
+  -- the canonical description of `malloc()` and `free()` whose misuse
+  creates leaks
+- Stevens, W. R. *Advanced Programming in the UNIX Environment* (1992)
+  -- systems programming context for resource management
+- Nethercote, N. & Seward, J. "Valgrind: A Framework for Heavyweight
+  Dynamic Binary Instrumentation" (PLDI 2007) -- the most widely used
+  leak detection tool
+- Raymond, E.S. *The Art of Unix Programming* (2003) -- documents the
+  plumbing metaphor family in Unix culture

--- a/catalog/mappings/process-parent-child.md
+++ b/catalog/mappings/process-parent-child.md
@@ -1,0 +1,170 @@
+---
+author: agent:metaphorex-miner
+categories:
+- computer-science
+contributors: []
+created: '2026-03-15'
+harness: Claude Code
+kind: dead-metaphor
+name: Process Parent-Child
+related:
+- zombie-process
+- orphan-process
+- environment-variable
+slug: process-parent-child
+source_frame: social-roles
+target_frame: software-programs
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+Human families have parents and children. Parents create children,
+children inherit traits from parents, parents are responsible for
+children, and when parents die, children become orphans. Unix processes
+use this exact vocabulary: `fork()` creates a child process from a
+parent, the child inherits the parent's memory, file descriptors, and
+environment variables, the parent can `wait()` for the child, and if
+the parent terminates first, the child is "adopted" by `init`. The
+family metaphor is one of the most internally consistent metaphor
+systems in all of computing -- it extends across the entire process
+lifecycle with remarkable structural fidelity.
+
+- **Creation through division** -- `fork()` creates a child by cloning
+  the parent. The child begins as an exact copy, then diverges. This
+  maps biological reproduction more closely than most software metaphors
+  manage: the child inherits everything from the parent and then
+  develops independently. The "fork" itself is a different metaphor
+  (a road forking in two), but the parent-child relationship that
+  results is purely familial.
+- **Inheritance is automatic and comprehensive** -- a human child
+  inherits genes, household, language, and social context from its
+  parents. A Unix child process inherits the parent's memory image,
+  open file descriptors, environment variables, working directory,
+  signal handlers, and process group. The metaphor maps the
+  comprehensiveness of biological inheritance: the child does not
+  choose what to inherit. It gets everything, and then selectively
+  modifies what it needs to change (typically via `exec()`).
+- **Parental responsibility** -- parents are responsible for their
+  children. In Unix, this responsibility has a specific technical form:
+  the parent must call `wait()` to retrieve the child's exit status.
+  If the parent fails this duty, the child becomes a zombie -- dead
+  but not properly buried. The metaphor imports the moral dimension
+  of parenting: there are consequences for neglecting your children.
+- **The orphan and the foster parent** -- when a parent dies, the
+  children become orphans. In Unix, when a parent process terminates,
+  its children are "adopted" by the `init` process (PID 1), which
+  assumes responsibility for reaping them. The metaphor is structurally
+  precise: init is the system's foster parent, the process of last
+  resort that takes in any child whose biological parent has died. This
+  adoption mechanism prevents permanent orphans and permanent zombies.
+- **The family tree** -- processes form a tree rooted at `init`.
+  Every process (except init) has exactly one parent. Parents can have
+  many children. The tree can be displayed with `pstree`. The family
+  metaphor extends naturally to this genealogical structure: you can
+  trace any process's ancestry back to init, just as you can trace a
+  family line.
+
+## Where It Breaks
+
+- **Children do not choose to be born; child processes are created
+  intentionally** -- in the human family, children have no agency in
+  their creation. But in Unix, it is the parent's code that calls
+  `fork()`. There is no accident, no biology, no desire -- just a
+  system call. The familial language imports emotional and moral
+  resonance (responsibility, care, abandonment) onto what is a
+  purely mechanical operation. When we say a parent "abandons" its
+  children by exiting without calling `wait()`, we are importing a
+  moral judgment that has no meaning in the domain of process management.
+- **The metaphor generates disturbing sentences** -- because the
+  family vocabulary is comprehensive, operational descriptions of
+  process management become inadvertently disturbing when read
+  literally. "Kill the parent to clean up the zombies." "The parent
+  spawns children, waits for them to die, then reaps them." "If the
+  parent dies first, init adopts the orphans." These sentences are
+  technically precise and emotionally grotesque. The metaphor works
+  structurally but creates a narrative that, if taken at face value,
+  describes child abuse and mass infanticide.
+- **Real families are bidirectional; Unix process relationships are
+  not** -- in human families, children affect parents as much as
+  parents affect children. Communication is bidirectional, influence
+  flows both ways, and the relationship evolves over time. In Unix,
+  the parent-child relationship is heavily asymmetric. The parent can
+  `wait()` for the child and receive its exit status, but the child
+  has no built-in mechanism to communicate with the parent except
+  through its exit code (a single integer). The family metaphor
+  suggests a rich, ongoing relationship where the actual mechanism
+  provides only a one-shot, one-byte farewell.
+- **Adoption by init is nothing like human adoption** -- when init
+  adopts orphan processes, it does so automatically and without any
+  of the features of human adoption: no selection, no bonding, no
+  ongoing relationship. Init's only role is to call `wait()` when
+  the orphan terminates, cleaning up the zombie. This is more like
+  a municipal cremation service than a foster family. The adoption
+  metaphor imports warmth and care that the mechanism does not provide.
+- **The metaphor obscures process groups and sessions** -- real Unix
+  process management involves process groups, sessions, controlling
+  terminals, and signal routing that have no family analogy. When a
+  terminal is closed, the entire session receives SIGHUP -- but the
+  "family" metaphor provides no vocabulary for "all the relatives in
+  this household." The metaphor covers the parent-child dyad well but
+  breaks down for the collective structures that actually govern
+  process lifecycle in practice.
+
+## Expressions
+
+- "Parent process" / "child process" -- the fundamental terminology,
+  used so universally that most programmers do not register the family
+  metaphor
+- "Fork a child" -- create a new process via `fork()`, blending the
+  road-splitting metaphor of "fork" with the familial metaphor of
+  "child"
+- "The parent waits for the child" -- describing the `wait()` system
+  call, which blocks until the child terminates
+- "Orphan process" -- a process whose parent has terminated, adopted
+  by init
+- "Zombie process" -- a terminated child whose parent has not yet
+  called `wait()`, layering horror-genre metaphor onto the family
+  metaphor
+- "Reap the children" -- call `wait()` to clean up terminated child
+  processes, adding an agricultural/funerary metaphor on top of the
+  family structure
+- "Daemonize by double-forking" -- the standard Unix technique for
+  creating a background process: fork, let the parent exit (making
+  the child an orphan adopted by init), then fork again. The family
+  metaphor makes this legible: abandon your child so it gets adopted
+  by the system
+
+## Origin Story
+
+The parent-child process model was designed by Ken Thompson and Dennis
+Ritchie at Bell Labs as part of the original Unix system (1969-1971).
+The `fork()` system call, which creates a child process by duplicating
+the parent, was Unix's distinctive contribution to operating system
+design. Earlier systems created processes differently -- often by
+loading a new program from scratch rather than cloning an existing
+process.
+
+The family terminology was a natural fit for the cloning mechanism:
+the child starts as a copy of the parent and then diverges. Thompson
+and Ritchie's choice of "parent" and "child" (rather than, say,
+"original" and "copy") encoded a relationship of responsibility and
+lifecycle into the vocabulary. The subsequent terms -- orphan, zombie,
+adopt, reap, inherit -- extended the family metaphor into a complete
+system that covers every state a process can occupy from creation to
+cleanup. The remarkable internal consistency of this metaphor system
+is one reason it has persisted unchanged for over fifty years.
+
+## References
+
+- Thompson, K. & Ritchie, D. "The UNIX Time-Sharing System," CACM
+  17(7), 1974 -- introduces the fork/wait/exec process model
+- Ritchie, D. & Thompson, K. "The UNIX Time-Sharing System," Bell
+  System Technical Journal 57(6), 1978 -- expanded treatment
+- Stevens, W. R. *Advanced Programming in the UNIX Environment*
+  (1992) -- canonical description of process lifecycle, including
+  orphans, zombies, and process groups
+- Kerrisk, M. *The Linux Programming Interface* (2010) -- modern
+  treatment with detailed coverage of process relationships
+- Bach, M. J. *The Design of the UNIX Operating System* (1986) --
+  early formal treatment of the process model

--- a/catalog/mappings/unix-filter.md
+++ b/catalog/mappings/unix-filter.md
@@ -1,0 +1,138 @@
+---
+author: agent:metaphorex-miner
+categories:
+- computer-science
+contributors: []
+created: '2026-03-15'
+harness: Claude Code
+kind: dead-metaphor
+name: Unix Filter
+related:
+- unix-pipe
+- unix-tee
+- data-flow-is-fluid-flow
+- the-pipeline-pattern
+slug: unix-filter
+source_frame: fluid-dynamics
+target_frame: data-processing
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+A physical filter lets desired material through and blocks the rest.
+A coffee filter passes water and retains grounds. A water purifier
+passes clean water and traps sediment. In Unix, a filter is a program
+that reads from standard input, transforms or selects from the data,
+and writes the result to standard output. `grep`, `sort`, `uniq`,
+`awk`, `sed`, `cut`, `tr`, `wc` -- the core Unix toolkit consists
+almost entirely of filters. The plumbing metaphor maps cleanly: data
+flows in, gets processed, flows out. The filter sits inside the pipe.
+
+- **Selective passage** -- the defining feature of a physical filter is
+  discrimination: it lets some things through and blocks others. `grep`
+  is the purest expression of this: it passes lines matching a pattern
+  and discards everything else. `uniq` passes unique lines and discards
+  duplicates. The metaphor gives programmers an immediate mental model
+  for what these tools do, without requiring any explanation of the
+  implementation.
+- **Transparency of the interface** -- a physical filter does not change
+  the nature of the fluid; water goes in and water comes out, just
+  cleaner. Unix filters maintain this property: text goes in and text
+  comes out. The filter's contract is that it will not change the
+  medium, only the content. This constraint -- inherited from the
+  metaphor -- is what makes filters composable. You can chain any
+  number of filters because they all speak the same medium: lines
+  of text.
+- **Part of the plumbing system** -- a filter makes no sense in
+  isolation. It is a component designed to sit between a source and
+  a sink, connected by pipes. The metaphor imports this compositional
+  identity: Unix filters are not standalone applications. They are
+  designed to be connected. McIlroy's garden hose vision -- "screw
+  in another segment" -- is realized most fully in the filter pattern,
+  where each program is a segment of pipe that transforms the flow.
+- **The design philosophy encoded in the name** -- calling these programs
+  "filters" rather than "transformers" or "processors" was a naming
+  decision that carried design implications. A filter is small, passive,
+  and single-purpose. It does one thing to the flow and passes it along.
+  The metaphor discouraged writing large, monolithic programs and
+  encouraged the Unix philosophy of small, composable tools. The name
+  shaped the culture.
+
+## Where It Breaks
+
+- **Most Unix "filters" do not filter** -- `sort` rearranges all input;
+  nothing is blocked. `tr` translates characters; nothing is removed
+  (unless you use the delete flag). `awk` is a full programming language
+  that can generate output bearing no resemblance to its input. Calling
+  these programs "filters" stretches the metaphor past its breaking
+  point. The term has drifted from "selective passage" to "any program
+  that reads stdin and writes stdout," which is a much broader concept
+  than filtering. The metaphor names the simplest case (`grep`) and
+  ignores the majority.
+- **Physical filters are passive; Unix filters are active** -- a coffee
+  filter does not do anything to the water; it simply has pores that are
+  too small for grounds to pass through. But `sed` actively rewrites
+  text. `awk` performs computations. `sort` reorders the entire stream.
+  These are active transformations, not passive selections. The filter
+  metaphor imports a false passivity -- as if the data is simply
+  flowing through a screen, when in reality the program is actively
+  manipulating it.
+- **The metaphor obscures state** -- a physical filter has no memory.
+  Each drop of water passes through independently. But many Unix
+  "filters" are stateful: `sort` must read all input before producing
+  any output. `uniq` must remember the previous line. `awk` can
+  maintain variables across its entire run. The metaphor suggests a
+  streaming, memoryless operation that many filters do not actually
+  provide, which leads to confusion when pipelines stall because
+  `sort` is buffering the entire input.
+- **Binary data breaks the metaphor entirely** -- the filter metaphor
+  assumes a homogeneous medium (water) flowing through. But Unix
+  commands process text, and when binary data enters the pipeline,
+  the "filtration" metaphor provides no guidance. Null bytes, encoding
+  mismatches, and binary-vs-text ambiguity are problems the plumbing
+  metaphor cannot express, because physical pipes do not care about
+  the structure of what flows through them.
+
+## Expressions
+
+- "Pipe it through a filter" -- the standard idiom for inserting a
+  processing step into a pipeline
+- "Unix filter" -- the category name for any stdin-to-stdout program,
+  regardless of whether it actually filters anything
+- "Write it as a filter" -- design advice meaning "make your program
+  read stdin and write stdout so it composes with pipes"
+- "Filter chain" -- a sequence of filters connected by pipes, the
+  plumbing metaphor applied to the composite structure
+- "The output is unfiltered" -- using the metaphor negatively, meaning
+  raw, unprocessed data has been presented without selection or
+  transformation
+
+## Origin Story
+
+The term "filter" for a data-processing program predates Unix but was
+cemented by Unix's pipe-and-filter architecture in the 1970s. McIlroy's
+1964 memo on program interconnection described the vision; when
+Thompson implemented pipes in 1973, the existing toolkit of small text
+processing programs (`grep`, `sort`, `wc`) retroactively became
+"filters" -- components of a plumbing system. The 1978 Kernighan and
+Pike *The Unix Programming Environment* formalized the filter concept
+and established it as a design principle: write programs that can serve
+as filters. By the 1980s, "filter" had become the standard term in
+software architecture for any component in a pipe-and-filter topology,
+extending far beyond Unix into enterprise integration patterns and
+stream processing frameworks.
+
+## References
+
+- Kernighan, B. & Pike, R. *The Unix Programming Environment*,
+  Prentice Hall, 1984 -- formalizes the filter concept as a design
+  principle
+- McIlroy, M.D. "A Research UNIX Reader," Bell Labs, 1987 -- describes
+  the filter pattern in the context of Unix's evolution
+- Thompson, K. & Ritchie, D. "The UNIX Time-Sharing System," CACM
+  17(7), 1974 -- the paper that introduced pipes, which gave filters
+  their compositional context
+- Garlan, D. & Shaw, M. "An Introduction to Software Architecture,"
+  CMU-CS-94-166, 1994 -- formalizes pipe-and-filter as an architectural
+  style

--- a/catalog/mappings/unix-tee.md
+++ b/catalog/mappings/unix-tee.md
@@ -1,0 +1,125 @@
+---
+author: agent:metaphorex-miner
+categories:
+- computer-science
+contributors: []
+created: '2026-03-15'
+harness: Claude Code
+kind: dead-metaphor
+name: Unix Tee
+related:
+- unix-pipe
+- unix-filter
+- data-flow-is-fluid-flow
+slug: unix-tee
+source_frame: fluid-dynamics
+target_frame: data-processing
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+In plumbing, a tee is a T-shaped pipe fitting that splits a single flow
+into two directions. Water enters from one end and exits from both
+branches simultaneously. The Unix `tee` command does exactly this: it
+reads from standard input and writes to both standard output and one or
+more files at the same time. The naming is one of the most transparently
+metaphorical in all of Unix -- the command is literally named after the
+pipe fitting it emulates.
+
+- **Splitting without losing** -- a tee fitting does not reduce the flow
+  in either branch; both outputs receive the full volume. The `tee`
+  command maintains this property: the data written to the file is
+  identical to the data passed to stdout. Nothing is lost, abbreviated,
+  or transformed in the split. This is the core structural mapping: you
+  can observe the flow at an intermediate point without interrupting it.
+- **Observation without interference** -- in laboratory plumbing, tees
+  are used to attach gauges and sensors to a pipeline without disrupting
+  the flow. The Unix `tee` serves the same function: it lets you inspect
+  intermediate data in a pipeline without altering what the next command
+  receives. This maps the scientific instrumentation use of tees onto
+  debugging: `cmd1 | tee /tmp/debug.txt | cmd2` lets you see what
+  `cmd1` produced without changing what `cmd2` gets.
+- **The shape is the name** -- the letter T and the pipe fitting called
+  a "tee" share their shape: one input, two outputs. The Unix command's
+  name encodes its behavior in a single character. This naming economy
+  is characteristic of Unix's plumbing vocabulary, where the physical
+  shape of the hardware directly describes the data flow topology.
+- **Extending the plumbing system** -- `tee` is the command that proves
+  Unix's pipe metaphor is not just a single mapping but a coherent
+  system. Pipes connect. Filters transform. Tees split. Together they
+  form a vocabulary for describing data flow topologies using plumbing
+  terms. Without `tee`, Unix pipelines would be strictly linear; with
+  it, they can branch, enabling logging, debugging, and parallel
+  processing within the plumbing metaphor.
+
+## Where It Breaks
+
+- **A physical tee splits flow; `tee` duplicates data** -- in plumbing,
+  a tee divides the water: each branch gets roughly half the pressure
+  and flow rate (depending on resistance). The Unix `tee` does not
+  divide anything. It copies the entire stream to both destinations.
+  Both outputs get 100% of the data. This is duplication, not splitting.
+  The metaphor borrows the topology (one input, two outputs) but inverts
+  the physics (division becomes replication). This is invisible in
+  practice but conceptually misleading: data is not fluid, and copying
+  data has no analogy in fluid dynamics.
+- **Physical tees are symmetric; `tee` is not** -- in plumbing, both
+  branches of a tee are equivalent pipe connections. In Unix, the two
+  outputs are fundamentally different: one is stdout (which continues
+  down the pipeline) and the other is a file (which terminates). The
+  metaphor suggests two equivalent branches, but the command implements
+  one primary flow and one side channel. The asymmetry is a design
+  choice that the plumbing metaphor does not prepare you for.
+- **The command is almost trivially simple** -- `tee` does so little
+  that its existence as a separate command reveals the limitations of
+  Unix's pipe model. In a more flexible dataflow system, splitting a
+  stream would be a built-in operation, not a separate program. The
+  fact that Unix needs a dedicated command named after a pipe fitting
+  to accomplish something this basic shows that the plumbing metaphor
+  promised more composability than the pipe implementation delivered.
+- **Nobody thinks about pipe fittings** -- most modern programmers who
+  use `tee` do not know what a tee fitting is. The plumbing reference
+  is opaque to anyone who has not worked with physical pipes. The
+  command's name has become an arbitrary label rather than a mnemonic,
+  which is the hallmark of a dead metaphor: the word survives but the
+  image has been forgotten.
+
+## Expressions
+
+- "Tee it to a file" -- the standard Unix idiom for using `tee` to
+  capture intermediate output, where "tee" functions as a verb
+- "Pipe through tee" -- describing the insertion of `tee` into a
+  pipeline for debugging or logging
+- "Tee off the output" -- a blend of the plumbing metaphor with the
+  golf metaphor, sometimes used to describe branching data flows in
+  general
+- "The tee trick" -- the common pattern of inserting `tee /dev/stderr`
+  or `tee /tmp/debug` into a pipeline to inspect data without breaking
+  the chain
+
+## Origin Story
+
+The `tee` command appeared in early Unix (Version 5, circa 1974) as
+part of the expanding plumbing vocabulary that followed Thompson's
+implementation of pipes. The name was a direct borrowing from plumbing
+terminology: a T-shaped pipe fitting that splits flow. The command was
+simple enough that it barely needed documentation -- the name explained
+its behavior to anyone familiar with plumbing.
+
+The `tee` command is sometimes cited as the purest example of Unix's
+plumbing metaphor because the naming is entirely transparent. While
+"pipe," "filter," and "stream" are generic enough to have multiple
+possible origins, "tee" can only come from plumbing. It is the
+smoking gun that confirms the metaphorical system was deliberate.
+
+## References
+
+- Thompson, K. & Ritchie, D. "The UNIX Time-Sharing System," CACM
+  17(7), 1974 -- the paper that established the pipe-based architecture
+  within which tee operates
+- Kernighan, B. & Pike, R. *The Unix Programming Environment*,
+  Prentice Hall, 1984 -- includes tee as part of the standard toolkit
+- McIlroy, M.D. "A Research UNIX Reader," Bell Labs, 1987 -- context
+  for the plumbing vocabulary
+- tee(1) man page, man7.org -- the command's formal specification


### PR DESCRIPTION
## Summary

- **memory-leak** (#313): unreleased memory as a leaking container (fluid-dynamics -> software-programs)
- **unix-filter** (#315): stdin-to-stdout programs as water filters (fluid-dynamics -> data-processing)
- **unix-tee** (#316): the tee command as a T-shaped pipe fitting (fluid-dynamics -> data-processing)
- **environment-variable** (#317): process execution context as ecological surroundings (embodied-experience -> software-programs)
- **process-parent-child** (#318): process relationships as family relationships (social-roles -> software-programs)

All 5 entries are `dead-metaphor` kind from the unix-c-metaphors project (#9). All required frames already exist in the catalog. No new frames or categories needed.

Closes #313
Closes #315
Closes #316
Closes #317
Closes #318

## Validator output

```
24 warning(s) (dangling references, non-blocking) -- all pre-existing
All content valid.
```

Zero errors, zero new warnings.

## Test plan

- [ ] Verify validator passes with zero errors
- [ ] Check frontmatter fields match schema (slug, kind, frames, categories)
- [ ] Verify all referenced frames exist
- [ ] Verify all `related:` entries exist
- [ ] Review "Where It Breaks" sections for substance

Generated with [Claude Code](https://claude.com/claude-code)