### PR TITLE
Add entry: Holodeck Is Total Simulation

### DIFF
--- a/catalog/frames/science-fiction.md
+++ b/catalog/frames/science-fiction.md
@@ -1,0 +1,30 @@
+---
+created: '2026-03-16'
+name: Science Fiction
+related:
+- computing
+- artificial-intelligence
+- narrative
+roles:
+- speculative-technology
+- fictional-world
+- thought-experiment
+- alien-encounter
+- utopia
+- dystopia
+- time-travel
+- artificial-being
+slug: science-fiction
+updated: '2026-03-16'
+---
+
+Imagined worlds, technologies, and scenarios that extrapolate from current
+science and social trends. Science fiction is an unusually productive source
+domain for metaphor because it manufactures concrete, vivid objects (tricorders,
+holodecks, warp drives) that stand in for abstract concepts still lacking
+literal vocabulary. Many sci-fi terms have crossed into general usage with their
+fictional origins fading -- "grok," "cyberspace," "robot" -- becoming dead
+metaphors whose source domain is a novel or film rather than a physical
+experience. The genre also generates thought experiments (paperclip maximizers,
+three-body problems) that function as mental models for reasoning about real
+risks and tradeoffs.

--- a/catalog/mappings/holodeck-is-total-simulation.md
+++ b/catalog/mappings/holodeck-is-total-simulation.md
@@ -1,0 +1,142 @@
+---
+applies_to:
+- computing
+- education
+author: agent:metaphorex-miner
+categories:
+- computer-science
+- arts-and-culture
+contributors:
+- fshot
+created: '2026-03-16'
+harness: Claude Code
+kind: metaphor
+limits:
+- "[source] A holodeck simulation is indistinguishable from reality for\
+  \ the participant -- no uncanny valley, no latency, no rendering artifacts"
+- "[source] The holodeck runs entirely self-contained scenarios with no\
+  \ external data dependencies or network effects"
+- "[source] Holodeck users can exit at any time by voice command -- the\
+  \ boundary between simulation and reality is always under user control"
+name: Holodeck Is Total Simulation
+related: []
+slug: holodeck-is-total-simulation
+source_frame: science-fiction
+transfers:
+- "[source] A holodeck generates a complete sensory environment from a\
+  \ program specification, mapping the aspiration to create immersive\
+  \ experiences from declarative descriptions"
+- "[source] The holodeck adapts its scenario in real time to participant\
+  \ actions, structuring the ideal simulation as responsive rather than\
+  \ pre-scripted"
+- "[source] A holodeck serves training, entertainment, and therapeutic\
+  \ purposes interchangeably, framing total simulation as a general-purpose\
+  \ platform"
+updated: '2026-03-16'
+---
+
+## Transfers
+
+Star Trek's holodeck is a room-sized simulator that generates fully
+immersive environments -- physical objects you can touch, characters you
+can talk to, scenarios that respond to your actions in real time. When
+people call a VR system, training simulator, or digital twin "a holodeck,"
+they are importing a specific set of structural expectations:
+
+- **Total sensory immersion from a declarative spec** -- a holodeck user
+  says "Computer, load program" and gets a complete world. The metaphor
+  frames the goal of simulation technology as: describe what you want,
+  and the system generates all the sensory detail. This maps directly onto
+  aspirations for generative AI environments, where a text prompt produces
+  a navigable 3D scene.
+- **Responsive, not pre-scripted** -- holodeck scenarios adapt in real
+  time. Characters respond to what you say. The environment changes based
+  on your actions. This structures the expectation that a good simulation
+  is not a movie you walk through but a world that reacts to you -- the
+  distinction between scripted tutorials and open-ended sandbox
+  environments.
+- **General-purpose platform** -- the same holodeck serves Worf's
+  combat training, Picard's detective novels, and Troi's therapeutic
+  sessions. The metaphor frames total simulation as a single platform
+  that supports any use case, rather than specialized simulators for
+  specialized tasks. This is why VR companies position their hardware as
+  platforms, not single-purpose devices.
+- **Physical interaction with virtual objects** -- holodeck objects have
+  mass, texture, and resistance. You can sit in a holodeck chair and hold
+  a holodeck glass of wine. The metaphor sets haptic fidelity as a core
+  requirement, distinguishing "holodeck-class" simulation from visual-only
+  VR.
+
+## Limits
+
+- **The holodeck has no uncanny valley** -- the fictional technology
+  produces perfect fidelity by assumption. Real simulation technology
+  lives in the uncanny valley: close enough to reality to invite
+  comparison, far enough to feel wrong. The holodeck metaphor makes this
+  gap invisible, framing it as a temporary engineering problem rather
+  than a potentially fundamental perceptual challenge.
+- **The metaphor obscures computation costs** -- a holodeck runs on a
+  starship's effectively unlimited power supply. Real immersive
+  simulation requires enormous computational resources, scales poorly
+  with fidelity, and faces hard tradeoffs between resolution, latency,
+  and scene complexity. "Building a holodeck" sounds like a product
+  roadmap; the physics of real-time photorealistic rendering suggest it
+  is closer to a research frontier.
+- **Exit is always available** -- holodeck users say "Computer, end
+  program" and walk out. The metaphor assumes clean boundaries between
+  simulation and reality. Real immersive systems raise genuine questions
+  about addiction, dissociation, and the psychological blurring of
+  simulated and real experiences. The holodeck metaphor handles the
+  "what can we build?" question but not the "what does it do to us?"
+  question.
+- **Solo or small-group framing** -- the holodeck typically serves one
+  user or a small team. It does not model massively multiplayer shared
+  worlds, network latency, or the social dynamics of persistent virtual
+  spaces. The metaphor is better suited to "personal simulation chamber"
+  than to "metaverse."
+- **The holodeck malfunction is the only acknowledged failure mode** --
+  in Star Trek, the holodeck's failure mode is that the safety protocols
+  turn off and the simulation becomes dangerous. Real simulation failures
+  are subtler: incorrect training data, biased scenarios, simulator
+  sickness, transfer gaps between simulated and real skills. The
+  holodeck's dramatic failure mode overshadows the mundane ones.
+
+## Expressions
+
+- "We're building the holodeck" -- venture capital pitch language for
+  immersive VR/AR platforms
+- "Holodeck for X" -- training, therapy, architecture, retail; the
+  template for applying total simulation to any vertical
+- "The holodeck problem" -- the challenge of making simulated
+  environments feel physically real, especially haptics
+- "When we get the holodeck" -- framing a future state where simulation
+  is good enough to replace physical presence
+- "Holodeck-ready" -- marketing term for hardware or content that aspires
+  to immersive-simulation quality
+
+## Origin Story
+
+The holodeck appeared in Star Trek: The Next Generation (1987-1994) as a
+standard feature of the Enterprise-D. It was preceded by the "recreation
+room" in Star Trek: The Animated Series (1973) and conceptually by the
+"experience machine" thought experiment in Robert Nozick's *Anarchy,
+State, and Utopia* (1974), though the holodeck became the culturally
+dominant image.
+
+The term became a technology benchmark in the 1990s as VR headsets
+emerged and failed to deliver on the promise. Each new wave of immersive
+technology -- VRML in the 1990s, Second Life in the 2000s, Oculus Rift
+in the 2010s, Apple Vision Pro in the 2020s -- has been measured against
+the holodeck standard. Mark Zuckerberg's 2021 Meta rebrand explicitly
+invoked holodeck-like aspirations. The metaphor persists because no
+real technology has come close enough to retire it.
+
+## References
+
+- Roddenberry, G. *Star Trek: The Next Generation* (Syndication, 1987-1994)
+- Nozick, R. *Anarchy, State, and Utopia* (1974) -- the "experience
+  machine" thought experiment
+- Murray, J. *Hamlet on the Holodeck* (1997) -- early academic treatment
+  of interactive narrative using the holodeck as organizing metaphor
+- Bailenson, J. *Experience on Demand* (2018) -- VR research framed
+  against the holodeck aspiration


### PR DESCRIPTION
## Summary

- Adds `holodeck-is-total-simulation` (metaphor) from science-fiction-metaphors project
- Includes `science-fiction` frame
- Star Trek's holodeck as metaphor for immersive simulation -- VR, digital twins, generative environments

Closes #1050

## Validation

✓ `uv run scripts/validate.py` — 0 errors
✓ Author format: `agent:metaphorex-miner`
✓ Harness: `Claude Code`
✓ Slug matches filename: `holodeck-is-total-simulation`
✓ All required sections present: Transfers, Limits, Expressions
✓ Related frame included: `science-fiction`

Generated with [Claude Code](https://claude.com/claude-code)