### PR TITLE
Add 5 mappings: causation/change cluster (cognitive-linguistics-canon)

### DIFF
--- a/catalog/mappings/causation-is-control-over-an-object-relative-to-a-possessor.md
+++ b/catalog/mappings/causation-is-control-over-an-object-relative-to-a-possessor.md
@@ -1,0 +1,154 @@
+---
+author: agent:metaphorex-miner
+categories:
+- cognitive-science
+- linguistics
+- philosophy
+contributors: []
+created: '2026-03-15'
+harness: Claude Code
+kind: conceptual-metaphor
+name: Causation Is Control Over An Object Relative To A Possessor
+provenance: osaka-master-metaphor-list
+related:
+- causation-is-commercial-transaction
+- action-is-control-over-possessions
+- causes-are-forces
+- properties-are-possessions
+- acting-on-is-transferring-an-object
+slug: causation-is-control-over-an-object-relative-to-a-possessor
+source_frame: economics
+target_frame: causal-reasoning
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+To cause something is to control what someone else has. This metaphor
+maps the three-party dynamics of possession -- an agent, an object, and
+a possessor -- onto the structure of causation. The causal agent does
+not merely produce an effect in the abstract; the agent controls an
+object that belongs to, or is destined for, a specific affected party.
+This gives causation a transitive, interpersonal shape: causing is doing
+something to someone's stuff.
+
+The metaphor is the object-case counterpart within the broader causation
+cluster. Where CAUSES ARE FORCES treats causation as direct physical
+impact and CAUSATION IS COMMERCIAL TRANSACTION treats it as market
+exchange, this mapping focuses on the asymmetry between the one who
+controls and the one who possesses. It structures situations where
+causation involves a third party whose interests are at stake.
+
+Key structural parallels:
+
+- **Causing as giving or withholding** -- "She gave him a headache."
+  "He denied them the opportunity." "The policy afforded workers new
+  protections." The causal agent transfers an object (the effect) to
+  the affected party, or prevents the transfer. This frames causation
+  as a gift economy of effects: someone bestows or withholds outcomes
+  that belong, by right or expectation, to someone else.
+
+- **Causal power as control over someone's resources** -- "The drought
+  robbed farmers of their livelihood." "The new law granted citizens
+  greater freedom." "His decision deprived the team of their best
+  player." The causal agent manipulates objects (outcomes, states,
+  resources) that are identified with a specific possessor. To cause
+  harm is to take away what someone has; to cause benefit is to give
+  them something they lacked.
+
+- **Indirect causation as mediated control** -- "The tax cut put money
+  back in people's pockets." "The scandal cost her the election."
+  "The reform delivered results to voters." The causal agent does not
+  act on the possessor directly but on the object, which then affects
+  the possessor. This three-way structure captures causation that
+  operates through intermediary effects.
+
+- **Responsibility as custody** -- "He was entrusted with their safety."
+  "She holds their fate in her hands." "The committee controls the
+  allocation of funds." When causation is mapped onto control over
+  someone's possessions, causal responsibility becomes a custodial
+  relationship. The agent is accountable not just for what they did but
+  for what they did to someone else's things.
+
+## Where It Breaks
+
+- **Causation without a possessor** -- many causal relationships have
+  no identifiable third party. Gravity causes objects to fall, but
+  there is no "possessor" of the falling. Natural causation, especially
+  in physics, resists the three-party structure. The metaphor forces a
+  search for a victim or beneficiary even when the effect is impersonal.
+
+- **The metaphor smuggles in entitlement** -- if effects are objects
+  relative to a possessor, then the possessor seems to have a prior
+  claim on the outcome. "He took away their chance" implies they owned
+  the chance to begin with. This creates a sense of entitlement to
+  outcomes that may never have been guaranteed, making any change in
+  circumstances feel like theft.
+
+- **Distributed causation resists the custodial frame** -- when many
+  agents contribute to an effect, the metaphor struggles. Who "controls"
+  the object? Climate change, for instance, harms millions, but no
+  single agent holds the relevant object. The three-party structure
+  demands identifiable controllers and possessors, pushing toward
+  oversimplified blame attribution.
+
+- **The asymmetry obscures mutual causation** -- the metaphor positions
+  one party as controller and another as possessor, creating a power
+  differential. But many causal relationships are reciprocal: two people
+  in a conversation cause effects on each other simultaneously. The
+  controller-possessor structure cannot represent symmetric causation
+  without awkwardly doubling itself.
+
+- **Self-causation becomes paradoxical** -- if causing is controlling
+  someone else's possessions, then causing something in yourself means
+  controlling your own possessions, which collapses the three-party
+  structure into reflexivity. "She gave herself confidence" sounds
+  natural but strains the mapping: who is the controller, who is the
+  possessor, and who is the object?
+
+## Expressions
+
+- "She gave him a headache" -- causing a state as transferring an object
+  to a possessor
+- "The drought robbed farmers of their livelihood" -- harmful causation
+  as theft from a possessor
+- "The new law granted citizens greater freedom" -- beneficial causation
+  as bestowing a possession
+- "His decision deprived the team of their best player" -- causation as
+  taking away what someone has
+- "The tax cut put money back in people's pockets" -- indirect causation
+  as returning an object to its owner
+- "She holds their fate in her hands" -- causal power as physical control
+  over someone's object
+- "The scandal cost her the election" -- harm as forced loss of a valued
+  possession
+- "He was entrusted with their safety" -- causal responsibility as
+  custodianship
+- "The policy afforded workers new protections" -- beneficial causation
+  as supplying possessions
+- "They denied us the chance" -- preventing an outcome as withholding an
+  object from its rightful possessor
+
+## Origin Story
+
+This metaphor is documented in the Master Metaphor List (Lakoff,
+Espenson & Schwartz 1991) as part of the causation metaphor cluster. It
+belongs to the object case of the Event Structure metaphor system, where
+attributes are possessions and changes are transfers of objects. The
+specific addition here is the third-party possessor: causation is not
+just moving objects around, but moving objects that belong to someone.
+This three-party structure reflects the embodied experience of early
+childhood, where a caregiver controls objects that the child wants or
+has -- giving a toy, taking away a bottle, offering food. The child
+learns causation partly through watching a more powerful agent manipulate
+objects that matter to the child, creating the prototype for all later
+understanding of causation as someone controlling what someone else has.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Causation Is Control Over An Object Relative To A Possessor"
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999), Chapter 11
+  -- the Event Structure metaphor system, object case
+- Lakoff, G. & Johnson, M. *Metaphors We Live By* (1980) -- ontological
+  metaphors involving objects and possession

