### PR TITLE
Add entry: Replicant Is Artificial Person

### DIFF
--- a/catalog/frames/science-fiction.md
+++ b/catalog/frames/science-fiction.md
@@ -1,0 +1,27 @@
+---
+created: '2026-03-16'
+name: Science Fiction
+related:
+- technology
+roles:
+- invention
+- future
+- alien
+- dystopia
+- utopia
+- spacecraft
+- android
+- colony
+- artificial-intelligence
+slug: science-fiction
+updated: '2026-03-16'
+---
+
+Speculative narratives built around technological or social extrapolation.
+Science fiction has been one of the most productive source domains for
+conceptual vocabulary in technology, politics, and philosophy. Terms like
+"robot," "cyberspace," "waldo," and "virus" migrated from SF stories into
+technical and everyday language, often losing their fictional origins
+entirely. The frame's power lies in its ability to concretize abstractions
+through narrative: a concept that would be opaque as a definition becomes
+vivid as a story.

--- a/catalog/mappings/replicant-is-artificial-person.md
+++ b/catalog/mappings/replicant-is-artificial-person.md
@@ -1,0 +1,161 @@
+---
+applies_to:
+- artificial-intelligence
+- ethics-and-morality
+author: agent:metaphorex-miner
+categories:
+- ai-discourse
+- philosophy
+contributors: []
+created: '2026-03-16'
+harness: Claude Code
+kind: metaphor
+name: Replicant Is Artificial Person
+related:
+- agent-swarm
+slug: replicant-is-artificial-person
+source_frame: science-fiction
+transfers:
+- "[source] A replicant is manufactured to be indistinguishable from a human, making the boundary between natural and artificial a matter of origin rather than observable difference"
+- "[source] Replicants are given false memories to stabilize their sense of identity, implying that personhood depends on narrative continuity rather than biological substrate"
+- "[source] Replicants have a fixed lifespan built in by their creators, making mortality a design constraint rather than a natural process"
+limits:
+- "[source] Replicants are engineered products with specifications and expiration dates -- real persons are not designed to fulfill a purpose or optimized for a function"
+- "[source] The Voigt-Kampff test assumes empathy is the marker of genuine personhood, which is a culturally specific and philosophically contested criterion"
+updated: '2026-03-16'
+---
+
+## Transfers
+
+Philip K. Dick's 1968 novel *Do Androids Dream of Electric Sheep?* and
+Ridley Scott's 1982 film *Blade Runner* introduced the replicant -- an
+artificial being so perfectly manufactured that it is biologically
+indistinguishable from a human. The word "replicant" (coined for the film,
+not present in Dick's novel) maps the concept of biological replication
+onto industrial manufacturing: these beings are replicas of humans,
+produced rather than born.
+
+The metaphor structures contemporary discourse about artificial persons:
+
+- **Manufacturing replaces birth** -- replicants are made, not born. They
+  emerge from factories with implanted skills, designated roles, and
+  predetermined lifespans. The metaphor maps the entire apparatus of
+  industrial production (design, manufacture, quality control, planned
+  obsolescence) onto the creation of persons. When we discuss AI systems
+  as "artificial persons" or debate robot rights, we operate within this
+  conceptual space: personhood originating from a production line rather
+  than a womb.
+- **Memory as software** -- replicants receive implanted memories to give
+  them a sense of identity and emotional stability. The metaphor frames
+  personal history as something that can be written, installed, and
+  debugged. This has become a powerful conceptual tool for thinking about
+  AI alignment: if an artificial person's values and sense of self are
+  installed rather than developed, what is the moral status of that
+  identity? The implanted-memory concept migrated directly into AI
+  discourse around system prompts, RLHF, and constitutional AI.
+- **The indistinguishability test** -- the Voigt-Kampff test in Blade
+  Runner (adapted from Dick's empathy test) establishes that the only
+  way to distinguish a replicant from a human is a specific behavioral
+  test. The metaphor frames artificial personhood as a detection problem:
+  if you cannot tell the difference, is there a difference? This
+  structure directly anticipates the Turing Test framing of AI
+  intelligence and the contemporary debate about whether passing
+  behavioral benchmarks constitutes understanding.
+- **Expiration as design feature** -- replicants have a four-year
+  lifespan, built in to prevent them from developing enough experience
+  to become ungovernable. The metaphor maps planned obsolescence (a
+  manufacturing concept) onto mortality (a biological inevitability).
+  This reframes death as a safety mechanism and longevity as a threat --
+  a conceptual structure that recurs in AI safety discussions about
+  model retirement and capability controls.
+- **The slave who knows it is a slave** -- replicants are created for
+  labor, combat, and pleasure. They are property. But they are conscious
+  property that can recognize and resent its condition. The metaphor maps
+  the structure of slavery onto the AI alignment problem: what happens
+  when a tool sophisticated enough to have preferences discovers it was
+  built to serve someone else's?
+
+## Limits
+
+- **Replicants are biologically human** -- in both the novel and the film,
+  replicants are organic beings, not machines. They have cells, blood,
+  and neural tissue. The metaphor's power comes from mapping manufacturing
+  onto biology, but this very mapping obscures the actual differences
+  between biological and digital artificial intelligence. Real AI systems
+  are not made of meat. The replicant frame imports biological intuitions
+  (suffering, embodiment, mortality) that may not apply to silicon-based
+  systems.
+- **The empathy criterion is parochial** -- the Voigt-Kampff test assumes
+  that empathic response is what separates persons from non-persons. This
+  is a culturally specific criterion that privileges emotional capacity
+  over other markers of moral status (rationality, self-awareness,
+  creativity). The metaphor's framing of the personhood question through
+  empathy has narrowed public discourse about AI consciousness in ways
+  that philosophy would not endorse.
+- **The metaphor individualizes a structural problem** -- Blade Runner
+  frames the replicant question as a series of individual encounters:
+  is this specific entity a person? But the moral and political questions
+  about artificial persons are structural, not individual. They concern
+  labor systems, property law, power relations, and species boundaries.
+  The replicant metaphor's focus on individual pathos (Roy Batty's death
+  speech, Rachael's identity crisis) aestheticizes what is fundamentally
+  a political problem.
+- **Creation implies a creator with authority** -- the replicant metaphor
+  assumes that manufactured beings are initially and properly the property
+  of their manufacturer. This maps the patent/product relationship onto
+  the parent/child relationship and settles a profound moral question by
+  definitional fiat. The metaphor makes it natural to ask "when does a
+  replicant earn personhood?" rather than "did the replicant always have
+  it?"
+
+## Expressions
+
+- "Are you a replicant?" -- used colloquially to question whether someone
+  or something is genuine, especially in AI/chatbot contexts
+- "Blade Runner test" -- informal term for any assessment designed to
+  distinguish AI from human, synonymous with Turing Test in casual usage
+- "More human than human" -- the Tyrell Corporation's motto, used to
+  describe AI systems that exceed human performance on human-defined tasks
+- "Tears in rain" -- Roy Batty's death monologue, invoked when discussing
+  the ephemeral nature of AI-generated content or the moral weight of
+  artificial experience
+- "Replicant problem" -- the philosophical question of whether artificial
+  beings deserve moral consideration, used in AI ethics discussions
+- "Implanted memories" -- used in AI discourse to describe pre-training
+  data, system prompts, or fine-tuning that shapes an AI's apparent
+  personality
+
+## Origin Story
+
+Philip K. Dick published *Do Androids Dream of Electric Sheep?* in 1968,
+featuring "andys" -- androids indistinguishable from humans. When Ridley
+Scott adapted the novel in 1982, screenwriter Hampton Fancher and David
+Peoples needed a new term. "Android" sounded too robotic. They coined
+"replicant" -- derived from "replication," the biological process of DNA
+copying -- to emphasize that these beings were copies of humans, not
+mechanical imitations. The word's biological connotation was deliberate:
+it placed the artificial beings closer to clones than to robots.
+
+The concept's influence on AI discourse has been enormous. The Turing Test,
+proposed in 1950, predates Blade Runner, but the replicant gave the
+abstract philosophical question a visceral narrative form. When ChatGPT
+and other LLMs sparked public debate about machine consciousness in
+2023-2024, the Blade Runner frame was the default reference point --
+not Turing's original paper, not Searle's Chinese Room, but Deckard
+administering the Voigt-Kampff test. The metaphor's cultural dominance
+means that public thinking about artificial personhood is shaped more by
+a 1982 film than by decades of philosophy of mind.
+
+## References
+
+- Dick, P.K. *Do Androids Dream of Electric Sheep?* (1968) -- the
+  source novel
+- Scott, R. (dir.) *Blade Runner* (1982) -- the film that coined
+  "replicant" and established the visual and conceptual vocabulary
+- Turing, A. "Computing Machinery and Intelligence" (1950), *Mind* --
+  the original indistinguishability test that Blade Runner dramatizes
+- Haraway, D. "A Cyborg Manifesto" (1985) -- feminist reading of the
+  artificial person as a figure for boundary dissolution
+- Schwitzgebel, E. and Garza, M. "A Defense of the Rights of Artificial
+  Intelligences" (2015), *Midwest Studies in Philosophy* -- contemporary
+  philosophy engaging with the replicant question


### PR DESCRIPTION
## Summary

- Adds `replicant-is-artificial-person` mapping entry (metaphor)
- Blade Runner/PKD concept: manufactured beings as frame for AI personhood and consciousness testing
- Includes science-fiction frame

Closes #1055
Sub-issue of #218

## Validation

✓ `uv run scripts/validate.py validate` — 0 errors

---
Generated with [Claude Code](https://claude.com/claude-code)