### PR TITLE
Add entry: Prometheus

### DIFF
--- a/catalog/mappings/prometheus.md
+++ b/catalog/mappings/prometheus.md
@@ -1,0 +1,174 @@
+---
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- ethics-and-morality
+contributors: []
+created: '2026-03-16'
+harness: Claude Code
+kind: archetype
+name: Prometheus
+related:
+- icarus
+- trojan-war
+- pandoras-box
+slug: prometheus
+source_frame: mythology
+updated: '2026-03-16'
+transfers:
+  - "[source] the gift is stolen from a higher order of being (gods) and given to a lower one (mortals), structuring innovation as transgression against a power hierarchy rather than natural progress"
+  - "[source] the punishment is eternal and regenerative -- the eagle eats the liver daily and it regrows -- mapping how the cost of democratizing power is not a one-time penalty but an ongoing, recurring burden"
+  - "[source] the fire is simultaneously tool and weapon, structurally inseparable, so the act of giving cannot be constrained to beneficial uses only"
+limits:
+  - "[source] breaks because Prometheus acts alone as a single heroic figure, while real technology democratization is distributed across institutions, teams, and incremental contributions with no singular gift-giver"
+  - "[source] misleads because the archetype frames the gods' punishment as unjust, biasing the narrative toward the innovator's perspective and making regulatory or cautionary responses seem like divine overreaction"
+---
+
+## Transfers
+
+Prometheus stole fire from the gods and gave it to humanity. Zeus
+punished him by chaining him to a rock where an eagle ate his liver
+daily, the organ regenerating each night so the torment could repeat
+forever. The structural core: someone democratizes a dangerous,
+transformative power by taking it from those who monopolize it and
+giving it to those who lack it, and pays an enormous personal price
+for the transgression. This pattern recurs so consistently across
+technology, science, politics, and culture that it functions as an
+archetype rather than a single metaphor.
+
+- **Innovation as transgression** -- Prometheus does not invent fire.
+  Fire already exists; the gods have it. His act is redistribution,
+  not creation. This maps a specific structure onto technological
+  disruption: the innovator does not always create something new but
+  makes something previously restricted available to a wider
+  population. Open-source software developers, whistleblowers, generic
+  drug manufacturers, and encryption advocates all fit the Promethean
+  structure -- they take capabilities that existed within a restricted
+  domain and make them broadly accessible.
+- **The gift cannot be ungiven** -- once Prometheus delivers fire to
+  humanity, it cannot be recalled. The gods can punish Prometheus but
+  they cannot take fire back from mortals. This maps the irreversibility
+  of certain technological releases: once nuclear weapons are
+  demonstrated, the knowledge cannot be unlearned. Once encryption
+  algorithms are published, they cannot be unpublished. Once gene
+  editing tools are widely available, restricting them becomes a
+  containment problem rather than a gatekeeping one. The archetype
+  captures the structural asymmetry between release (one act) and
+  containment (perpetual effort).
+- **The cost falls on the gift-giver, not the recipients** -- mortals
+  benefit from fire; Prometheus suffers. This maps a recurring pattern
+  in innovation: the person who democratizes the technology bears the
+  punishment while the users enjoy the benefit. Aaron Swartz downloaded
+  academic papers and faced federal prosecution; millions read those
+  papers freely. Edward Snowden revealed surveillance programs and lives
+  in exile; the public gained knowledge. The archetype explains why
+  rational self-interest should prevent such acts, and why they happen
+  anyway -- Promethean actors value the gift more than their own safety.
+- **Fire is dual-use by nature** -- fire cooks food and burns cities.
+  Prometheus cannot give humanity the cooking without also giving them
+  the arson. This is the structural core of dual-use technology
+  debates: nuclear energy and nuclear weapons, the internet as
+  communication tool and surveillance infrastructure, AI as assistant
+  and weapon. The archetype insists that the beneficial and destructive
+  applications are not separable -- they are the same gift viewed from
+  different angles.
+- **The punishment is regenerative** -- the eagle eats the liver and it
+  grows back. The torment does not diminish over time; it resets. This
+  maps the ongoing cost that innovators and institutions bear: the
+  regulatory battles, the ethical reckonings, the unintended
+  consequences that keep appearing in new forms. Nuclear power's
+  Promethean cost is not Hiroshima alone but also Three Mile Island,
+  Chernobyl, and Fukushima -- the liver keeps growing back.
+
+## Limits
+
+- **The lone hero distorts the structure of real innovation** --
+  Prometheus acts alone. Real technology democratization is almost
+  never the act of a single individual. The Human Genome Project
+  involved thousands of researchers. Open-source software is built
+  by communities. Even apparent lone actors (Oppenheimer, Berners-Lee)
+  operated within large institutional contexts. The archetype encourages
+  a Great Man narrative that obscures the collective, incremental nature
+  of most technological change.
+- **The gods are not always wrong** -- in the myth, Zeus's anger at
+  Prometheus is framed as tyrannical overreaction, making the audience
+  sympathize with the fire-bringer. But the archetype imports this
+  moral framing into situations where the "gods" (regulators,
+  institutions, gatekeepers) may have legitimate reasons for restricting
+  access. Gain-of-function research, weapons-grade materials, and
+  certain surveillance capabilities are restricted not because the
+  gatekeepers are petty tyrants but because unrestricted access creates
+  genuine catastrophic risk. Calling someone "Promethean" can short-
+  circuit the question of whether the restriction was justified.
+- **The archetype valorizes the act regardless of outcome** -- because
+  the myth frames Prometheus as heroic, invoking the archetype tends to
+  ennoble the act of democratization. But some acts of "giving fire to
+  mortals" are reckless rather than brave. Publishing bioweapon synthesis
+  instructions is structurally Promethean -- taking restricted knowledge
+  and making it broadly available -- but it is not heroic. The archetype
+  lacks internal criteria for distinguishing courageous dissemination
+  from dangerous irresponsibility.
+- **Fire is a poor model for information** -- fire is consumed and
+  must be maintained. Information can be copied infinitely at zero
+  marginal cost. The economics of the original gift (fire) and the
+  economics of the modern gifts it maps onto (software, data,
+  knowledge) are fundamentally different. The archetype captures the
+  transgression but not the replication dynamics that make digital
+  Promethean acts qualitatively different from mythological ones.
+
+## Expressions
+
+- "Promethean" -- adjective for any bold, defiant act of bringing
+  transformative power to the masses, often with an implication of
+  noble suffering
+- "Playing with fire" -- loosely connected: engaging with dangerous
+  forces, though this expression has mostly detached from the myth
+- "Stealing fire" -- taking restricted knowledge or capability and
+  making it publicly available
+- "The Modern Prometheus" -- subtitle of Mary Shelley's *Frankenstein*
+  (1818), mapping the Promethean structure onto scientific creation
+- "Promethean bargain" -- accepting enormous personal cost in exchange
+  for a transformative gift to others
+- "Unbound" -- from Shelley's *Prometheus Unbound* (1820), the idea
+  of the innovator eventually freed from punishment, used for liberation
+  and vindication narratives
+
+## Origin Story
+
+The Prometheus myth appears in Hesiod's *Theogony* and *Works and Days*
+(c. 700 BCE) and receives its most influential dramatic treatment in
+Aeschylus's *Prometheus Bound* (c. 460 BCE). In Hesiod, Prometheus is
+a trickster who deceives Zeus at a sacrifice and steals fire as
+retaliation after Zeus withholds it from mortals. Aeschylus elevates
+him to a tragic hero, a benefactor of humanity who suffers divine
+injustice.
+
+The Romantic poets (Shelley, Byron, Goethe) adopted Prometheus as a
+symbol of human creativity rebelling against arbitrary authority. Mary
+Shelley's *Frankenstein; or, The Modern Prometheus* (1818) added a
+critical dimension: what if the fire-giver's gift is monstrous? This
+inflection made the archetype applicable to technology anxiety as well
+as technology celebration.
+
+In the 20th and 21st centuries, the archetype maps onto nuclear
+technology (Oppenheimer as Prometheus), computing (open-source as
+fire-sharing), genetic engineering (CRISPR democratization), and AI
+development. The archetype persists because the structural tension it
+captures -- the inseparability of empowerment and danger, the personal
+cost of democratization, the irreversibility of release -- has not
+been resolved by any technological or political development since
+Hesiod first told the story.
+
+## References
+
+- Hesiod. *Theogony* and *Works and Days* (c. 700 BCE) -- earliest
+  written versions of the Prometheus myth
+- Aeschylus. *Prometheus Bound* (c. 460 BCE) -- the dramatic
+  treatment that established Prometheus as tragic hero
+- Shelley, Mary. *Frankenstein; or, The Modern Prometheus* (1818) --
+  the critical inflection point where the archetype gains its
+  ambivalence about technology
+- Shelley, Percy Bysshe. *Prometheus Unbound* (1820) -- Romantic
+  reinterpretation emphasizing liberation
+- Dougherty, Carol. *Prometheus* (Routledge, 2006) -- survey of
+  the myth's cultural history and modern applications


### PR DESCRIPTION
## Summary

- Adds `prometheus` entry (archetype, source_frame: mythology)
- Democratizing dangerous/powerful technology at personal cost
- Covers transfers to open-source, whistleblowing, dual-use tech, nuclear technology, AI development

Closes #1077

## Validation

```
✓ `uv run scripts/validate.py` — 0 errors, 28 warnings (pre-existing dangling references)
```

Generated with [Claude Code](https://claude.com/claude-code)