--- a/catalog/mappings/causation-is-control-over-relative-location.md
+++ b/catalog/mappings/causation-is-control-over-relative-location.md
@@ -1,0 +1,162 @@
+---
+author: agent:metaphorex-miner
+categories:
+- cognitive-science
+- linguistics
+- philosophy
+contributors: []
+created: '2026-03-15'
+harness: Claude Code
+kind: conceptual-metaphor
+name: Causation Is Control Over Relative Location
+provenance: osaka-master-metaphor-list
+related:
+- causes-are-forces
+- states-are-locations
+- change-is-motion
+- causation-is-control-over-an-object-relative-to-a-possessor
+- difficulties-are-impediments-to-motion
+slug: causation-is-control-over-relative-location
+source_frame: spatial-location
+target_frame: causal-reasoning
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+To cause something is to put it somewhere -- or to keep it from getting
+there. This metaphor maps the spatial dynamics of positioning onto
+causation. If STATES ARE LOCATIONS (a foundational mapping in the Event
+Structure system), then causing a change of state is moving something
+from one location to another, and causal power is the ability to control
+where things end up. The causal agent is the one who places, moves,
+blocks, or redirects.
+
+This is the location-case counterpart to CAUSATION IS CONTROL OVER AN
+OBJECT RELATIVE TO A POSSESSOR (the object case). Where the object case
+frames causation as controlling someone's stuff, the location case frames
+causation as controlling someone's position. Both are about control, but
+the spatial version trades the vocabulary of giving and taking for the
+vocabulary of placing and displacing.
+
+Key structural parallels:
+
+- **Causing as placing** -- "That put him in a difficult position."
+  "She placed them at a disadvantage." "The ruling left the company in
+  limbo." The causal agent moves the affected entity into a location
+  (state). The agent has the power to determine where things end up,
+  and the affected party finds itself situated in a new place.
+
+- **Preventing as blocking movement** -- "The regulation kept prices
+  from rising." "He held her back from advancing." "The treaty prevented
+  the conflict from spreading." The causal agent obstructs motion from
+  one location to another. Preventing a change of state is preventing
+  a change of location -- standing in the way, blocking the path,
+  holding something in place.
+
+- **Enabling as clearing a path** -- "The scholarship opened the door
+  to higher education." "That decision cleared the way for reform."
+  "The new technology paved the way for innovation." Enabling causation
+  is removing obstacles to movement. The causal agent does not push the
+  entity to a new location but removes whatever was preventing it from
+  getting there.
+
+- **Causal power as spatial authority** -- "She's in a position to
+  influence the outcome." "He controls access to the resources." "They
+  determine where the money goes." Causal power is the authority to
+  decide locations -- who goes where, what stays where. This maps
+  political and social power onto spatial control: the powerful decide
+  positions; the powerless are positioned.
+
+- **Causal chains as sequences of relocations** -- "One thing led to
+  another." "The crisis drove them from one problem to the next." "The
+  discovery brought them to a new understanding." Complex causation is
+  a sequence of movements, each caused by the previous placement. The
+  chain of causes is a chain of relocations.
+
+## Where It Breaks
+
+- **Not all causation involves position** -- the metaphor works well
+  for causation that changes someone's situation or status. But causes
+  that produce entirely new entities (a chemical reaction creating a
+  new compound, an idea sparking a new field) are not well captured by
+  relocation. Creating is not the same as placing. The metaphor has no
+  vocabulary for causation that generates rather than repositions.
+
+- **The metaphor privileges external causation** -- someone or something
+  controls your location. Self-causation (deciding to change your own
+  state) becomes awkward: "She put herself in a better position" works
+  but implies the agent is both the mover and the moved, collapsing
+  the spatial asymmetry. Internal transformation resists the external
+  positioning frame.
+
+- **Locations suggest fixity** -- if causes put things in places, the
+  implication is that the thing stays put until another cause moves it.
+  But many effects are dynamic processes, not static states. An
+  infection, a rumor, or a market panic is a process that unfolds and
+  propagates, not a thing sitting in a location. The spatial frame
+  makes dynamic effects look more stable than they are.
+
+- **Spatial control implies a single controller** -- who "put" the
+  economy in recession? The metaphor demands an agent with positioning
+  power, but many large-scale effects result from distributed,
+  uncoordinated actions. No one controls the relative location because
+  no one is in charge. The metaphor can create false narratives of
+  intentional positioning where there was only emergence.
+
+- **The metaphor flattens the moral dimension** -- "She placed him in
+  danger" and "She placed him in safety" have the same spatial structure.
+  The metaphor treats beneficial and harmful causation identically --
+  both are acts of positioning. It provides no inherent moral vocabulary,
+  which can make harmful causation sound as neutral as rearranging
+  furniture.
+
+## Expressions
+
+- "That put him in a difficult position" -- causing a state as placing
+  someone in a location
+- "She placed them at a disadvantage" -- harmful causation as
+  unfavorable positioning
+- "The regulation kept prices from rising" -- preventing change as
+  blocking movement
+- "The scholarship opened the door to higher education" -- enabling as
+  clearing a spatial passage
+- "One thing led to another" -- causal chains as guided movement through
+  locations
+- "He held her back from advancing" -- preventing progress as physically
+  restraining movement
+- "That decision cleared the way for reform" -- enabling causation as
+  removing spatial obstacles
+- "The crisis drove them from one problem to the next" -- sequential
+  causation as forced relocation
+- "She's in a position to influence the outcome" -- causal power as
+  advantageous spatial placement
+- "The ruling left the company in limbo" -- causing an uncertain state
+  as abandoning something in an indeterminate location
+
+## Origin Story
+
+CAUSATION IS CONTROL OVER RELATIVE LOCATION is documented in the Master
+Metaphor List (Lakoff, Espenson & Schwartz 1991) as part of the
+causation metaphor cluster. It is the location-case variant of the
+Event Structure system's approach to causation. If states are locations
+and changes are motions (as the system stipulates), then causing a
+change is controlling the motion -- deciding where things go. The
+metaphor is grounded in the infant's early experience of being placed:
+a caregiver picks up the child and puts the child somewhere (in a crib,
+on the floor, at the table). The child's state changes because someone
+with greater physical power controlled the child's location. This
+embodied prototype -- a powerful agent moving a less powerful entity
+from one place to another -- becomes the template for understanding
+causation as spatial control.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Causation Is Control Over Relative Location"
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999), Chapter 11
+  -- the Event Structure metaphor system, location case
+- Lakoff, G. & Johnson, M. *Metaphors We Live By* (1980) -- orientational
+  and ontological metaphors
+- Johnson, M. *The Body in the Mind* (1987) -- image schemas underlying
+  spatial causation

