### PR TITLE
Add entry: Labyrinth

### DIFF
--- a/catalog/mappings/labyrinth.md
+++ b/catalog/mappings/labyrinth.md
@@ -1,0 +1,172 @@
+---
+applies_to:
+- governance
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- law-and-governance
+contributors: []
+created: '2026-03-16'
+dead: true
+harness: Claude Code
+kind: metaphor
+name: Labyrinth
+related:
+- trojan-war
+slug: labyrinth
+source_frame: mythology
+updated: '2026-03-16'
+transfers:
+  - "[source] the labyrinth is designed by its creator (Daedalus) to be inescapable, mapping the structure where complexity is intentionally engineered rather than accidentally accumulated"
+  - "[source] the path through the labyrinth exists but is hidden from the person inside it, distinguishing this from a dead-end or an impossible task -- the solution is navigation, not demolition"
+  - "[source] Ariadne's thread solves the labyrinth not by mapping it but by recording the path taken, enabling backtracking -- the structural insight that a trace of your own history is more useful than a map of the whole system"
+limits:
+  - "[source] breaks because the mythological labyrinth has a single correct path and a single center, while real bureaucratic and systemic complexity typically has multiple overlapping paths, no center, and goals that shift as you navigate"
+  - "[source] misleads because the metaphor implies the complexity is deliberate (someone designed this to trap you), encouraging paranoia about intentional obfuscation when most real complexity is emergent and unplanned"
+---
+
+## Transfers
+
+King Minos commissioned Daedalus to build the Labyrinth on Crete to
+contain the Minotaur. The structure was so complex that no one who
+entered could find their way out. Theseus navigated it successfully
+only because Ariadne gave him a ball of thread to unwind as he went,
+allowing him to retrace his path after killing the Minotaur. The
+structural core: a system so complex that being inside it means being
+lost, where the difficulty is not the task at the center but the
+navigation required to reach it and return.
+
+- **Designed complexity as containment** -- the Labyrinth was built
+  to imprison. Its complexity is not accidental but functional: the
+  twisting corridors serve to prevent escape. This maps a specific
+  suspicion onto bureaucratic and institutional complexity -- that
+  the difficulty of navigating the system is not a bug but a feature.
+  Tax codes, immigration processes, insurance claims procedures, and
+  corporate procurement systems all attract the labyrinth metaphor
+  when their complexity seems to serve the interests of those who
+  built them rather than those who must navigate them. The metaphor
+  encodes the insight that some systems are complex because complexity
+  benefits the system's operators.
+- **Local knowledge is insufficient** -- inside the Labyrinth, every
+  corridor looks like every other corridor. You can see the walls
+  around you but cannot determine your position within the whole. This
+  maps the experience of navigating complex systems where local
+  information is abundant but global orientation is impossible: you
+  can read each regulation but cannot see how they interact; you can
+  understand each department's function but cannot trace a decision
+  through the whole organization. The metaphor captures the specific
+  frustration of having detailed information and no usable overview.
+- **Ariadne's thread as a navigation strategy** -- the thread does not
+  map the Labyrinth. It does not reveal the optimal path. It simply
+  records where you have been, guaranteeing you can get back out. This
+  maps a specific problem-solving strategy: when facing irreducible
+  complexity, do not try to understand the whole system; instead,
+  maintain a reliable record of your own path. Version control systems,
+  audit trails, paper trails, and breadcrumb navigation in software
+  interfaces are all structural descendants of Ariadne's thread.
+- **The Minotaur at the center** -- the Labyrinth exists to contain
+  something dangerous. The complexity is not pointless; it guards a
+  real threat. This maps situations where bureaucratic complexity
+  protects genuinely important boundaries. Nuclear regulatory
+  complexity protects against meltdowns. Financial regulatory
+  complexity (in theory) protects against systemic risk. The metaphor
+  warns that simplifying the labyrinth may release the Minotaur --
+  that deregulation, streamlining, and "cutting red tape" can expose
+  the dangerous thing the complexity was designed to contain.
+
+## Limits
+
+- **Most real complexity is emergent, not designed** -- the Labyrinth
+  was built by a master architect with a clear purpose. But most of
+  the systems we call "labyrinthine" -- tax codes, healthcare systems,
+  legacy codebases -- were not designed by anyone. They accreted over
+  decades through incremental additions, political compromises, and
+  accumulated patches. The labyrinth metaphor implies intentionality
+  where there is usually path dependence. This can lead to conspiracy
+  thinking: the conviction that someone designed the system to be
+  confusing, when in fact no one designed it at all.
+- **The metaphor has a single center and a single path** -- the
+  mythological Labyrinth has one Minotaur and one correct route.
+  Real complex systems typically have multiple goals, multiple
+  viable paths, and no single center. Navigating a healthcare system
+  is not about finding the one correct route to the one destination;
+  it is about making a series of judgment calls among partially
+  adequate options. The labyrinth metaphor imposes a false simplicity
+  of structure (one path, one center) onto systems that are complex
+  precisely because they lack this structure.
+- **Ariadne's thread assumes you will return the way you came** --
+  the thread strategy works because the Labyrinth is stable: the
+  corridors do not move while you are inside them. But many real
+  complex systems change as you navigate them. Regulatory landscapes
+  shift, organizational structures are reorganized, software
+  dependencies are updated. The path you took in may not exist when
+  you try to retrace it. The metaphor assumes a static complexity that
+  does not match dynamic real-world systems.
+- **The metaphor encourages escape over inhabitation** -- the goal
+  in the myth is to get in, kill the Minotaur, and get out. Nobody
+  lives in the Labyrinth. But many people must live permanently inside
+  complex systems rather than pass through them. The labyrinth metaphor
+  frames complexity as a temporary obstacle to be navigated and
+  escaped, not as a persistent environment to be inhabited and
+  adapted to. For people who work inside bureaucracies, regulatory
+  frameworks, or legacy codebases, the relevant skill is not
+  navigation but habitation -- and the labyrinth metaphor has nothing
+  to say about that.
+
+## Expressions
+
+- "Labyrinthine" -- adjective for any complex, confusing system or
+  process, used so commonly that most speakers do not think of Crete
+- "A labyrinth of regulations" -- bureaucratic complexity as
+  mythological architecture
+- "Lost in the labyrinth" -- unable to navigate a complex system,
+  lacking orientation
+- "Ariadne's thread" -- any guiding principle, audit trail, or
+  navigation aid through complexity
+- "At the heart of the labyrinth" -- the hidden truth, core problem,
+  or central challenge concealed by surrounding complexity
+- "There's a Minotaur in there somewhere" -- the dangerous thing
+  that the complexity was built to contain or conceal
+- "Cutting through the maze" -- simplifying or bypassing labyrinthine
+  complexity (note: "maze" and "labyrinth" have merged in popular
+  usage, though a labyrinth technically has one path while a maze
+  has branching choices)
+
+## Origin Story
+
+The Labyrinth myth appears in multiple ancient sources: Apollodorus's
+*Bibliotheca*, Ovid's *Metamorphoses*, and Plutarch's *Life of Theseus*.
+The historical basis may be the complex palace at Knossos on Crete,
+excavated by Arthur Evans in 1900, whose hundreds of interconnected rooms
+could have inspired stories of an inescapable structure. The word
+"labyrinth" itself may derive from *labrys*, the double-headed axe that
+was a sacred symbol of Minoan culture.
+
+The metaphor entered English through classical education and was
+established by the 16th century. By the 18th century, "labyrinthine"
+was a standard adjective for bureaucratic complexity, legal intricacy,
+and psychological confusion. Jorge Luis Borges made the labyrinth a
+central literary symbol in the 20th century, exploring it as a metaphor
+for the universe, the mind, and the nature of narrative itself.
+
+The word is now thoroughly dead as a metaphor in everyday usage.
+"Labyrinthine bureaucracy" activates no mythological imagery for most
+speakers; it simply means "confusingly complex." The deeper structural
+content -- designed containment, the Minotaur, Ariadne's thread -- is
+available only to those who know the myth, which makes the metaphor
+richer for classically educated users and thinner for everyone else.
+
+## References
+
+- Apollodorus. *Bibliotheca* 3.1.4, 3.15.8 (c. 1st-2nd century CE)
+  -- the most complete ancient narrative of the Labyrinth
+- Ovid. *Metamorphoses* 8.152-182 (8 CE) -- Daedalus's construction
+  of the Labyrinth
+- Plutarch. *Life of Theseus* (c. 75 CE) -- Theseus's navigation and
+  Ariadne's thread
+- Borges, Jorge Luis. "The Garden of Forking Paths" (1941) and
+  "The House of Asterion" (1949) -- modern literary explorations of
+  the labyrinth as metaphor
+- Doob, Penelope Reed. *The Idea of the Labyrinth from Classical
+  Antiquity through the Middle Ages* (Cornell, 1990) -- scholarly
+  history of the labyrinth as architectural form and metaphor


### PR DESCRIPTION
## Summary

- Adds `labyrinth` entry (metaphor, dead: true, source_frame: mythology)
- Impenetrable complexity that traps the navigator
- Covers transfers to bureaucratic complexity, designed containment, Ariadne's thread as audit trail

Closes #1079

## Validation

```
✓ `uv run scripts/validate.py` — 0 errors, 28 warnings (pre-existing dangling references)
```

Generated with [Claude Code](https://claude.com/claude-code)