### PR TITLE
Fix kaizen #1489: smelter undercounts limits in enrichment validation

### DIFF
--- a/.claude/agents/smelter.md
+++ b/.claude/agents/smelter.md
@@ -100,6 +100,30 @@ additional mechanical checks:
 - No empty strings in the lists
 - No exact duplicate propositions within an entry
 
+**How to count transfers and limits reliably:**
+
+Do NOT eyeball the count. YAML list items can span multiple lines (long quoted
+strings wrap), so visually scanning is unreliable. Instead, use a script to
+parse the frontmatter and count items:
+
+```bash
+python3 -c "
+import yaml, sys
+with open(sys.argv[1]) as f:
+    text = f.read()
+fm = text.split('---')[1]
+data = yaml.safe_load(fm)
+t = data.get('transfers', []) or []
+l = data.get('limits', []) or []
+print(f'transfers={len(t)} limits={len(l)}')
+" path/to/entry.md
+```
+
+Run this for every entry file in the PR that has enrichment changes. Compare
+the printed counts against the minimums above. Never rely on manual counting
+of `- "` lines — long propositions wrap across multiple lines and cause
+undercounts.
+
 These are purely mechanical checks — the Smelter makes no judgment about
 proposition content quality.
 


### PR DESCRIPTION
## Summary

Fixes #1489

**What was broken:** The smelter agent was undercounting `limits` (and potentially `transfers`) in enrichment validation. When YAML list items contain long quoted strings that wrap across multiple lines, visual inspection or line-counting heuristics miscount — typically stopping after the first item and reporting 1 when there are actually 2+.

**What this fixes:** Added explicit instructions to the smelter prompt requiring it to use `python3 -c "import yaml; ..."` to parse frontmatter and count list items programmatically. The prompt now includes a ready-to-use script snippet and a clear warning against manual counting.

**File changed:** `.claude/agents/smelter.md`

## Test plan

- [x] Read updated prompt — counting instructions are clear and unambiguous
- [x] `uv run scripts/validate.py validate` passes (0 errors, only pre-existing dangling-ref warnings)


Generated with [Claude Code](https://claude.com/claude-code)