--- a/catalog/mappings/causes-and-effects-are-linked-objects.md
+++ b/catalog/mappings/causes-and-effects-are-linked-objects.md
@@ -1,0 +1,171 @@
+---
+author: agent:metaphorex-miner
+categories:
+- cognitive-science
+- linguistics
+- philosophy
+contributors: []
+created: '2026-03-15'
+harness: Claude Code
+kind: conceptual-metaphor
+name: Causes And Effects Are Linked Objects
+provenance: osaka-master-metaphor-list
+related:
+- causes-are-forces
+- causation-is-commercial-transaction
+- causation-is-control-over-an-object-relative-to-a-possessor
+- causation-is-control-over-relative-location
+slug: causes-and-effects-are-linked-objects
+source_frame: physical-connection
+target_frame: causal-reasoning
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+Causes and effects are tied together. This metaphor maps the physical
+domain of connected objects -- chains, links, bonds, ties, ropes -- onto
+the abstract relationship between causes and their effects. Instead of
+framing causation as force, transaction, or spatial control, this mapping
+focuses on the connection itself: causes and effects are distinct objects
+joined by a link, and the link can be strong or weak, direct or
+indirect, visible or hidden.
+
+The metaphor gives causation a topology. Causal relationships have the
+structure of physical connections: they can form chains (A links to B
+links to C), networks (multiple causes linked to multiple effects),
+and they can break. This topological vocabulary is central to both
+everyday and scientific talk about causation.
+
+Key structural parallels:
+
+- **Causal relationships as physical links** -- "There's a connection
+  between smoking and cancer." "The link between poverty and crime is
+  well established." "What ties these events together?" Cause and
+  effect are separate objects with something between them -- a chain,
+  a bond, a thread. To understand causation is to see the link.
+
+- **Causal chains** -- "The chain of events that led to the crash."
+  "One link in a long causal chain." "Trace the chain back to the
+  original cause." When causes produce effects that in turn become
+  causes, the metaphor generates a chain -- a series of connected
+  links extending from first cause to final effect. The chain can be
+  long or short, and any single link can be the weak point.
+
+- **Strength of connection as strength of causation** -- "There's a
+  strong link between exercise and longevity." "The connection is
+  tenuous at best." "That's a weak tie." Physical connections vary
+  in strength, and so do causal ones. A strong link is a reliable
+  causal relationship; a weak link is a dubious one. This gives us a
+  vocabulary for degrees of causal confidence.
+
+- **Breaking connections as breaking causation** -- "She broke the
+  cycle of poverty." "We need to sever the link between lobbying and
+  legislation." "The chain was broken." If causes and effects are
+  physically linked, then stopping causation is cutting the link.
+  Intervention is disconnection: you break the chain, sever the tie,
+  cut the cord.
+
+- **Hidden connections as hidden causation** -- "There's a hidden
+  connection between these two phenomena." "The thread connecting
+  the events was invisible at first." "Unravel the tangled web of
+  causes." When the physical link is not visible, the causal
+  relationship is not understood. Discovery is finding the link;
+  confusion is a tangle.
+
+## Where It Breaks
+
+- **Links are symmetric; causation is not** -- a chain link connects
+  two objects equally: A is linked to B just as B is linked to A.
+  But causation is directional: the cause produces the effect, not
+  the other way around. The metaphor has no inherent way to represent
+  the asymmetry of causation. We add directionality through context
+  ("the chain of events leading to X"), but the link itself does not
+  point.
+
+- **The metaphor implies discrete, separable components** -- linked
+  objects are distinct things joined together. But many causal
+  relationships are not cleanly separable into cause and effect.
+  Development, coevolution, and feedback loops involve causes and
+  effects that merge into each other. The metaphor insists on two
+  separate objects connected by a third thing, which is the wrong
+  topology for continuous, interpenetrating causation.
+
+- **Connection implies contact** -- physical links are material things
+  that bridge physical space. The metaphor makes distant causation
+  (action at a distance, delayed effects, statistical causation) feel
+  suspicious or mysterious. "How can they be connected? There's nothing
+  between them." The link metaphor demands a visible mechanism, which
+  is why people find quantum entanglement and epidemiological
+  correlations counterintuitive.
+
+- **Chain topology is linear** -- a chain is a sequence. But many
+  causal structures are networks with multiple inputs, branching
+  outputs, and feedback. The chain metaphor encourages a search for
+  "the" causal chain when the actual structure is a web. "The chain
+  of events" suggests a single story; the reality is usually many
+  overlapping stories.
+
+- **Breaking a link looks easy** -- in the physical domain, cutting a
+  rope or breaking a chain is a single decisive act. But breaking a
+  causal relationship is rarely so simple. The "link" between poverty
+  and crime involves thousands of mediating factors, institutional
+  structures, and feedback loops. The metaphor makes intervention
+  sound like it requires a single cut when it actually requires
+  systemic change.
+
+## Expressions
+
+- "There's a connection between smoking and cancer" -- causal
+  relationship as physical link
+- "The chain of events that led to the disaster" -- sequential
+  causation as linked chain
+- "A strong link between exercise and health" -- reliable causation as
+  sturdy connection
+- "Break the cycle of violence" -- stopping causation as severing a
+  link
+- "The missing link in the argument" -- unexplained causation as a
+  gap in a chain
+- "Trace the chain back to its origin" -- causal investigation as
+  following a physical connection
+- "A tenuous connection at best" -- weak causation as a fragile link
+- "Unravel the web of causes" -- understanding complex causation as
+  disentangling connected objects
+- "She severed the link between the two departments" -- ending a
+  causal relationship as cutting a physical connection
+- "These events are tied together" -- co-causation as objects bound to
+  each other
+
+## Origin Story
+
+CAUSES AND EFFECTS ARE LINKED OBJECTS is documented in the Master
+Metaphor List (Lakoff, Espenson & Schwartz 1991) as part of the
+causation metaphor cluster. It represents a distinct way of
+understanding causation, complementary to the force-dynamic model
+(CAUSES ARE FORCES) and the transactional model (CAUSATION IS
+COMMERCIAL TRANSACTION). The link metaphor is grounded in the
+embodied experience of physical connections: pulling a rope and
+feeling the object at the other end move, watching a chain transmit
+force from one link to the next, tugging a thread and seeing fabric
+pucker. These experiences establish the prototype of mediated
+connection -- two things joined by something between them -- that
+becomes the default model for understanding how remote events can be
+causally related.
+
+The metaphor has been especially productive in scientific discourse.
+The concept of a "causal chain" is a staple of epidemiology,
+forensics, and historical explanation. The search for "missing links"
+(in evolution, in arguments, in criminal investigations) is a direct
+consequence of the link metaphor: if causes and effects are connected
+objects, then gaps in the chain demand explanation.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Causes And Effects Are Linked Objects"
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999), Chapter 11
+  -- causation as a radial category with multiple metaphorical models
+- Lakoff, G. & Johnson, M. *Metaphors We Live By* (1980) -- ontological
+  metaphors and structural metaphors
+- Talmy, L. *Toward a Cognitive Semantics* (2000), Vol. 1 -- force
+  dynamics and connection schemas

