### PR TITLE
Add entry: Tricorder Is Universal Sensor

### DIFF
--- a/catalog/frames/science-fiction.md
+++ b/catalog/frames/science-fiction.md
@@ -1,0 +1,30 @@
+---
+created: '2026-03-16'
+name: Science Fiction
+related:
+- computing
+- artificial-intelligence
+- narrative
+roles:
+- speculative-technology
+- fictional-world
+- thought-experiment
+- alien-encounter
+- utopia
+- dystopia
+- time-travel
+- artificial-being
+slug: science-fiction
+updated: '2026-03-16'
+---
+
+Imagined worlds, technologies, and scenarios that extrapolate from current
+science and social trends. Science fiction is an unusually productive source
+domain for metaphor because it manufactures concrete, vivid objects (tricorders,
+holodecks, warp drives) that stand in for abstract concepts still lacking
+literal vocabulary. Many sci-fi terms have crossed into general usage with their
+fictional origins fading -- "grok," "cyberspace," "robot" -- becoming dead
+metaphors whose source domain is a novel or film rather than a physical
+experience. The genre also generates thought experiments (paperclip maximizers,
+three-body problems) that function as mental models for reasoning about real
+risks and tradeoffs.

--- a/catalog/mappings/tricorder-is-universal-sensor.md
+++ b/catalog/mappings/tricorder-is-universal-sensor.md
@@ -1,0 +1,132 @@
+---
+applies_to:
+- medicine
+- measurement
+author: agent:metaphorex-miner
+categories:
+- health-and-medicine
+- ai-discourse
+contributors:
+- fshot
+created: '2026-03-16'
+harness: Claude Code
+kind: metaphor
+limits:
+- "[source] A tricorder works by scanning -- it requires no sample preparation,\
+  \ no invasive procedure, no waiting period; real diagnostic instruments\
+  \ rarely achieve all three simultaneously"
+- "[source] The tricorder presents a single unified readout from multiple\
+  \ sensor types, implying that data fusion across modalities is a solved\
+  \ problem"
+- "[source] A tricorder is operated by a single person with no specialized\
+  \ training in the sensor hardware itself -- the device abstracts away\
+  \ all calibration and interpretation"
+name: Tricorder Is Universal Sensor
+related: []
+slug: tricorder-is-universal-sensor
+source_frame: science-fiction
+transfers:
+- "[source] A tricorder collapses many separate instruments into one handheld\
+  \ device, mapping the aspiration to unify fragmented diagnostic workflows"
+- "[source] The tricorder provides instant readout without laboratory delay,\
+  \ structuring the goal of point-of-care diagnostics as scan-and-know"
+- "[source] A tricorder is non-invasive -- it reads the body without cutting\
+  \ or sampling, framing the ideal sensor as one that observes without\
+  \ disturbing"
+updated: '2026-03-16'
+---
+
+## Transfers
+
+Star Trek's tricorder is a handheld device that scans anything -- a patient,
+a rock, an alien atmosphere -- and returns an immediate, comprehensive
+readout. When people call a new diagnostic device "a real-life tricorder,"
+they are importing a specific structure from the fictional source:
+
+- **Convergence of many instruments into one** -- the tricorder replaces
+  the blood test, the X-ray, the MRI, the spectrometer. The metaphor
+  frames the goal of diagnostic technology as radical consolidation: one
+  device, one scan, all the answers. This is why the Qualcomm Tricorder
+  XPRIZE (2012-2017) required competitors to diagnose 13 conditions with
+  a single consumer device.
+- **Instant readout, no laboratory delay** -- the tricorder does not send
+  samples away. It knows immediately. This maps the aspiration for
+  point-of-care diagnostics: the doctor (or patient) scans and acts in
+  the same moment, with no waiting for results.
+- **Non-invasive sensing** -- the tricorder reads the body without touching
+  it, let alone cutting into it. The metaphor frames the ideal sensor as
+  one that observes without disturbing -- a passive receiver of information
+  rather than an active intervention.
+- **Operator-independent** -- McCoy waves the tricorder and reads the
+  display. He is a physician, not an imaging technician. The device
+  abstracts away all the skill of operating an ultrasound, calibrating a
+  mass spectrometer, or interpreting a raw MRI. The metaphor implies that
+  the ideal diagnostic tool requires clinical judgment but not equipment
+  expertise.
+
+## Limits
+
+- **Real sensing involves tradeoffs the tricorder ignores** -- in physics,
+  there is no free lunch: higher resolution requires more energy, broader
+  bandwidth reduces sensitivity, non-invasive methods lose the information
+  that invasive methods gain. The tricorder metaphor flattens these
+  tradeoffs into a single device that does everything well, which can
+  distort engineering expectations and funding priorities.
+- **The tricorder implies diagnosis is a sensing problem** -- in real
+  medicine, diagnosis is only partly about measurement. It is also about
+  patient history, differential reasoning, contextual judgment, and
+  probabilistic thinking. The tricorder metaphor foregrounds the sensor
+  and backgrounds the clinician, which misframes the bottleneck in many
+  diagnostic failures.
+- **Unified readout obscures interpretive complexity** -- a tricorder
+  display shows "the answer." Real multi-modal sensing produces
+  conflicting signals, ambiguous readings, and probability distributions.
+  Fusing data from an optical sensor, an acoustic sensor, and a chemical
+  sensor into a single confident diagnosis is an unsolved problem, not
+  a display design challenge.
+- **The metaphor creates unrealistic consumer expectations** -- calling
+  a device a "tricorder" promises a Star Trek experience. When the device
+  requires training, produces uncertain results, or only works for some
+  conditions, users feel cheated -- not because the device is bad, but
+  because the metaphor promised more than any real device can deliver.
+
+## Expressions
+
+- "The medical tricorder" -- generic label for any handheld diagnostic
+  device that aspires to multi-condition scanning
+- "Qualcomm Tricorder XPRIZE" -- the literal competition (2012-2017)
+  to build a consumer diagnostic device, named after the Star Trek prop
+- "We need a tricorder for X" -- expressing the desire for a single
+  universal instrument in any domain (environmental monitoring, food
+  safety, materials science)
+- "Tricorder-class device" -- marketing and grant-writing language for
+  point-of-care diagnostics
+- "Just wave it and get the answer" -- the aspiration embedded in the
+  metaphor, often used critically when a device fails to deliver
+
+## Origin Story
+
+The tricorder first appeared in the original Star Trek series (1966-1969)
+as a standard-issue Starfleet scanning device. The "medical tricorder"
+variant, used by Dr. McCoy, could diagnose any condition by waving the
+sensor over the patient. The prop was designed to look futuristic and
+simple -- no cables, no reagents, no waiting.
+
+The term entered real-world technology discourse in the 2000s as
+miniaturized sensors, MEMS devices, and machine learning made handheld
+multi-sensor platforms conceivable. The Qualcomm Tricorder XPRIZE (2012)
+made the connection explicit: build a consumer device that diagnoses 13
+health conditions. The competition was won in 2017 by Final Frontier
+Medical Devices (the name itself a Star Trek reference), though the
+winning device fell far short of the fictional ideal.
+
+Today "tricorder" functions as both aspiration and benchmark in medical
+device development, environmental sensing, and analytical chemistry.
+
+## References
+
+- Roddenberry, G. *Star Trek* (NBC, 1966-1969) -- the original tricorder prop
+- Qualcomm Tricorder XPRIZE, https://www.xprize.org/prizes/tricorder
+- Topol, E. *The Creative Destruction of Medicine* (2012), Chapter 7 --
+  discusses the tricorder aspiration in digital health
+- Harris, B. et al. "The Tricorder Project" in *IEEE Spectrum* (2014)


### PR DESCRIPTION
## Summary

- Adds `tricorder-is-universal-sensor` (metaphor) from science-fiction-metaphors project
- Creates `science-fiction` frame (new, shared across sci-fi entries)
- Star Trek's tricorder as metaphor for handheld multi-modal diagnostics

Closes #1049

## Validation

✓ `uv run scripts/validate.py` — 0 errors
✓ Author format: `agent:metaphorex-miner`
✓ Harness: `Claude Code`
✓ Slug matches filename: `tricorder-is-universal-sensor`
✓ All required sections present: Transfers, Limits, Expressions
✓ Related frame included: `science-fiction`

Generated with [Claude Code](https://claude.com/claude-code)