### PR TITLE
Add entry: Siren Song

### DIFF
--- a/catalog/mappings/siren-song.md
+++ b/catalog/mappings/siren-song.md
@@ -1,0 +1,158 @@
+---
+applies_to:
+- decision-making
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- psychology
+contributors: []
+created: '2026-03-16'
+dead: true
+harness: Claude Code
+kind: metaphor
+name: Siren Song
+related:
+- icarus
+- trojan-war
+slug: siren-song
+source_frame: mythology
+updated: '2026-03-16'
+transfers:
+  - "[source] the attraction operates through a specific sensory channel (hearing) that bypasses rational evaluation, mapping how certain temptations work through aesthetic or emotional appeal rather than logical persuasion"
+  - "[source] the Sirens are stationary on their island while sailors must navigate past them, structuring the encounter as a fixed hazard on a necessary route rather than a pursuer-prey dynamic"
+  - "[source] Odysseus's solution requires external constraint (being bound to the mast) because willpower alone is insufficient, mapping the structure where knowing a temptation is dangerous does not protect against it"
+limits:
+  - "[source] breaks because the Sirens offer a single, uniform temptation (their song) to all sailors, while real dangerous attractions are personalized -- what tempts one person leaves another indifferent"
+  - "[source] misleads because the metaphor frames all strong attraction as lethal, collapsing the distinction between desires that are genuinely destructive and desires that are merely risky or socially disapproved"
+---
+
+## Transfers
+
+In Homer's *Odyssey*, the Sirens are creatures whose singing is so
+beautiful that sailors who hear it are compelled to steer toward them,
+wrecking their ships on the rocks. The song is irresistible not because
+the sailors are weak but because the beauty is superhuman -- the
+temptation exceeds the capacity of ordinary willpower to resist. Odysseus
+survives by having his crew plug their ears with wax and lash him to the
+mast, so he can hear the song without acting on it.
+
+Key structural parallels:
+
+- **The temptation is beautiful, not deceptive** -- the Sirens do not
+  lie. Their song is genuinely beautiful. The danger is not that the
+  offer is false but that accepting it is fatal. This distinguishes the
+  siren song from a con or a trap: the thing being offered is real and
+  desirable. The metaphor maps onto situations where the attraction is
+  genuine -- a lucrative but ethically compromised deal, an addictive
+  product that delivers real pleasure, a toxic relationship with a
+  person who is genuinely charismatic. The structural point is that
+  knowing something is dangerous does not make it less attractive.
+- **Hearing is involuntary; action is the variable** -- the Sirens'
+  song reaches every sailor within range. You cannot choose not to hear
+  it. The only choice is whether to act on it. This maps the structure
+  of temptations that cannot be avoided by ignorance: once you have
+  seen the opportunity, tasted the substance, or met the person, the
+  exposure cannot be undone. The strategic question becomes not "how do
+  I avoid knowing about this" but "how do I constrain my response."
+- **Willpower is structurally insufficient** -- Odysseus does not resist
+  the Sirens through discipline or moral character. He resists them
+  through physical constraint. The metaphor transfers a specific insight
+  about human agency: for certain classes of temptation, the correct
+  strategy is not to strengthen resolve but to remove the ability to act
+  on desire. This maps onto commitment devices, pre-commitment
+  strategies, environmental design, and the entire behavioral economics
+  toolkit of "choice architecture." Ulysses contracts in behavioral
+  economics are named directly after this episode.
+- **The hazard is fixed; the route is necessary** -- the Sirens sit on
+  their island. Sailors must pass them to reach their destination. You
+  cannot simply avoid the strait. This maps situations where the
+  temptation is embedded in a necessary path: the recovering alcoholic
+  who must attend business dinners, the trader who must monitor volatile
+  markets, the reformer who must engage with the system they are trying
+  to change. The metaphor captures the impossibility of pure avoidance
+  when the dangerous thing sits on the only available route.
+
+## Limits
+
+- **The binary outcome flattens real risk** -- in the myth, you either
+  wreck on the rocks or you sail past safely. There is no middle ground,
+  no partial indulgence, no harm reduction. But most real-world
+  temptations have a spectrum of engagement: you can take the lucrative
+  deal with safeguards, use the addictive product occasionally, or
+  maintain the complicated relationship with boundaries. The siren song
+  metaphor, by making attraction binary and fatal, discourages
+  graduated risk assessment and makes every temptation feel like an
+  all-or-nothing proposition.
+- **The metaphor pathologizes desire itself** -- calling something a
+  "siren song" frames the attraction as inherently dangerous. But
+  strong attraction is not always a warning sign. Sometimes the
+  compelling opportunity really is a good opportunity. The siren song
+  frame can make people distrust their own desires even when those
+  desires are healthy, creating a suspicious relationship with
+  enthusiasm that serves caution at the expense of engagement.
+- **It assumes a single, recognizable source** -- the Sirens are visible.
+  You know where they are. Real temptations are often diffuse,
+  ambient, or disguised as normal features of the environment. Social
+  media is not an island you sail past; it is the water you swim in.
+  The metaphor's clean geography -- a specific hazard at a specific
+  location -- does not map well onto temptations that are everywhere
+  and nowhere.
+- **The crew's perspective is erased** -- the myth focuses on Odysseus,
+  the leader who gets to hear the song. The crew, ears plugged with wax,
+  experience nothing. In organizational contexts, the siren-song
+  metaphor tends to center the decision-maker's struggle while ignoring
+  that others may be affected by the same temptation in different ways,
+  or may not find the thing tempting at all. The metaphor assumes
+  universal susceptibility to a specific attraction.
+
+## Expressions
+
+- "Siren song" -- any dangerously attractive offer or temptation, used
+  so commonly that most speakers do not connect it to Homer
+- "Siren call" -- variant of siren song, emphasizing the pull rather
+  than the beauty
+- "Lured by the siren song of easy money" -- financial temptation as
+  mythological hazard
+- "The siren song of [X]" -- productive construction applied to
+  technology, fame, power, nostalgia, or any seductive abstraction
+- "Ulysses contract" -- behavioral economics term for a pre-commitment
+  device, named after Odysseus's strategy of binding himself to the mast
+- "Tied to the mast" -- choosing to constrain one's own future actions
+  as a strategy for resisting known temptation
+- "Plug your ears" -- deliberate ignorance as a strategy for avoiding
+  temptation, from the crew's wax earplugs
+
+## Origin Story
+
+The Sirens appear in Book 12 of Homer's *Odyssey* (c. 8th century BCE).
+Circe warns Odysseus about them and advises the wax-and-rope strategy.
+In Homer's telling, there are two Sirens (later traditions increase the
+number), and their song promises knowledge -- they claim to know
+everything that happened at Troy and everything that will happen on
+earth. The temptation is intellectual as much as aesthetic.
+
+The Sirens' appearance is unspecified in Homer. Later Greek art depicted
+them as bird-women (human heads on bird bodies), which gradually shifted
+to the fish-tailed form that merged with mermaid iconography in medieval
+European art. This visual evolution erased the original auditory focus
+and replaced it with visual seduction, which is why "siren" today
+connotes a seductive woman rather than a beautiful voice.
+
+The metaphor entered English through classical education and became
+conventional by the Renaissance. "Siren song" is now a dead metaphor
+for most speakers: it means "dangerous temptation" without any conscious
+reference to Homer, Greek mythology, or the specific structure of the
+original encounter.
+
+## References
+
+- Homer. *Odyssey*, Book 12 (c. 8th century BCE) -- the primary source
+  for the Sirens episode
+- Elster, Jon. *Ulysses and the Sirens* (1979) -- foundational work
+  in rational choice theory using the Odysseus episode as a model for
+  pre-commitment and self-binding
+- Thaler, Richard and Sunstein, Cass. *Nudge* (2008) -- choice
+  architecture as a modern application of the mast-binding strategy
+- Becker, Gary and Murphy, Kevin. "A Theory of Rational Addiction,"
+  *Journal of Political Economy* 96.4 (1988) -- economic modeling of
+  the structural problem the siren song metaphor describes


### PR DESCRIPTION
## Summary

- Adds `siren-song` entry (metaphor, dead: true, source_frame: mythology)
- Dangerously attractive temptation that leads to ruin, from Homer's Odyssey
- Covers transfers to decision-making, behavioral economics (Ulysses contracts), pre-commitment strategies

Closes #1076

## Validation

```
✓ `uv run scripts/validate.py` — 0 errors, 28 warnings (pre-existing dangling references)
```

Generated with [Claude Code](https://claude.com/claude-code)