--- a/catalog/mappings/change-is-replacement.md
+++ b/catalog/mappings/change-is-replacement.md
@@ -1,0 +1,152 @@
+---
+author: agent:metaphorex-miner
+categories:
+- cognitive-science
+- linguistics
+- philosophy
+contributors: []
+created: '2026-03-15'
+harness: Claude Code
+kind: conceptual-metaphor
+name: Change Is Replacement
+provenance: osaka-master-metaphor-list
+related:
+- change-is-motion
+- states-are-locations
+- action-is-control-over-possessions
+- properties-are-possessions
+slug: change-is-replacement
+source_frame: physical-objects
+target_frame: event-structure
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+When something changes, the old version disappears and a new one takes
+its place. This metaphor maps the physical act of replacing one object
+with another onto abstract change. Instead of framing change as motion
+from one place to another (CHANGE IS MOTION) or as gradual
+transformation, this mapping treats change as substitution: the old
+state is removed and a new state is put in its place, as if swapping
+parts.
+
+The metaphor gives change a discrete, discontinuous character. There is
+no gradual transition -- there is a before-object and an after-object,
+and the moment of change is the moment of exchange. This makes change
+feel clean, decisive, and total.
+
+Key structural parallels:
+
+- **Changing as swapping** -- "She's a changed person." "He replaced his
+  anger with acceptance." "The old regime was overthrown and a new one
+  installed." The changed entity is treated as if the old version was
+  physically removed and a different object put in its place. Change is
+  not modification but substitution.
+
+- **The old state as a discarded object** -- "She shed her old identity."
+  "He cast off his former beliefs." "They discarded the old approach."
+  What was before is an object to be thrown away, abandoned, left
+  behind. The metaphor makes the prior state disposable.
+
+- **The new state as a new object** -- "She adopted a new strategy."
+  "He took on a new role." "They put a new system in place." The result
+  of change is something acquired, installed, or picked up -- a new
+  thing that now occupies the space the old thing left.
+
+- **The agent of change as the one who swaps** -- "Management replaced
+  the old policy with a new one." "The committee substituted a weaker
+  proposal." "She switched from pessimism to optimism." The person or
+  force causing the change is the one who performs the substitution,
+  removing one object and installing another.
+
+- **Irreversibility as permanence of removal** -- "There's no going
+  back." "The old ways are gone for good." "You can't unbreak an egg."
+  When the replacement is complete, the old object is gone. The metaphor
+  makes some changes feel irreversible because the discarded object no
+  longer exists to be reinstalled.
+
+## Where It Breaks
+
+- **Most change is continuous, not discrete** -- the metaphor insists
+  on a clean swap: old out, new in. But real change is usually gradual.
+  A person recovering from grief does not wake up one morning with a
+  "new" emotional state installed. The replacement model cannot represent
+  incremental transformation, blending of old and new, or partial
+  change. It forces continuous processes into a binary frame.
+
+- **Identity does not survive replacement** -- if something is replaced,
+  it is a different thing. But we routinely say things change while
+  remaining themselves: "The city has changed but it's still London."
+  The replacement metaphor makes identity through change paradoxical.
+  If the old London was replaced by a new London, which one is "really"
+  London? The metaphor invites Ship-of-Theseus puzzles that continuous
+  models of change avoid.
+
+- **The metaphor erases the process** -- replacement is instantaneous:
+  one object out, another in. The actual process of change -- the
+  struggle, the ambiguity, the mixed states -- disappears. A career
+  change involves years of doubt, retraining, and overlap, but "she
+  replaced her old career with a new one" makes it sound like changing
+  a lightbulb.
+
+- **It implies someone chose the replacement** -- in physical
+  replacement, someone decides which new object to install. But many
+  changes are unchosen: aging, cultural drift, ecological succession.
+  The metaphor imports agency and intention into processes that may have
+  neither, making involuntary change sound like a deliberate swap.
+
+- **The model privileges novelty over continuity** -- if change means
+  the old is discarded, then continuity becomes the absence of change.
+  This makes it hard to value what persists through change. The
+  metaphor celebrates the new and dismisses the old, which can
+  accelerate disposability in thinking about institutions, traditions,
+  and relationships.
+
+## Expressions
+
+- "She's a changed person" -- transformation as replacement of one
+  entity with another
+- "He replaced his anger with calm" -- emotional change as object
+  substitution
+- "Out with the old, in with the new" -- change as sequential removal
+  and installation
+- "She shed her old identity" -- personal change as discarding an
+  object
+- "They put a new system in place" -- institutional change as
+  installing a replacement
+- "He took on a new role" -- change of function as acquiring a
+  replacement object
+- "The old guard was replaced" -- leadership change as substitution of
+  persons
+- "She switched from one strategy to another" -- change of approach as
+  swapping implements
+- "They overhauled the entire program" -- comprehensive change as
+  total replacement of parts
+- "Cast off the old ways" -- cultural change as discarding worn-out
+  objects
+
+## Origin Story
+
+CHANGE IS REPLACEMENT is documented in the Master Metaphor List
+(Lakoff, Espenson & Schwartz 1991) as part of the broader change
+metaphor cluster within the Event Structure system. It provides an
+alternative to the dominant CHANGE IS MOTION mapping: where motion
+treats change as continuous displacement along a path, replacement
+treats change as discrete substitution of one object for another. The
+embodied grounding is in the early childhood experience of objects
+being swapped -- a broken toy replaced by a new one, a dirty shirt
+replaced by a clean one, an old bottle replaced by a full one. The
+child experiences change as disappearance-and-appearance: one thing
+goes away, another thing shows up. This becomes a template for
+understanding any change as a swap, especially when the old and new
+states are strikingly different.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Change Is Replacement"
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999), Chapter 11
+  -- the Event Structure metaphor system
+- Lakoff, G. & Johnson, M. *Metaphors We Live By* (1980) -- structural
+  metaphors for change

