### PR TITLE
docs: add plans, scheins playbook, and gitignore __pycache__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ graph.png
 .worktrees/
 .playwright-mcp/
 .DS_Store
+__pycache__/

--- a/docs/plans/2026-03-13-Metaphor-sources-to-mine.md
+++ b/docs/plans/2026-03-13-Metaphor-sources-to-mine.md
@@ -1,0 +1,269 @@
+# Load-bearing metaphors: a harvest map for Metaphorex
+
+**The richest seams for Metaphorex lie in domains that are already self-aware about their own metaphorical reasoning.** Across 22 domains researched, we identified hundreds of specific archives, glossaries, books, and curated collections — many bulk-importable. The highest-value targets combine three traits: dense load-bearing language, existing structured corpora, and active communities that already debate which metaphors serve them well. Law, manufacturing, sailing, medicine, and software engineering offer the easiest harvests; comedy writers' rooms, firefighting culture, and psychotherapy offer the most surprising and under-documented material.
+
+The Metaphorex project website (metaphorex.org) and GitHub repository (github.com/metaphorex/metaphorex) are not yet publicly accessible — they appear to be pre-launch or private. No cached or archived versions were found. This report therefore stands as a greenfield planning document.
+
+---
+
+## The ten user-nominated domains
+
+### 1. Music practice and performing arts
+
+**Harvest difficulty: MEDIUM**
+
+The standout importable resource is **"Notes on Directing" by Frank Hauser & Russell Reich** — 130 numbered lessons of theatrical wisdom, each a load-bearing aphorism with commentary. For music, **"Metaphors for the Musician" by Randy Halberstadt** (Sher Music, 330 pages) is a rare curated collection of jazz-specific metaphorical thinking. The academic literature includes Zbikowski's "Metaphor and Music" (Cambridge Handbook of Metaphor and Thought, 2008) and Whalley's 2024 paper in *Empirical Musicology Review* on embodied metaphor in pedagogy. Film glossaries from StudioBinder (400+ terms) and Wikipedia are structured and scrapeable.
+
+Sample load-bearing metaphors: **"Don't play what's there; play what's not there"** (Miles Davis) encodes that expression lives in absence. **"You have to spend time in the woodshed"** (jazz tradition) — "woodshedding" encodes that mastery requires solitary, unglamorous repetition. **"Every scene is a chase scene"** (Hauser) — character A wants something from character B who won't give it — encodes that dramatic tension requires active resistance. **"You cannot create results, you can only create conditions"** (Anne Bogart) reframes the director as environmental designer, not dictator.
+
+Target-rich sub-disciplines include **jazz pedagogy** (oral tradition of metaphorical instruction), **film editing** (Walter Murch's *In the Blink of an Eye*), and **method acting/Stanislavski** (emotional memory, "the magic if," super-objective).
+
+### 2. Folk arts and crafts
+
+**Harvest difficulty: MEDIUM-HARD**
+
+The single most important academic resource across all domains is the **University of Glasgow's Mapping Metaphor project** (mappingmetaphor.arts.gla.ac.uk) — an AHRC-funded database containing **14,000+ metaphorical connections** across 415 semantic domains, with 70,000+ individual metaphorical words. It specifically documents how textile and craft metaphors entered English. The companion volume *Mapping English Metaphor Through Time* (OUP, 2016) is import-ready. Richard Sennett's *The Craftsman* (2008) is the landmark philosophical treatment; its thesis — **"making is thinking"** — encodes that the hand informs the mind.
+
+Weaving is extraordinarily target-rich: "text" and "textile" share the Latin root *texere*; "sutra" originally meant "thread." The field generated "thread of argument," "spin a yarn," "unravel a mystery," "tangled web," "fabric of society," "on tenterhooks," "dyed in the wool." Blacksmithing gives us **"strike while the iron is hot"** — timing as physical necessity, not preference. Pottery encodes patience as technical requirement: **"you can't rush the kiln."**
+
+### 3. Visual arts
+
+**Harvest difficulty: EASY-MEDIUM**
+
+Best-served by curated collections. **"Aphorisms for Artists" by Walter Darby Bannard** (Letter16 Press, 2021) provides 100 numbered, annotated aphorisms from an abstract painter. Robert Henri's **"The Art Spirit"** (1923, continuously in print) is "almost the equivalent of a bumper-sticker factory" per reviewers. **"The Mind of the Artist" compiled by Laurence Binyon** is available free on Project Gutenberg. For academic treatment, Mark Staff Brandl's *A Philosophy of Visual Metaphor in Contemporary Art* (Bloomsbury, 2020) develops a theory of "central visual trope."
+
+Key metaphors: **"Negative space is as important as positive space"** — the design equivalent of "play the silence." **"Form follows function"** (Sullivan, 1896) generated a productive dialectic with Venturi's **"Less is a bore"** (1966). The visual arts demonstrate how load-bearing metaphors come in opposed pairs that together encode a permanent professional tension.
+
+### 4. Military strategy and tactics
+
+**Harvest difficulty: EASY-MEDIUM**
+
+Among the best-documented domains. **Napoleon's Military Maxims** (78 numbered items) are on Project Gutenberg. Sun Tzu's *Art of War* is at MIT Classics Archive. Clausewitz quotations are curated at clausewitz.com. The **DoD Dictionary of Military and Associated Terms (JP 1-02)** is the official reference, downloadable as a free PDF. Wiktionary's military slang glossary contains hundreds of structured entries. Bret Devereaux's "Very Short Glossary of Military Terminology" (acoup.blog, 2022) provides historian-grade explanations of theory-level terms.
+
+**"Fog of war"** (Clausewitz) encodes that information during conflict is always incomplete — act decisively anyway. **"Amateurs study tactics; professionals study logistics"** (attributed to Bradley) encodes that unglamorous infrastructure determines outcomes. **"Friction"** (Clausewitz) — "everything in war is very simple, but the simplest thing is difficult" — names the accumulated drag of countless small obstacles.
+
+Target-rich sub-disciplines: counterinsurgency doctrine ("hearts and minds," "clear-hold-build"), the **OODA loop** (John Boyd), and naval warfare terminology.
+
+### 5. Firefighting and emergency response
+
+**Harvest difficulty: MEDIUM**
+
+The structured resources include Wikipedia's Glossary of Firefighting, NIMS/ICS terminology (FEMA standard), and the **10 Standard Fire Orders and 18 Watch Out Situations** for wildland firefighting (compact, importable). The National Fallen Firefighters Foundation's **16 Life Safety Initiatives** codify culture-change principles. NIOSH's firefighter fatality investigation reports (cdc.gov/niosh/fire) encode recurring lessons in the "NIOSH 5" causal factors.
+
+The foundational risk maxim is: **"Risk a lot to save a lot, risk a little to save a little, risk nothing to save nothing"** (NFPA 1500 / Chief Alan Brunacini). **"160 years of tradition unimpeded by progress"** is the fire service's darkly self-aware acknowledgment that institutional inertia kills. **"Good luck reinforces bad habits"** (from NIOSH analysis) encodes that surviving a risky action doesn't validate it.
+
+### 6. Manufacturing
+
+**Harvest difficulty: EASY**
+
+The best-documented domain overall. The **Toyota Production System** provides a coherent, bounded lexicon with official definitions: Kaizen, Gemba, Jidoka, Kanban, Muda/Mura/Muri, Poka-Yoke, Andon, Heijunka, Hoshin Kanri. Multiple structured glossaries exist — Toyota UK's official glossary, LeanProduction.com, ASQ, and Lean Six Sigma Definition. Deming's 14 Points are codified at deming.org.
+
+**"You can't inspect quality in"** (Deming) — quality must be built into the process, not caught at the end. **"A bad system will beat a good person every time"** (Deming) — fix the system, not the worker. **"The most dangerous kind of waste is the waste we do not recognize"** (Shigeo Shingo) drives the practice of going to the gemba. The **Andon cord** — any worker can halt the entire production line — is a metaphor-in-practice encoding that quality authority must be distributed to the lowest level.
+
+### 7. Deep sea and space exploration
+
+**Harvest difficulty: MEDIUM**
+
+NASA's Basics of Spaceflight Glossary is comprehensive and machine-parsable. Jonathan McDowell's Space Report Glossary (planet4589.org) is expert-curated with nuanced definitional commentary. USGS, MarineBio, and World Ocean Review provide deep-sea glossaries. However, the metaphorical layer — operational proverbs and decision-making heuristics — is scattered across memoirs (Chris Hadfield's *An Astronaut's Guide to Life on Earth*) and journalism.
+
+**"Single point of failure"** crossed from NASA engineering into universal risk-assessment language. **"There is no 'up' in space"** encodes that your default frame of reference will deceive you. Mission control culture contributes the **"go/no-go" binary decision framework** and **"flight rules"** (pre-agreed decision trees that remove emotion from crisis decisions).
+
+### 8. Math and theoretical physics
+
+**Harvest difficulty: EASY**
+
+Mathematicians and physicists actively curate their own folklore. Wikipedia's "Mathematical Folklore" article is an excellent entry point. The AMS *Notices* paper **"Foolproof: A Sampling of Mathematical Folk Humor"** (Renteln & Dundes, 2005) is directly importable. Steven Krantz's *Mathematical Apocrypha* (2002) and *Redux* (2005) are compilation volumes.
+
+**"Shut up and calculate"** (David Mermin, *Physics Today*, 1989 — not Feynman) encodes an entire epistemological stance: refuse to interpret, just predict. The **"spherical cow"** (John Harte, *Consider a Spherical Cow*, 1988) encodes both the methodology of radical simplification and the warning not to forget you simplified. **"Proof by intimidation"** (Mark Kac about William Feller) names a real failure mode where social pressure substitutes for logical rigor.
+
+### 9. Anthropology
+
+**Harvest difficulty: MEDIUM**
+
+Glossaries are plentiful (OUP Companion, multiple Pressbooks open textbooks, Alan Macfarlane's Dictionary of Anthropological Terms PDF). The meta-literature is uniquely strong — Clifford & Marcus's *Writing Culture* (1986) problematizes the field's own figures of speech, making the meta-commentary itself harvestable.
+
+**"Thick description"** (Geertz via Ryle, 1973) defines the goal of ethnography. **"Emic vs. etic"** (Kenneth Pike, from "phonemic" vs. "phonetic") structures all anthropological analysis as a decision framework for how to represent others' worlds. **"Armchair anthropology"** functions as a standing rebuke encoding the discipline's commitment to immersive empirical research.
+
+### 10. Child psychology and development
+
+**Harvest difficulty: EASY**
+
+This field is almost entirely constituted by its load-bearing metaphors. **"Scaffolding"** (Bruner et al., 1976) encodes a complete pedagogical strategy — and its adequacy has been explicitly debated in Stone's 1998 paper "Should we salvage the scaffolding metaphor?" **"The good enough mother"** (Winnicott, 1953) reframes imperfection as developmentally necessary. **"Zone of proximal development"** (Vygotsky) redefines ability as a range shaped by social context. **"Internal working model"** (Bowlby) explains how early experience shapes later relationships while acknowledging models can be updated.
+
+The Squiggle Foundation (squiggle-foundation.org) maintains detailed Winnicott terminology. CliffsNotes, Simply Psychology, and LibreTexts provide structured glossaries. The meta-literature explicitly debates whether the metaphors are adequate — a feature, not a bug, for Metaphorex.
+
+---
+
+## Twelve additional high-value domains
+
+### 11. Software engineering folklore
+
+**Harvest difficulty: EASY**
+
+The single highest-value import target is **`dwmkerr/hacker-laws` on GitHub** — a curated, structured Markdown catalog of 40+ laws, theories, and principles (Conway's Law, Hyrum's Law, Goodhart's Law, Gall's Law, etc.). Tom Van Vleck's **"Software Engineering Proverbs"** (multicians.org, updated January 2026) is a living collection from a Multics veteran. Matthew Reinbold's "Technology Aphorisms" catalogs 60+ named laws alphabetically. The 2026 arxiv paper "Folklore in Software Engineering" (Enoiu et al.) explicitly treats SE as a folk tradition.
+
+Less-obvious metaphors worth highlighting: **"Lava Flow"** anti-pattern — dead code solidifies like cooled lava, nobody dares remove it. **The Dead Sea Effect** (Bruce Webster) — talented engineers evaporate while the least talented sink and accumulate. **The 8 Fallacies of Distributed Computing** (Deutsch, Gosling, et al.) function as "a catechism of humility for systems architects."
+
+Target-rich sub-disciplines: **SRE/DevOps culture** ("cattle not pets," "error budgets," "toil"), **distributed systems** (CAP theorem, Byzantine generals), and **refactoring/code smells** (Fowler/Beck).
+
+### 12. Carpentry and woodworking
+
+**Harvest difficulty: MEDIUM**
+
+Wikipedia's Glossary of Woodworking is comprehensive and freely licensed. Popular Woodworking Magazine maintains a living glossary and has serialized "Woodworking Quotations: Quips, Aphorisms & More." Forum collections on LumberJocks, SawdustZone, and Sawmill Creek contain community-curated wisdom. David Pye's *The Nature and Art of Workmanship* (1968) introduced the foundational distinction between **"workmanship of risk"** (hand) vs. **"workmanship of certainty"** (machine).
+
+Beyond "measure twice, cut once": **"Let the tool do the work"** — if you're struggling, the problem is your preparation, not your effort. **"Read the grain"** — every material has a nature; skilled work means cooperating with it. **"You can always take more off, but you can't put it back on"** encodes asymmetric risk and iterative refinement.
+
+### 13. Sailing and seamanship
+
+**Harvest difficulty: EASY**
+
+Perhaps the single richest domain for metaphors that have migrated into everyday language. Wikipedia's Glossary of Nautical Terms (A–Z) is massive, structured, and freely licensed — **the highest import value of any single resource identified**. The Royal Museums Greenwich, NOAA, and US Sailing all maintain authoritative glossaries. Olivia Isil's *When a Loose Cannon Flogs a Dead Horse There's the Devil to Pay* (2003) is an entire book on seafaring words in everyday speech. Beavis & McCloskey's *Salty Dog Talk* (1983) is the classic reference on nautical etymologies.
+
+The sheer volume of nautical dead metaphors in English is staggering: loose cannon, bitter end, sailing close to the wind, taken aback, three sheets to the wind, jury-rigged, between the devil and the deep blue sea, in the doldrums, wide berth, even keel, know the ropes, showing true colors. Each encodes specific professional wisdom from an era when misunderstanding these concepts was lethal.
+
+### 14. Medicine and surgery
+
+**Harvest difficulty: EASY**
+
+Medicine has the most systematically cataloged aphorism tradition of any field. **Moshe Schein's "Aphorisms & Quotations for the Surgeon"** (2004) and companion volume contain **~2,100 items**. **"Sir William Osler: Aphorisms from His Bedside Teachings"** (Bean, 1950) collects ~280 sayings from Johns Hopkins ward rounds. **Maimonides' Medical Aphorisms** (1,500 maxims, English translation by Gerrit Bos, BYU Press). The Mayo Clinic Library maintains digitized Mayo Brothers aphorisms. LITFL (Life in the Fast Lane) curates Oslerisms online.
+
+**"When you hear hoofbeats, think horses, not zebras"** (Theodore Woodward, 1940s) warns against the base-rate fallacy — but "zebra" has become the symbol of rare disease advocacy, creating a productive tension. **"All bleeding stops eventually"** carries dual meaning: reassurance that hemostasis is achievable, and grim reminder of what happens if you don't act. **Samuel Shem's "The House of God"** (1978) codified resident cynicism into numbered Laws, including **"At a cardiac arrest, the first procedure is to take your own pulse."**
+
+### 15. Law and legal reasoning
+
+**Harvest difficulty: EASY**
+
+The most systematically cataloged domain of all. **Herbert Broom's "A Selection of Legal Maxims"** (first published 1845, now in its 14th edition) is the definitive classic — available on Project Gutenberg and Archive.org. **Halkerston's "Collection of Latin Maxims & Rules"** and **Cotterell's "Collection of Latin Maxims and Phrases"** are also on Project Gutenberg (ebooks #72240 and #68465). WritingLaw.com catalogs 235 legal maxims with meanings. The challenge is not finding maxims but selecting the truly load-bearing ones from the vast inventory.
+
+**"Hard cases make bad law"** (Holmes, 1904) — emotionally extreme cases tempt judges to bend doctrine, distorting law for ordinary situations. Eugene Volokh's 100+ page Harvard Law Review article "The Mechanisms of the Slippery Slope" (2003) identifies concrete causal mechanisms behind the metaphor, demonstrating how a figure of speech can encode real analytical content.
+
+Target-rich sub-disciplines: constitutional law ("penumbras and emanations," "marketplace of ideas," "chilling effect"), criminal law ("fruit of the poisonous tree"), equity ("clean hands doctrine").
+
+### 16. Economics and markets
+
+**Harvest difficulty: MEDIUM**
+
+No single canonical collection exists comparable to Broom's legal maxims or Schein's surgical aphorisms. Deirdre McCloskey's *The Rhetoric of Economics* (1985) is the pathbreaking work arguing economics is fundamentally rhetorical. The OMFIF's "Wisdom of Markets and the Madness of Crowds" (2020) is the closest to a market-sayings compendium. Wall Street folklore is rich but poorly cataloged in formal publications.
+
+**"The invisible hand"** (Adam Smith) may be the most consequential metaphor in all of social science. **"Animal spirits"** (Keynes, 1936) grounds behavioral economics and challenges rational expectations theory. **"Creative destruction"** (Schumpeter, 1942) makes growth and loss inseparable. The trading floor contributes a rich oral tradition: "markets can remain irrational longer than you can remain solvent," "when the tide goes out, you can see who's swimming naked" (Buffett), "dead cat bounce."
+
+### 17. Ecology and systems biology
+
+**Harvest difficulty: MEDIUM**
+
+Ecology has the strongest meta-literature on how its own metaphors shape reasoning. **Brendon Larson's *Metaphors for Environmental Sustainability* (Yale UP, 2011)** is the definitive treatment. Andrew Reynolds's *Understanding Metaphors in the Life Sciences* (Cambridge UP, 2022) devotes a full chapter to ecology. Wikipedia's Glossary of Ecology is comprehensive. Kim Cuddington's paper demonstrated that the **"balance of nature" metaphor has "constricted the meaning of mathematical equilibrium"** — a case study in how a metaphor can both enable and constrain scientific thinking.
+
+**"Keystone species"** (Robert Paine, 1969) — a single, often inconspicuous entity holding an entire system together — is an architectural metaphor that has migrated to business, software, and community organizing. **"Tragedy of the commons"** (Hardin, 1968) is powerful but contested: Elinor Ostrom won the Nobel Prize (2009) demonstrating that communities often self-govern successfully, exposing the metaphor's smuggled assumptions.
+
+Target-rich sub-disciplines: **resilience theory** (Holling's "adaptive cycle," "panarchy," "tipping points"), invasion ecology ("native vs. alien"), succession ecology ("pioneer species," "climax community").
+
+### 18. Cooking and culinary arts
+
+**Harvest difficulty: EASY**
+
+Kitchen culture is extraordinarily well-documented. Multiple comprehensive glossaries exist online (Escoffier School, WebstaurantStore, Toast POS, TouchBistro, MarketMan). Bourdain's *Kitchen Confidential* (2000) made kitchen jargon mainstream. Dan Charnas's **"Work Clean" (2016)** explicitly translates mise en place philosophy into 10 universal productivity principles extracted from 100+ chef interviews — proving the concept has fully migrated from cooking to general practice.
+
+**"Mise en place"** (everything in its place) encodes that preparation IS the work. Bourdain: "Mise-en-place is the religion of all good line cooks." **"In the weeds"** names the threshold beyond which more effort doesn't help — you've lost coordination. The call-and-response safety system (**"Behind!" / "Corner!" / "Hot!" / "Heard!"**) is load-bearing in the most literal sense: communication prevents burns.
+
+### 19. Agriculture and farming
+
+**Harvest difficulty: EASY**
+
+Agricultural wisdom may be the most ancient metaphor corpus in human civilization, appearing in Sumerian tablets, Biblical Proverbs, Aesop's Fables, and every agrarian culture. The Farmer's Almanac has been publishing continuously since 1792. Wendell Berry's work (*Bringing It to the Table*, *The Unsettling of America*) is the poet-philosophical treatment. The USDA NRCS maintains a massive Glossary of Soil Survey Terms.
+
+Beyond the familiar ("you reap what you sow," "make hay while the sun shines"), look for: **"The master's eye is the best fertilizer"** (Pliny the Elder) — attention itself is a nutrient for systems. **"Life is simpler when you plow around the stump"** — pragmatic avoidance vs. heroic removal.
+
+Target-rich sub-disciplines: **permaculture** ("stacking functions," "the problem is the solution"), regenerative agriculture ("feeding the soil not the plant"), and **viticulture** (terroir as the total environment expressed through the grape).
+
+### 20. Architecture and urban planning
+
+**Harvest difficulty: EASY**
+
+Christopher Alexander's **"A Pattern Language" (1977)** — 253 named design patterns organized as a grammar — is the foundational resource. The concept migrated powerfully into software engineering. Jane Jacobs's *Death and Life of Great American Cities* (1961) coined **"eyes on the street"** and "sidewalk ballet." Vitruvius's 2,000-year-old triad — **firmitas, utilitas, venustas** — remains currency.
+
+**"Desire paths"** — informal trails worn into grass by pedestrians ignoring designed walkways — encode that users are the ultimate authority on how space should work. Some Finnish planners wait for first snowfall, observe footprints, then pave accordingly. This concept has migrated to UX design (heat maps, user workarounds). Urban Design Works, Urban Design Lab, and ArchDaily maintain comprehensive glossaries.
+
+### 21. Comedy and stand-up performance
+
+**Harvest difficulty: MEDIUM**
+
+The single most valuable discovery for Metaphorex's format design is **Andy Riley's "How to Talk Comedy Writer"** (misterandyriley.com) — a crowdsourced glossary of insider terminology from British TV comedy writers' rooms, with attributions and stories. It includes gems like **"lightning rod"** (deliberately offensive joke inserted to distract producers from a slightly less offensive joke you actually want to keep), **"gorilla"** (a moment so memorable the audience talks about it afterward), and **"load-bearing pun"** (one word carrying an entire misunderstanding).
+
+**"Yes, and..."** (Del Close / improv tradition) has become a load-bearing metaphor far beyond comedy — used in business, therapy, education, and design thinking. **"Punch up, not down"** is comedy's central ethical principle, now a dominant framework in all discourse about the ethics of humor. **"The rule of three"** mirrors how the brain does pattern recognition: setup, confirmation, subversion.
+
+Key texts: Vorhaus's *The Comic Toolbox* ("comedy = truth + pain"), Halpern/Close's *Truth in Comedy*, Keith Johnstone's *Impro* (1979). Greg Dean maintains a comprehensive glossary at stand-upcomedy.com.
+
+### 22. Psychotherapy and clinical psychology
+
+**Harvest difficulty: MEDIUM-HARD**
+
+Clinical psychology's load-bearing metaphors live in practitioner training, blog posts, and oral tradition more than in neat corpora. Narrative therapy is the richest sub-discipline because it explicitly theorizes its own metaphorical structure. Michael White's **"Maps of Narrative Practice"** (2007) systematically maps five therapeutic territories. Niklas Törneke's *Metaphor in Practice* (2017, New Harbinger) is explicitly about clinical use of metaphor in ACT.
+
+**"Holding space"** encodes a counter-intuitive therapeutic stance: doing less is doing more. **"The presenting problem"** teaches clinicians to listen behind the stated complaint. **"Externalizing the problem"** (White) — "the person is not the problem; the problem is the problem" — is both a metaphorical frame and a clinical intervention. **"Rupture and repair"** reframes therapeutic relationship breakdowns as the healing mechanism, not failure.
+
+ACT (Acceptance and Commitment Therapy) is particularly target-rich with named metaphor-interventions: **"passengers on the bus"** (unwanted thoughts as passengers you don't have to obey), **"quicksand"** (struggling makes it worse), **"the chessboard"** (you are the board, not the pieces).
+
+---
+
+## Harvest difficulty at a glance
+
+| Domain | Difficulty | Best entry point for bulk import |
+|---|---|---|
+| Manufacturing (TPS/Lean) | **Easy** | Toyota UK glossary, LeanProduction.com, Deming's 14 Points |
+| Law / legal maxims | **Easy** | Broom's Legal Maxims (Project Gutenberg), Halkerston (Gutenberg) |
+| Sailing / seamanship | **Easy** | Wikipedia Glossary of Nautical Terms (A–Z) |
+| Medicine / surgery | **Easy** | Schein's 2,100 aphorisms, Osler collection, LITFL |
+| Software engineering | **Easy** | `dwmkerr/hacker-laws` GitHub repo, Van Vleck's Proverbs |
+| Architecture / planning | **Easy** | A Pattern Language (253 patterns), urban design glossaries |
+| Cooking / culinary arts | **Easy** | Escoffier School glossary, WebstaurantStore, Charnas's 10 principles |
+| Agriculture / farming | **Easy** | Farmer's Almanac tradition, USDA glossaries, Biblical Proverbs |
+| Child psychology | **Easy** | CliffsNotes glossary, Squiggle Foundation (Winnicott) |
+| Math / physics | **Easy** | Wikipedia: Mathematical Folklore, AMS "Foolproof" paper |
+| Visual arts | **Easy-Med** | Bannard's 100 Aphorisms, Henri's Art Spirit, Binyon (Gutenberg) |
+| Military strategy | **Easy-Med** | Napoleon's Maxims (Gutenberg), DoD Dictionary, Wiktionary |
+| Ecology / systems biology | **Medium** | Wikipedia Glossary of Ecology, Larson (2011) |
+| Economics / markets | **Medium** | McCloskey (1985), OMFIF book, Wall Street oral tradition |
+| Anthropology | **Medium** | OUP Companion glossary, Geertz, Macfarlane dictionary |
+| Performing arts | **Medium** | Notes on Directing, Halberstadt, StudioBinder glossary |
+| Firefighting | **Medium** | Wikipedia glossary, 10 Standard Fire Orders, NIOSH reports |
+| Carpentry / woodworking | **Medium** | Wikipedia Glossary of Woodworking, Popular Woodworking |
+| Comedy / stand-up | **Medium** | Andy Riley's writers' room glossary, Greg Dean's glossary |
+| Deep sea / space | **Medium** | NASA glossary, McDowell's Space Report glossary |
+| Folk arts / crafts | **Med-Hard** | Glasgow Mapping Metaphor project (14,000+ connections) |
+| Psychotherapy | **Med-Hard** | Narrative therapy texts (White), ACT metaphor collections |
+
+---
+
+## Cross-domain patterns worth tracking
+
+**Five structural observations** emerged from this research that could shape Metaphorex's taxonomy and architecture:
+
+**Metaphors migrate along predictable paths.** "Pattern language" went from architecture to software to organizational design. "Scaffolding" went from construction to child psychology to education. "Desire paths" went from landscape architecture to UX. "Mise en place" went from cooking to productivity. "Yes, and" went from improv to business to therapy. Tracking these migration histories would be a distinctive Metaphorex feature.
+
+**The most powerful load-bearing metaphors encode entire methodologies, not just names.** "Scaffolding" encodes assess → support → withdraw. "Mise en place" encodes prepare → organize → execute. "Dead reckoning" encodes estimate from known position → account for drift → accept cumulative error. These are the metaphors most worth cataloging because they transmit compressed operational knowledge.
+
+**Load-bearing metaphors come in productive opposed pairs.** "Less is more" / "Less is a bore." "Horses, not zebras" / the zebra as symbol of rare disease advocacy. "Balance of nature" / Holling's non-equilibrium dynamics. "Tragedy of the commons" / Ostrom's self-governing commons. The dialectic between paired metaphors is where professional reasoning actually lives.
+
+**Domains that debate their own metaphors are the richest targets.** Child psychology explicitly asks "should we salvage the scaffolding metaphor?" Ecology publishes papers on how "balance of nature" constrains scientific thinking. Anthropology's *Writing Culture* problematizes its own language. These reflexive debates are themselves harvestable.
+
+**A universal pattern recurs across unrelated domains: "the absence matters as much as the presence."** Music: play the silence. Visual arts: negative space. Theater: what you leave out. Crafts: the space between threads. Architecture: desire paths as the design of omission. Cooking: resting the meat. Identifying such cross-domain isomorphisms could be a core Metaphorex capability.
+
+---
+
+## Top 10 import targets by return on effort
+
+The following resources offer the best ratio of load-bearing metaphor density to import difficulty:
+
+1. **`dwmkerr/hacker-laws` (GitHub)** — 40+ structured laws/principles in Markdown, openly licensed
+2. **Wikipedia Glossary of Nautical Terms** — hundreds of entries, freely licensed, etymologies included
+3. **Broom's Legal Maxims** — 14 editions since 1845, full text on Project Gutenberg
+4. **Glasgow Mapping Metaphor database** — 14,000+ metaphorical connections, academic, queryable
+5. **Schein's "Aphorisms & Quotations for the Surgeon"** — ~2,100 curated items
+6. **Napoleon's Military Maxims** — 78 numbered items, Project Gutenberg
+7. **Bannard's "Aphorisms for Artists"** — 100 numbered items with commentary
+8. **Hauser & Reich's "Notes on Directing"** — 130 numbered lessons
+9. **Toyota UK TPS Glossary + Deming's 14 Points** — structured, official, bounded
+10. **Andy Riley's comedy writers' room glossary** — crowdsourced insider terms with attribution — and a model for what Metaphorex itself could become
+
+The Riley glossary deserves special attention as a format model. It does exactly what Metaphorex aspires to do: collect the insider language that practitioners actually use to reason, attribute it, explain the context, and make it available to outsiders. The difference is scale and cross-domain reach. Metaphorex could be Andy Riley's glossary applied to all of human professional knowledge.

--- a/docs/plans/2026-03-15-kaizen-feedback-loops.md
+++ b/docs/plans/2026-03-15-kaizen-feedback-loops.md
@@ -1,0 +1,386 @@
+# Kaizen Feedback Loops Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the kaizen system visible and self-reinforcing — pitboss uses correct labels, round summaries highlight improvements, survey surfaces the kaizen backlog, and close-the-loop reporting shows the operator what changed.
+
+**Architecture:** Five incremental changes across two files (`work.md`, `survey.py`) plus label hygiene. Each task is independently valuable and can ship alone. No new files, no new dependencies.
+
+**Tech Stack:** Markdown (work.md), Python (survey.py), GitHub CLI (label ops)
+
+---
+
+### Task 1: Pitboss Kaizen Labeling Rule
+
+**Why:** The pitboss filed 5/8 kaizen issues this session with wrong labels (`bug`, `enhancement`), making them invisible to `digest.py` kaizen_backlog(). One-line fix, immediate impact.
+
+**Files:**
+- Modify: `.claude/commands/work.md:111-131` (Phase C section)
+
+**Step 1: Add kaizen labeling rule to work.md**
+
+Insert after the "Stats accounting" section (after line 153), a new section:
+
+```markdown
+## Kaizen reporting
+
+When filing improvement or friction issues during a session, always use the
+kaizen label namespace — never bare `bug` or `enhancement`:
+
+```bash
+gh issue create --repo metaphorex/metaphorex \
+  --label "kaizen:pipeline" \
+  --title "kaizen: <short description>" \
+  --body "<description>"
+```
+
+Use `kaizen:pipeline` for agent prompts, orchestration, scripts, merge flow.
+Use `kaizen:content` for schema, validation, taxonomy issues.
+Search for duplicates first: `gh issue list -R metaphorex/metaphorex --label kaizen:pipeline --state open`
+```
+
+**Step 2: Verify the instruction is reachable**
+
+Run: `grep -c "kaizen:pipeline" .claude/commands/work.md`
+Expected: at least 2 matches (the label and the search command)
+
+**Step 3: Commit**
+
+```bash
+git add .claude/commands/work.md
+git commit -m "kaizen: add pitboss kaizen labeling rules to /work command"
+```
+
+**Human verification:** Read the new section in work.md — does it match the pattern used in `.claude/agents/miner.md` lines 154-179?
+
+---
+
+### Task 2: Survey Surfaces Kaizen Backlog
+
+**Why:** The survey currently returns zero information about kaizen issues. The pitboss can't report what it can't see. Adding a `kaizen_open` field to survey output makes the backlog visible in every round's summary table.
+
+**Files:**
+- Modify: `scripts/survey.py:84-284` (survey function)
+- Test: run `uv run scripts/survey.py --repo metaphorex/metaphorex` and check output
+
+**Step 1: Write a manual test expectation**
+
+Run the survey and confirm kaizen issues are NOT in the output:
+```bash
+uv run scripts/survey.py --repo metaphorex/metaphorex | python3 -c "import json,sys; d=json.load(sys.stdin); print('kaizen_open' in d)"
+```
+Expected: `False`
+
+**Step 2: Add kaizen query to survey.py**
+
+In the `survey()` function, after the existing `pr_in_progress` query (line 108), add a new concurrent query:
+
+```python
+    kaizen_issues = gh_query([
+        "issue", "list", "-R", repo,
+        "--label", "kaizen:pipeline,kaizen:content",
+        "--state", "open",
+        "--json", "number,title,labels",
+        "--limit", "20",
+    ])
+```
+
+Then after the existing `collect()` calls (after line 120), add:
+
+```python
+    kaizen_open = [{"number": i["number"], "title": i["title"]} for i in collect(kaizen_issues)]
+```
+
+Finally, add `"kaizen_open": kaizen_open,` to the result dict (after line 287, the `stale_in_progress` line). Do NOT add kaizen_open to `total_actionable` — kaizen issues are informational, not dispatched work.
+
+**Step 3: Run the survey and verify kaizen appears**
+
+```bash
+uv run scripts/survey.py --repo metaphorex/metaphorex | python3 -c "import json,sys; d=json.load(sys.stdin); print(f'kaizen_open: {len(d.get(\"kaizen_open\", []))}')"
+```
+Expected: `kaizen_open: 8` (or current count of open kaizen issues)
+
+**Step 4: Commit**
+
+```bash
+git add scripts/survey.py
+git commit -m "feat: survey.py surfaces open kaizen issues in output"
+```
+
+**Human verification:** Run the survey — does the `kaizen_open` array contain the issues you filed this session?
+
+---
+
+### Task 3: Round Summary Includes Highlights Section
+
+**Why:** Round summaries currently show only mining output ("Mined 5 issues → PR opened"). The operator has no visibility into improvements made, kaizen filed, or before/after metrics. This is the core feedback loop.
+
+**Files:**
+- Modify: `.claude/commands/work.md:111-131` (Phase C section)
+
+**Step 1: Replace the Phase C round summary template**
+
+Replace the existing Phase C section (lines 111-131) with:
+
+````markdown
+## Phase C — Round summary & loop
+
+After all agents in a round complete, print a round summary with three
+sections: Work, Highlights, and Kaizen.
+
+```
+## Round N Complete
+
+### Work
+- Smelted: PR #55 → needs-assay
+- Assayed: PR #48 → approved + auto-merge
+- Mined: 5 issues → PR #123 opened
+- Remaining: 12 unclaimed issues
+
+### Highlights
+- (any bugs fixed and pushed to main this round)
+- (any stale issues reclaimed, with before/after counts)
+- (any structural improvements made to scripts or agent prompts)
+- (if nothing notable: "Routine round, no structural changes.")
+
+### Kaizen
+- Open: N issues — #1451 (kaizen feedback loops), #1432 (worktree confusion)
+- Filed this round: #1449 (missing playbook details)
+- Resolved this round: #1369, #1370, #1371 (survey.py fixes → commit abc123)
+- (if no kaizen activity: "No kaizen activity this round.")
+```
+
+**Highlights rules:**
+- Only include genuinely notable items — not every agent completing normally
+- Always include before/after metrics when fixing pipeline blockages
+  (e.g., "Reclaimed 187 stale issues: unclaimed went 0 → 188")
+- When pushing fixes to main, name the commit and what it changes
+- When closing kaizen issues, link the fix and describe the impact
+
+**Kaizen rules:**
+- Read `kaizen_open` from the survey output each round
+- Show the open count + first 3 issue numbers/titles
+- Track which kaizen issues were filed or resolved this round
+- When resolving kaizen, always describe what the operator can expect
+  to see differently in future runs
+
+Then loop back to **Phase A** (sync + survey). The sync step pulls any PRs
+that merged during this round, so the next round works from fresh main.
+If `total_actionable` is 0 after survey, print a final summary and stop.
+
+**Do NOT stop early.** The only valid termination condition is
+`total_actionable == 0`. Do not apply cost reasoning, session-length
+heuristics, or "diminishing returns" logic. The user controls budget
+externally; the pipeline runs until idle.
+````
+
+**Step 2: Verify the template has all three sections**
+
+Run: `grep -c "###" .claude/commands/work.md`
+Expected: at least 3 (Work, Highlights, Kaizen)
+
+**Step 3: Commit**
+
+```bash
+git add .claude/commands/work.md
+git commit -m "feat: /work round summaries now include Highlights and Kaizen sections"
+```
+
+**Human verification:** Read the new Phase C — does it describe the three-section format clearly enough that the pitboss will follow it without improvising?
+
+---
+
+### Task 4: Session-End Summary with Before/After Metrics
+
+**Why:** At end of session, the operator should see a dashboard of what the session accomplished — not just "X PRs opened" but "factory went from stalled to producing." This is the cumulative version of per-round Highlights.
+
+**Files:**
+- Modify: `.claude/commands/work.md` (add after Phase C, before Stats accounting)
+
+**Step 1: Add session-end summary template**
+
+Insert before the "Stats accounting" section a new section:
+
+````markdown
+## Session-end summary
+
+When `total_actionable` reaches 0 (or the session ends), print a final
+summary covering the entire session:
+
+```
+## Session Complete
+
+### Production
+- Rounds: N
+- PRs opened: N (list PR numbers)
+- New mappings created: ~N
+- Duplicates closed: N
+- Projects surveyed/approved: N
+- Sub-issues created: N
+
+### Improvements Made
+- (list each structural fix with before/after impact)
+- Example: "Fixed survey.py (3 bugs) → unclaimed went 0 → 188"
+- Example: "Reclaimed 187 stale in-progress issues"
+
+### Kaizen Filed
+- #NNNN: title (priority)
+- #NNNN: title (priority)
+
+### Kaizen Resolved
+- #NNNN: title — fixed via commit/PR, impact description
+
+### Open Kaizen Backlog
+- N issues remain open (list top 5 by priority)
+```
+
+Track these metrics incrementally as the session progresses. Keep running
+counters for PRs opened, mappings created, kaizen filed/resolved.
+````
+
+**Step 2: Verify section exists**
+
+Run: `grep -c "Session-end summary" .claude/commands/work.md`
+Expected: 1
+
+**Step 3: Commit**
+
+```bash
+git add .claude/commands/work.md
+git commit -m "feat: /work includes session-end summary with before/after metrics and kaizen status"
+```
+
+**Human verification:** Does the session-end template capture the kind of summary the operator asked for at the end of the session that prompted this work?
+
+---
+
+### Task 5: Friction Aggregation in Pitboss
+
+**Why:** When 12 miners all hit the same worktree bug (#1432), one agent files it but the pitboss doesn't escalate. The operator has no idea it's systemic until they ask. The pitboss should scan agent results for repeated friction and bump priority.
+
+**Files:**
+- Modify: `.claude/commands/work.md` (add to Phase C, after agent completion)
+
+**Step 1: Add friction aggregation instructions to Phase C**
+
+Insert after the "Wait for all parallel agents to complete" instruction (current line 80-81):
+
+````markdown
+3. **Friction aggregation** — after all agents in a round complete, scan
+   their result text for kaizen issue references (e.g., "#1432"). If 3+
+   agents reference the same kaizen issue:
+   - Add `priority:high` label if not already set:
+     ```bash
+     gh issue edit <N> --repo metaphorex/metaphorex --add-label "priority:high"
+     ```
+   - Add a comment noting the systemic impact:
+     ```bash
+     gh api repos/metaphorex/metaphorex/issues/<N>/comments \
+       -f body="Systemic: hit by N/M agents in round R. Escalating to priority:high."
+     ```
+   - Include in the round summary Kaizen section:
+     "Escalated: #1432 (worktree confusion) — hit by 5/5 miners this round"
+````
+
+**Step 2: Verify the instruction is in Phase C**
+
+Run: `grep -c "Friction aggregation" .claude/commands/work.md`
+Expected: 1
+
+**Step 3: Commit**
+
+```bash
+git add .claude/commands/work.md
+git commit -m "feat: pitboss aggregates repeated agent friction and escalates kaizen priority"
+```
+
+**Human verification:** Read the friction aggregation rule — is the threshold (3+ agents) reasonable? Is the escalation action (priority:high + comment) proportionate?
+
+---
+
+### Task 6: Stale Claim Auto-Reclaim in Pitboss
+
+**Why:** This session required manual reclaim of 187 stale in-progress issues. The pitboss should handle `stale_in_progress` automatically before dispatching miners, so the factory never stalls on orphaned claims again.
+
+**Files:**
+- Modify: `.claude/commands/work.md` (add to Phase B dispatch rules)
+
+**Step 1: Add stale reclaim step to Phase B**
+
+Insert at the beginning of Phase B (before the parallel dispatch group):
+
+````markdown
+0. **Reclaim stale issues** — if `stale_in_progress` is non-empty, remove
+   the `in-progress` label from each stale issue before dispatching miners.
+   These are sub-issues that were claimed by a miner but never completed
+   (no open PR references them).
+
+   ```bash
+   for num in <stale_issue_numbers>; do
+     gh api "repos/metaphorex/metaphorex/issues/$num/labels/in-progress" -X DELETE --silent
+   done
+   ```
+
+   Report in the round summary Highlights:
+   "Reclaimed N stale in-progress issues — now available for mining"
+
+   This step runs before miner dispatch so the reclaimed issues appear
+   in the `unclaimed` bucket on the next survey.
+````
+
+**Step 2: Verify the instruction is in Phase B**
+
+Run: `grep -c "Reclaim stale" .claude/commands/work.md`
+Expected: 1
+
+**Step 3: Commit**
+
+```bash
+git add .claude/commands/work.md
+git commit -m "feat: pitboss auto-reclaims stale in-progress issues before mining dispatch"
+```
+
+**Human verification:** Read the reclaim step — does it match what was done manually in round 2 of this session?
+
+---
+
+### Task 7: Final Integration Test
+
+**Step 1: Run the full survey and verify all new fields**
+
+```bash
+uv run scripts/survey.py --repo metaphorex/metaphorex | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+required = ['needs_smelting', 'needs_assay', 'needs_miner_fix', 'needs_survey',
+            'needs_rework', 'in_progress', 'unclaimed', 'stale_in_progress',
+            'needs_prospecting', 'prospected_projects', 'kaizen_open', 'total_actionable']
+for key in required:
+    print(f'{key}: {len(d[key]) if isinstance(d[key], list) else d[key]}')
+missing = [k for k in required if k not in d]
+print(f'Missing keys: {missing or \"none\"}')
+"
+```
+Expected: All keys present, `kaizen_open` shows current count, no missing keys.
+
+**Step 2: Verify work.md has all new sections**
+
+```bash
+grep -n "Kaizen reporting\|Session-end summary\|Friction aggregation\|Reclaim stale\|### Highlights\|### Kaizen" .claude/commands/work.md
+```
+Expected: 6 matches, one for each new section/subsection.
+
+**Step 3: Run validator to make sure nothing broke**
+
+```bash
+uv run scripts/validate.py validate
+```
+Expected: zero errors, zero new warnings.
+
+**Step 4: Final commit if any cleanup needed, then push**
+
+```bash
+git push origin main
+```
+
+**Human verification:** Read through the complete `work.md` end-to-end. Does the flow make sense? Phase A surveys (including kaizen), Phase B reclaims stale + dispatches, Phase C reports Work + Highlights + Kaizen. Session-end gives the full dashboard.

--- a/playbooks/scheins-surgical-aphorisms/playbook.md
+++ b/playbooks/scheins-surgical-aphorisms/playbook.md
@@ -1,0 +1,242 @@
+---
+project_issue: 1229
+repo: metaphorex/metaphorex
+source_type: book
+status: draft
+---
+
+# Playbook: Schein's Surgical Aphorisms -- Medical Wisdom as Metaphor
+
+## Source Description
+
+This project draws on the surgical and medical aphorism tradition to
+extract conceptual metaphors that have genuine cross-domain transfer
+beyond medicine. The primary source is Moshe Schein's *Aphorisms &
+Quotations for the Surgeon* (tfm Publishing, 2003; ~1,500 items across
+94 chapters), supplemented by:
+
+- William Bean (ed.), *Sir William Osler: Aphorisms from His Bedside
+  Teachings and Writings* (Henry Schuman, 1950; ~280 sayings)
+- Samuel Shem, *The House of God* (1978; 13 numbered Laws)
+- The Mayo Brothers (William J. and Charles H. Mayo) aphorism tradition
+- Traditional surgical folklore (unattributed sayings passed down in
+  residency training)
+
+The combined source pool is ~2,100+ items. However, the vast majority
+are domain-specific clinical advice. The issue's selectivity guidance is
+clear: import only aphorisms that encode reasoning patterns that transfer
+beyond medicine.
+
+**Estimated yield: 20-25 mappings.**
+
+### What Makes This Source Distinctive
+
+Medical aphorisms are unusual in the metaphor landscape because:
+
+1. **Life-or-death stakes compress wisdom.** These are not armchair
+   philosophies but decision heuristics tested under mortal pressure.
+2. **Medicine is the original applied epistemology.** Diagnosis *is*
+   reasoning under uncertainty. Triage *is* resource allocation. The
+   metaphorical transfer is structural, not decorative.
+3. **Many have already crossed over.** "Triage," "first do no harm,"
+   "diagnosis," "vital signs," "second opinion," and "side effects" are
+   dead metaphors in business and technology -- so deeply embedded that
+   people forget they are medical.
+
+## Access Method
+
+### Primary Archive: Internet Archive -- Osler Aphorisms (full text)
+
+**URL:** https://archive.org/stream/in.ernet.dli.2015.63933/2015.63933.Osler-Aphorisms-From-His-Bedside-Teachings-And-Writings_djvu.txt
+
+Full OCR text of Bean's 1950 edition of Osler's aphorisms, organized
+into sections: The Medical Student, The Ethos, The Patient, The Great
+Republic of Medicine, Epitomes. Free access, no authentication required.
+
+### Secondary Archive: LITFL Oslerisms
+
+**URL:** https://litfl.com/eponymictionary/oslerisms/
+
+Curated selection of Osler quotations maintained by the Life in the Fast
+Lane medical education site. 27+ aphorisms with context.
+
+### Tertiary Archive: Mayo Clinic Library Aphorisms Guide
+
+**URL:** https://libraryguides.mayo.edu/historicalunit/aphorisms
+
+Extensive collection of William J. Mayo and Charles H. Mayo quotations
+(190+ items), organized by speaker.
+
+### House of God Laws
+
+**URL:** https://litfl.com/house-of-god/
+
+The 13 Laws from Shem's novel, widely known in medical culture.
+
+### No Structured Digital Archive Exists for Schein
+
+Schein's book is copyrighted and not digitized in any open archive. The
+PMC book review (https://pmc.ncbi.nlm.nih.gov/articles/PMC1422679/)
+confirms 1,500+ items across 94 alphabetically-ordered chapters but
+quotes only a handful. No table of contents or chapter listing is
+publicly available online.
+
+**Consequence:** Candidates sourced from Schein are tagged `"llm"` in the
+manifest because they cannot be verified against a scraping script. The
+Osler, Mayo, and House of God candidates are tagged `"archive"` where
+the exact text was found in the archive sources above.
+
+### Surgical Folklore (Unattributed)
+
+Many of the most potent surgical aphorisms circulate without clear
+attribution. The BJS article by Campbell (2013) and the West J Med
+article by Merrell & McGreevy (1991) document these as oral tradition.
+Candidates from this tradition are tagged `"llm"` but are well-attested
+in multiple independent sources.
+
+## Extraction Strategy
+
+### Selection Criteria
+
+An aphorism qualifies for the manifest ONLY if it meets ALL of:
+
+1. **Cross-domain transfer.** The saying must encode a reasoning pattern
+   that has demonstrable use outside medicine. "NPO after midnight" does
+   not qualify. "When you hear hoofbeats, think horses not zebras"
+   encodes base-rate reasoning used in debugging, investing, and
+   engineering.
+
+2. **Structural mapping, not just analogy.** The metaphorical transfer
+   must involve a source frame (medicine/surgery) mapping onto a target
+   frame (decision-making, organizational behavior, epistemology, etc.)
+   with specific structural correspondences.
+
+3. **Active usage.** The concept must be currently used metaphorically
+   in at least one non-medical domain. Historical curiosities that
+   never left medicine are excluded.
+
+### For Miners
+
+Each candidate in the manifest has:
+- `slug`: the filename for `catalog/mappings/{slug}.md`
+- `name`: human-readable name
+- `kind`: `conceptual-metaphor`, `dead-metaphor`, or `paradigm`
+- `source_frame`: the medical/surgical domain
+- `target_frame`: the domain where the metaphor has migrated
+- `categories`: primary categorization
+- `aphorism_text`: the canonical form of the saying (where applicable)
+- `source`: `"archive"` or `"llm"`
+- `description`: what makes this interesting as a cross-domain mapping
+
+**Miner workflow:**
+
+1. For `source: "archive"` entries, fetch the archive URL listed and
+   extract the original context
+2. Research the medical origin: when was this concept first articulated,
+   by whom, under what circumstances?
+3. Document the cross-domain migration: how did this medical concept
+   enter business/technology/everyday language? What structural parallels
+   does the borrowing exploit?
+4. **"Where It Breaks" is critical.** Medical metaphors often import
+   false authority ("the diagnosis is...") or false precision ("vital
+   signs show..."). The Miner must interrogate what the medical framing
+   smuggles into the target domain.
+5. Set `author: schein-surgical-aphorisms` as provenance
+6. Set `related:` links to other entries from this project and to
+   existing catalog entries where relevant
+
+### Batching Recommendation
+
+Process in thematic clusters:
+
+- **Batch 1 -- Decision heuristics (6):** triage, differential-diagnosis,
+  hoofbeats-think-horses, first-do-no-harm, second-opinion,
+  treat-the-patient-not-the-test
+- **Batch 2 -- Temporal wisdom (4):** all-bleeding-stops, the-tincture-
+  of-time, never-let-the-sun-set-on-undrained-pus, a-chance-to-cut-is-a-
+  chance-to-cure
+- **Batch 3 -- Composure and judgment (5):** take-your-own-pulse,
+  the-enemy-of-good-is-better, the-retrospectoscope,
+  experience-is-the-great-teacher, we-may-be-wrong-but-never-in-doubt
+- **Batch 4 -- Systemic/organizational (5):** side-effects,
+  vital-signs, prognosis-as-forecast, surgical-precision,
+  see-one-do-one-teach-one
+
+## Schema Mapping
+
+### Kind Assignment
+
+| Pattern | Kind | Criteria |
+|---------|------|----------|
+| Active aphorism with clear source-target structure | `conceptual-metaphor` | Clear structural mapping between medicine and another domain |
+| Medical term so embedded it is no longer felt as metaphorical | `dead-metaphor` | "Triage," "diagnosis," "side effects" in business |
+| Systematic framework | `paradigm` | Triage as a complete decision system |
+
+Most entries will be `conceptual-metaphor`. A few high-frequency dead
+metaphors (triage, diagnosis, vital signs) are `dead-metaphor`.
+
+### Frame Inventory
+
+**Existing reusable frames:**
+- `medicine` -- source frame for most entries
+- `decision-making` -- target for diagnostic/triage metaphors
+- `social-behavior` -- target for organizational metaphors
+- `time-and-temporality` -- target for temporal aphorisms
+- `ethics-and-morality` -- target for "first do no harm"
+- `education` -- target for "see one, do one, teach one"
+
+**New frames potentially needed:**
+- `surgery` -- more specific than `medicine` for operative aphorisms
+- `organizational-management` -- target for management metaphors
+- `epistemology` -- target for reasoning-under-uncertainty metaphors
+
+### Categories
+
+Primary category for all entries: `health-and-medicine`.
+
+Additional categories by cluster:
+- Decision heuristics: `cognitive-science`
+- Temporal wisdom: `philosophy`
+- Composure/judgment: `psychology`
+- Systemic: `organizational-behavior`
+
+## Gotchas
+
+1. **Copyright on Schein.** The book is copyrighted and not freely
+   available online. Miners should not attempt to reproduce verbatim
+   content from Schein. The aphorisms themselves are traditional sayings
+   (not copyrightable), but Schein's commentary and selection are his
+   intellectual property. Miners should cite Schein as a collector, not
+   quote his prose.
+
+2. **Attribution is fuzzy.** Many surgical aphorisms circulate without
+   clear attribution. "All bleeding eventually stops" is variously
+   attributed to multiple surgeons. Miners should note the attribution
+   uncertainty in the Origin Story section rather than asserting false
+   precision.
+
+3. **Dead metaphors require extra work.** For entries like "triage" and
+   "diagnosis," the metaphorical transfer happened so long ago that
+   people do not experience these as metaphors. The "What It Brings"
+   section needs to defamiliarize the concept: explain why the medical
+   origin matters and what structural baggage it carries into the
+   target domain.
+
+4. **"First do no harm" is misattributed.** Commonly attributed to
+   Hippocrates, it does not appear in the Hippocratic corpus in that
+   exact form. The Latin "primum non nocere" is of uncertain origin.
+   Miners should address this in the Origin Story.
+
+5. **Overlapping entries.** Some candidates overlap conceptually (e.g.,
+   "triage" and "differential diagnosis" both involve prioritization).
+   Use `related:` links to connect them rather than merging.
+
+6. **The House of God is satire.** Shem's Laws are satirical and often
+   dark. The ones included here (Law III: "take your own pulse"; Law
+   XIII: "do as much nothing as possible") have transcended their
+   satirical origin to become genuine wisdom. Miners should acknowledge
+   the satirical source while treating the cross-domain insight
+   seriously.
+
+7. **Candidate count is under 100.** No sub-issue cap concerns for
+   this project.


### PR DESCRIPTION
## Summary
- **Kaizen feedback loops plan** (`docs/plans/2026-03-15-kaizen-feedback-loops.md`) — the design doc behind PR #1457, committed alongside its implementation
- **Metaphor sources research** (`docs/plans/2026-03-13-Metaphor-sources-to-mine.md`) — 22-domain harvest map with top 10 import targets by ROI
- **Scheins surgical aphorisms playbook** (`playbooks/scheins-surgical-aphorisms/playbook.md`) — prospecting playbook for issue #1229, ~20-25 medical aphorism mappings in 4 thematic batches
- **gitignore** — add `__pycache__/`

No code changes. All docs/planning artifacts that were sitting untracked.

## Test plan
- [ ] `uv run scripts/validate.py validate` passes clean (no content changes)
- [ ] Playbook frontmatter references valid issue #1229

🤖 Generated with [Claude Code](https://claude.com/claude-code)