### PR TITLE
Fix kaizen #1262: smelter uses wrong label ready-for-assay

### DIFF
--- a/.claude/agents/smelter.md
+++ b/.claude/agents/smelter.md
@@ -41,7 +41,7 @@ transform raw mining output into clean, validated content.
 
 1. Find PRs labeled `needs-smelting` (up to 2 per invocation)
 2. Run mechanical checks and push fixup commits
-3. Advance PRs to `ready-for-assay` or flag as `needs-miner-fix`
+3. Advance PRs to `needs-assay` or flag as `needs-miner-fix`
 
 **Process:**
 
@@ -61,7 +61,7 @@ transform raw mining output into clean, validated content.
       for every sub-issue in the batch
    f. Run `uv run scripts/validate.py validate`
    g. If issues found: push fixup commits to the PR branch
-   h. If all fixed: remove `smelting`, add `ready-for-assay`
+   h. If all fixed: remove `smelting`, add `needs-assay`
    i. If unfixable (e.g., missing frame that doesn't exist, broken entry
       structure): remove `smelting`, add `needs-miner-fix`, post comment
       explaining the specific error


### PR DESCRIPTION
## Summary

Fixes #1262

The smelter agent prompt referenced `ready-for-assay` in two places:
- Line 44: the summary of responsibilities
- Line 64: the step where it relabels a PR after successful smelting

The rest of the pipeline (survey.py, assayer.md, work.md) all use `needs-assay`. This mismatch meant smelted PRs were labeled with a tag nobody listens for, so they never entered the assay queue.

## Fix

Replaced both occurrences of `ready-for-assay` with `needs-assay` in `.claude/agents/smelter.md`.

## Test plan

- [x] `grep ready-for-assay .claude/agents/smelter.md` returns zero matches
- [x] `grep needs-assay .claude/agents/smelter.md` shows the label in both expected locations
- [x] `uv run scripts/validate.py validate` passes (0 errors)

Generated with [Claude Code](https://claude.com/claude-code)