### PR TITLE
Add entry: Waldo Is Remote Manipulation

### DIFF
--- a/catalog/frames/science-fiction.md
+++ b/catalog/frames/science-fiction.md
@@ -1,0 +1,27 @@
+---
+created: '2026-03-16'
+name: Science Fiction
+related:
+- technology
+roles:
+- invention
+- future
+- alien
+- dystopia
+- utopia
+- spacecraft
+- android
+- colony
+- artificial-intelligence
+slug: science-fiction
+updated: '2026-03-16'
+---
+
+Speculative narratives built around technological or social extrapolation.
+Science fiction has been one of the most productive source domains for
+conceptual vocabulary in technology, politics, and philosophy. Terms like
+"robot," "cyberspace," "waldo," and "virus" migrated from SF stories into
+technical and everyday language, often losing their fictional origins
+entirely. The frame's power lies in its ability to concretize abstractions
+through narrative: a concept that would be opaque as a definition becomes
+vivid as a story.

--- a/catalog/mappings/waldo-is-remote-manipulation.md
+++ b/catalog/mappings/waldo-is-remote-manipulation.md
@@ -1,0 +1,130 @@
+---
+applies_to:
+- tool-use
+- manufacturing
+author: agent:metaphorex-miner
+categories:
+- physics-and-engineering
+contributors: []
+created: '2026-03-16'
+dead: true
+harness: Claude Code
+kind: metaphor
+name: Waldo Is Remote Manipulation
+related:
+- agent-swarm
+slug: waldo-is-remote-manipulation
+source_frame: science-fiction
+transfers:
+- "[source] A waldo is a mechanical hand operated from a distance, replicating the operator's grip and motion"
+- "[source] The operator cannot feel what the waldo touches except through mediated feedback"
+- "[source] The waldo amplifies or reduces the operator's movements to match the scale of the task"
+limits:
+- "[source] A waldo is a slave device with no autonomy -- it does nothing without a human operator in the loop"
+- "[source] The waldo's fidelity degrades with distance and latency -- the further away, the clumsier the grasp"
+updated: '2026-03-16'
+---
+
+## Transfers
+
+Robert A. Heinlein's 1942 novella "Waldo" featured a character who built
+mechanical arms to manipulate objects remotely. The devices were so vividly
+described that real-world engineers adopted the name for their own remote
+manipulators. By the 1950s, "waldo" was a standard engineering term for
+any master-slave teleoperator -- a mechanical device that reproduces the
+operator's hand movements at a distance.
+
+The metaphor imports several structural features from Heinlein's fiction:
+
+- **Extension of the body** -- Heinlein's Waldo Jones was physically weak
+  and used his waldos to interact with the physical world from his orbital
+  home. The engineering term inherits this idea: a waldo extends the human
+  hand into environments the body cannot reach -- inside nuclear reactors,
+  underwater, in contaminated zones. The tool is conceptualized not as a
+  separate machine but as a prosthetic extension of the operator.
+- **Mimetic coupling** -- in the story, the waldos faithfully reproduced
+  the operator's gestures. Real teleoperators are designed around this
+  same principle: the mechanical arm mirrors the human arm's movements.
+  The fiction established the expectation that remote manipulation should
+  feel like natural movement, not like programming a robot.
+- **Scale transformation** -- Heinlein described waldos that could be
+  scaled up or down, letting the operator do fine microsurgery or move
+  heavy machinery with the same hand gestures. This concept transferred
+  directly into engineering, where teleoperators routinely translate
+  movements between scales -- a surgeon's centimeter-scale hand movements
+  become millimeter-scale instrument movements.
+- **The absent body** -- the operator is physically elsewhere. The waldo
+  metaphor frames remote manipulation as a particular kind of presence:
+  you are there through your hands but not through your body. This shaped
+  how engineers think about telepresence -- as a partial projection of
+  agency, not full embodiment.
+
+## Limits
+
+- **Heinlein's waldos were magical** -- the fictional devices had perfect
+  fidelity, zero latency, and infinite range. Real teleoperators suffer
+  from all three problems. Signal delay makes remote surgery at great
+  distances dangerous. Force feedback is crude compared to the human hand's
+  sensitivity. The fiction set expectations that engineering still cannot
+  meet, and the borrowed name carries those inflated expectations with it.
+- **Modern remote manipulation is increasingly autonomous** -- Heinlein's
+  waldos were pure slave devices: no intelligence, just faithful copying
+  of the operator's intent. Contemporary surgical robots, industrial
+  teleoperators, and Mars rovers incorporate significant autonomous
+  behavior -- tremor filtering, collision avoidance, path planning. The
+  "waldo" framing, with its emphasis on direct mimetic control, obscures
+  the shift toward shared autonomy between operator and machine.
+- **The metaphor hides the interface** -- in Heinlein's story, using a
+  waldo was as natural as using your own hands. In reality, operating a
+  telemanipulator requires extensive training and involves a complex
+  interface: pedals, joysticks, displays, haptic feedback devices. The
+  borrowed fictional name makes the technology sound intuitive when it
+  is anything but.
+- **The word is dying** -- "waldo" as an engineering term peaked in the
+  mid-twentieth century. Modern discourse prefers "teleoperator,"
+  "telerobot," "remote manipulator," or specific product names. The
+  metaphor's death illustrates how fiction-to-engineering borrowings
+  fade as the field develops its own technical vocabulary.
+
+## Expressions
+
+- "Pass me the waldos" -- referring to remote manipulator arms in nuclear
+  facilities, a usage documented since the 1950s
+- "Waldo operation" -- performing a task through a teleoperator, used in
+  nuclear engineering contexts
+- "Waldos" in surgical robotics discussions -- informal term for the
+  manipulator arms of systems like the da Vinci surgical robot
+- "He's using waldos" -- colloquial description of remote manipulation
+  in hazardous environment work
+
+## Origin Story
+
+Heinlein published "Waldo" under the pen name Anson MacDonald in the
+August 1942 issue of *Astounding Science-Fiction*. The protagonist,
+Waldo Farthingwaite Jones, suffered from myasthenia gravis and lived in
+an orbital habitat, interacting with the world below through his
+eponymous remote manipulators. The devices could be built at any scale
+and were operated through a gestural interface that transmitted the
+operator's movements with perfect fidelity.
+
+The term entered engineering vocabulary through the nuclear industry.
+After World War II, facilities handling radioactive materials needed
+tools that let operators manipulate objects behind thick shielding.
+Engineers who had read Heinlein's story naturally called the devices
+"waldos." Raymond Goertz at Argonne National Laboratory built the first
+practical master-slave teleoperator in 1949, and the Heinlein term
+attached to this class of devices. By the 1960s, "waldo" appeared in
+engineering handbooks without attribution to its fictional source --
+the metaphor had died, the word fully naturalized.
+
+## References
+
+- Heinlein, R.A. "Waldo" (1942), published in *Astounding Science-Fiction*
+  -- the source fiction
+- Goertz, R.C. "Fundamentals of General-Purpose Remote Manipulators"
+  (1952), *Nucleonics* -- early engineering adoption of teleoperator
+  concepts
+- Vertut, J. and Coiffet, P. *Robot Technology: Teleoperation and
+  Robotics* (1986) -- documents the "waldo" terminology in engineering
+- Nichols, P. (ed.) *The Encyclopedia of Science Fiction* (1979) --
+  entry on "Waldo" and its influence on engineering terminology


### PR DESCRIPTION
## Summary

- Adds `waldo-is-remote-manipulation` mapping entry (metaphor, dead: true)
- Creates `science-fiction` frame (shared by all entries in this project)
- Source: Heinlein's 1942 novella "Waldo" -- term adopted by nuclear engineers for teleoperators

Closes #1053
Sub-issue of #218

## Validation

✓ `uv run scripts/validate.py validate` — 0 errors

---
Generated with [Claude Code](https://claude.com/claude-code)