### PR TITLE
Add entry: Technology Is a Dark Mirror

### DIFF
--- a/catalog/mappings/technology-is-a-dark-mirror.md
+++ b/catalog/mappings/technology-is-a-dark-mirror.md
@@ -21,7 +21,6 @@ transfers:
 - "[source] a dark mirror reflects the viewer's image back in a distorted, unflattering form -- the reflection is recognizable but unsettling"
 - "[source] mirrors require a viewer: the reflection is meaningless without someone to see themselves in it, making the act of looking an essential part of the encounter"
 - "[source] a dark mirror shows the viewer only when the light source (the screen) is off -- the reflection appears precisely when the device stops performing its intended function"
-- "[source] mirrors reverse left and right, producing a familiar but subtly wrong image -- close enough to recognize, different enough to disturb"
 updated: '2026-03-16'
 ---
 


### PR DESCRIPTION
## Summary

- Reframed entry from "Black Mirror Is Technology Dark Side" to "Technology Is a Dark Mirror"
- Changed `source_frame` from `science-fiction` to `vision` (matching `ai-is-a-mirror`)
- Rewrote Transfers to focus on mirror source domain: reflection, distortion, self-recognition, the black screen
- Moved TV show discussion to Origin Story where it belongs
- Removed `dead: false` from frontmatter

Closes #1060
Sub-issue of #218

## Validation

```
✓ `uv run scripts/validate.py` — 0 errors, 26 warnings (pre-existing dangling references)
```

Generated with [Claude Code](https://claude.com/claude-code)