--- a/catalog/mappings/change-of-state-is-change-of-direction.md
+++ b/catalog/mappings/change-of-state-is-change-of-direction.md
@@ -1,0 +1,166 @@
+---
+author: agent:metaphorex-miner
+categories:
+- cognitive-science
+- linguistics
+- philosophy
+contributors: []
+created: '2026-03-15'
+harness: Claude Code
+kind: conceptual-metaphor
+name: Change Of State Is Change Of Direction
+provenance: osaka-master-metaphor-list
+related:
+- change-is-motion
+- states-are-locations
+- purposes-are-destinations
+- difficulties-are-impediments-to-motion
+- life-is-a-journey
+slug: change-of-state-is-change-of-direction
+source_frame: journeys
+target_frame: event-structure
+updated: '2026-03-15'
+---
+
+## What It Brings
+
+When your state changes, you turn. This metaphor maps the physical
+experience of changing direction during movement onto the abstract
+experience of changing from one state to another. If STATES ARE
+LOCATIONS and CHANGE IS MOTION, then changing state is moving from one
+location to another -- but this particular mapping adds a crucial
+element: the change involves a turn, a redirection, a departure from
+the current trajectory. It is not just movement; it is movement that
+bends.
+
+The metaphor distinguishes state change from mere continuation. Walking
+straight ahead is continuing in the same state. Turning -- veering,
+swerving, pivoting -- is entering a new state. This gives state changes
+a geometry: they have angles, they can be sharp or gradual, and they
+create a contrast between the old direction and the new one.
+
+Key structural parallels:
+
+- **State change as turning** -- "Her life took a turn for the worse."
+  "The conversation took an unexpected turn." "The economy turned
+  around." Entering a new state is changing the direction of travel.
+  The turn marks the boundary between before and after, the moment
+  where the trajectory breaks.
+
+- **Improvement as turning upward** -- "Things are looking up." "The
+  company's fortunes turned around." "His health took a turn for the
+  better." Positive state change is an upward or favorable redirection.
+  The new direction is better than the old one, which means the old
+  direction was heading somewhere worse.
+
+- **Deterioration as turning downward** -- "The situation took a
+  downward turn." "Her career spiraled downward." "Things went south."
+  Negative state change is a turn toward a worse direction. The
+  spatial orientation (down = bad, up = good) from orientational
+  metaphors combines with the directional change to give deterioration
+  a vivid geometry.
+
+- **Sudden change as sharp turns** -- "A sharp reversal in policy."
+  "The plot twist nobody saw coming." "An abrupt about-face." When the
+  change of state is sudden and dramatic, the metaphor represents it as
+  a sharp angle -- a hairpin turn, an about-face, a U-turn. Gradual
+  change is a gentle curve; sudden change is a right angle or a
+  reversal.
+
+- **Indecision as wavering direction** -- "She's going back and forth
+  on the decision." "He keeps changing direction." "They can't decide
+  which way to turn." When someone oscillates between states, the
+  metaphor frames it as erratic directional changes -- zigzagging,
+  wavering, unable to hold a course. Decisiveness is holding a
+  direction; indecision is turning too often.
+
+## Where It Breaks
+
+- **Not all state changes are directional** -- the metaphor requires a
+  trajectory that bends. But some changes are more like transformations
+  than turns: a caterpillar becoming a butterfly, water turning to
+  steam, a student becoming a professional. These changes alter what
+  the entity is, not which direction it is heading. The directional
+  frame cannot capture changes in kind as opposed to changes in
+  course.
+
+- **The metaphor implies a single dimension of movement** -- you turn
+  from one direction to another along a plane. But states can be
+  multidimensional: a person can simultaneously change emotionally,
+  professionally, and physically. The directional metaphor flattens
+  complex, multi-axis change into a single turn, losing the
+  dimensionality of real transformation.
+
+- **Directions imply continuation** -- when you turn, you then proceed
+  in the new direction. The metaphor implies that after the state
+  change, you continue in the new state. But many state changes are
+  momentary: a flash of insight, a burst of anger, a brief period of
+  clarity. The directional metaphor makes all state changes look like
+  new sustained trajectories, when some are just blips.
+
+- **The geometry creates false precision** -- "a 180-degree turn," "a
+  slight shift in direction" -- the metaphor invites quantification of
+  state changes as if they had angular measurements. But states do not
+  have degrees of turn. This can create misleading confidence about the
+  magnitude of change: was it a sharp turn or a gentle curve? The
+  metaphor offers a spectrum that the target domain does not actually
+  have.
+
+- **The metaphor has no vocabulary for return to the same state** --
+  physically, you can turn around and go back the way you came. But
+  psychologically and socially, returning to a former state is never
+  really going back to the same place. "She went back to her old ways"
+  uses the directional metaphor, but the person who returns is not the
+  same person who left. The spatial model makes return look possible
+  when the temporal reality makes it impossible.
+
+## Expressions
+
+- "Her life took a turn for the worse" -- negative state change as
+  unfavorable redirection
+- "The company turned around" -- recovery as directional reversal
+- "The conversation took an unexpected turn" -- surprising change as
+  unanticipated redirection
+- "Things went south" -- deterioration as downward directional change
+- "He did an about-face on the issue" -- complete reversal as
+  180-degree turn
+- "A sharp reversal in policy" -- sudden change as abrupt angular
+  change
+- "She's going back and forth" -- indecision as oscillating direction
+- "The plot twist" -- narrative surprise as a bend in the path
+- "His career took a new direction" -- professional change as altered
+  trajectory
+- "They veered off course" -- unintended change as involuntary
+  redirection
+
+## Origin Story
+
+CHANGE OF STATE IS CHANGE OF DIRECTION is documented in the Master
+Metaphor List (Lakoff, Espenson & Schwartz 1991) as a specification
+within the broader CHANGE IS MOTION mapping. If change is motion and
+states are locations, then changing state is moving to a new location --
+and this particular sub-mapping focuses on the turning point, the moment
+where the trajectory bends. The embodied grounding is in the experience
+of locomotion: when you are walking and you turn, your visual field
+changes, the terrain underfoot changes, and the destination changes.
+The turn is a perceptible discontinuity in otherwise continuous motion.
+This experiential salience of turning makes it a natural prototype for
+the moment of state change -- the point where things start being
+different.
+
+The metaphor interacts with PURPOSES ARE DESTINATIONS (a change of
+direction may mean a change of purpose) and with LIFE IS A JOURNEY
+(major life changes are "turns" in the journey). It is especially
+productive in narrative, where "turning points" and "plot twists" are
+standard vocabulary for moments of significant change.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Change Of State Is Change Of Direction"
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999), Chapter 11
+  -- the Event Structure metaphor system, location case
+- Lakoff, G. & Johnson, M. *Metaphors We Live By* (1980) -- orientational
+  metaphors and structural metaphors
+- Lakoff, G. & Turner, M. *More Than Cool Reason* (1989) -- the role of
+  directional change in literary narrative


### PR DESCRIPTION
## Summary

- **causation-is-control-over-an-object-relative-to-a-possessor** (Closes #355) -- object-case causation: controlling what someone else has
- **causation-is-control-over-relative-location** (Closes #356) -- location-case causation: controlling where things end up
- **causes-and-effects-are-linked-objects** (Closes #357) -- topological causation: causes and effects joined by physical links
- **change-is-replacement** (Closes #358) -- change as discrete substitution of one object for another
- **change-of-state-is-change-of-direction** (Closes #359) -- state change as a turn in trajectory

All from the Master Metaphor List / Osaka archive. Part of the cognitive-linguistics-canon project (#4).

## Validator output

```
All content valid.
```

26 pre-existing dangling-reference warnings (none from this PR).

## Frames

No new frames needed. Uses existing frames: economics, spatial-location, physical-connection, physical-objects, journeys, causal-reasoning, event-structure.

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors
- [ ] Review mapping quality: What It Brings, Where It Breaks, Expressions
- [ ] Check related links point to existing catalog entries
- [ ] Confirm source_frame and target_frame assignments are appropriate

Generated with [Claude Code](https://claude.com/claude-code)