### PR TITLE
Fix kaizen #1488: YAML quoting for enrichment propositions

### DIFF
--- a/.claude/agents/miner.md
+++ b/.claude/agents/miner.md
@@ -91,8 +91,21 @@ If invoked without a specific project or issue:
    d. Generate `limits:` list — same prefix conventions
    e. Each proposition must pass three tests: independence (true of source domain), discrimination (false of 2+ similar domains), relational (not attributive)
    f. Meet min counts: 3 transfers for metaphor/pattern/archetype, 2 for paradigm/mental-model; 2 limits for all kinds
-   g. Insert `transfers:` and `limits:` into the YAML frontmatter
-   h. Do NOT alter any existing body text or other frontmatter fields
+   g. Insert `transfers:` and `limits:` into the YAML frontmatter.
+      **YAML quoting rule:** Use single-quoted strings for all proposition
+      values. Single quotes prevent nested-double-quote breakage. If a
+      proposition contains an apostrophe, double it (`''`). Example:
+      ```yaml
+      transfers:
+        - '[source] Attacks can be "repelled" or "deflected"'
+        - '[source] A speaker''s position is a territory to hold'
+      ```
+   h. After inserting frontmatter, verify YAML parses cleanly:
+      ```bash
+      python3 -c "import yaml; yaml.safe_load(open('<filepath>'))"
+      ```
+      If it fails, fix the quoting before moving to the next entry.
+   i. Do NOT alter any existing body text or other frontmatter fields
 5. If an entry already has `transfers`/`limits`, skip it
 6. If an entry's body is too thin for good propositions, note the slug in a comment on the batch sub-issue rather than generating bad propositions
 7. Run `uv run scripts/validate.py validate` — zero errors required


### PR DESCRIPTION
Fixes #1488

## What was broken

Enrichment propositions containing inner double quotes (e.g., `"breaking down silos"`) produced invalid YAML when wrapped in double-quoted strings. 7 of 50 entries in batch 8 needed manual escaping.

## What this changes

Two additions to the Miner's enrichment process in `.claude/agents/miner.md`:

1. **Single-quoted YAML strings** — Propositions must now use single quotes, which avoid nested-double-quote breakage. Apostrophes are escaped by doubling (`''`). Includes a concrete example.

2. **Post-insertion YAML validation** — After inserting `transfers:` and `limits:` into frontmatter, the Miner must run `python3 -c "import yaml; yaml.safe_load(open(filepath))"` and fix any parse errors before proceeding.

## Test plan

- [x] `uv run scripts/validate.py validate` passes (no new errors)
- [ ] Next enrichment batch produces valid YAML without manual fixes

Generated with [Claude Code](https://claude.com/claude-code)