### PR TITLE
Add entry: Icarus

### DIFF
--- a/catalog/mappings/icarus.md
+++ b/catalog/mappings/icarus.md
@@ -1,0 +1,173 @@
+---
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- social-dynamics
+contributors: []
+created: '2026-03-16'
+dead: true
+harness: Claude Code
+kind: metaphor
+name: Icarus
+related:
+- prometheus
+- siren-song
+- trojan-war
+slug: icarus
+source_frame: mythology
+updated: '2026-03-16'
+transfers:
+  - "[source] the wings work perfectly within their design parameters -- wax holds feathers at moderate altitude -- and fail only when the user exceeds those parameters, mapping the structure where a tool's failure mode is overextension rather than malfunction"
+  - "[source] the warning comes from the builder (Daedalus) who understands the material constraints, but the user (Icarus) disregards it because the experience of flight overrides the abstract knowledge of limits"
+  - "[source] the fall is caused by proximity to the sun (success/height), not by an external adversary, mapping the structure where destruction comes from the same direction as achievement"
+limits:
+  - "[source] breaks because Icarus is a youth who literally does not know better, while the metaphor is typically applied to experienced adults (CEOs, founders, politicians) whose overreach involves conscious risk-taking rather than naive ignorance"
+  - "[source] misleads because it frames all ambitious failure as hubris, making it impossible to distinguish reckless overreach from reasonable risk that happened to fail -- the metaphor has no category for 'flew high and succeeded'"
+---
+
+## Transfers
+
+Daedalus, imprisoned on Crete, built wings of feathers and wax for
+himself and his son Icarus to escape. He warned Icarus not to fly too
+close to the sun, which would melt the wax, or too close to the sea,
+which would dampen the feathers. Icarus, exhilarated by flight, soared
+too high. The wax melted, the wings disintegrated, and he fell into
+the sea and drowned. The structural core: ambition that ignores the
+material limits of the system enabling it, leading to destruction at
+the moment of greatest apparent success.
+
+- **The tool has known limits** -- the wings are not defective. They
+  work exactly as designed within their operating parameters. Wax holds
+  feathers together at moderate altitudes; it melts at extreme ones.
+  Daedalus understands this and communicates it clearly. The metaphor
+  maps onto any technology, strategy, or system that functions well
+  within its design envelope and fails catastrophically outside it.
+  Financial leverage works in normal markets and destroys in volatile
+  ones. Startup growth strategies work at certain scales and collapse
+  at others. The Icarus metaphor captures not tool failure but tool
+  misuse through overextension.
+- **Experience overrides warning** -- Icarus knows the rule. Daedalus
+  told him. But the experience of flying -- the visceral thrill of
+  altitude, the sensation of capability -- makes the abstract warning
+  feel irrelevant. This maps a specific cognitive pattern: the lived
+  experience of success making risk warnings feel theoretical. The CEO
+  whose company has grown 10x hears the advisor's caution about
+  overexpansion but feels it as noise against the signal of their own
+  track record. The metaphor captures the mechanism by which success
+  itself becomes the cause of failure -- not through complacency but
+  through experiential override of analytical knowledge.
+- **Height and danger are the same direction** -- Icarus does not fall
+  because an enemy attacks him. He falls because the thing he is
+  pursuing (altitude, freedom, the sun) is the same thing that destroys
+  him. The metaphor maps situations where the variable you are
+  optimizing is the variable that kills you. The trader who maximizes
+  leverage. The politician who maximizes media attention. The company
+  that maximizes growth rate. In each case, the metric of success and
+  the mechanism of destruction are identical, differing only in degree.
+- **The fall is total** -- Icarus does not lose one wing and limp home.
+  He loses both wings and dies. The metaphor maps a specific failure
+  shape: not gradual decline but sudden, complete collapse from peak
+  performance. This is the shape of blowups, crashes, and spectacular
+  corporate failures -- Enron, WeWork, Theranos -- where the arc from
+  highest valuation to destruction is steep and brief. The Icarus
+  metaphor predicts that overextension failures will be sudden rather
+  than gradual because the system has no intermediate failure state.
+
+## Limits
+
+- **The metaphor conflates hubris with ambition** -- calling something
+  an "Icarus moment" frames the failure as a moral lesson about knowing
+  your place. But ambition is not inherently foolish. Many people "fly
+  high" and succeed. The Wright brothers, the Apollo program, and
+  every successful startup that scaled aggressively all defied
+  cautious advice. The Icarus metaphor provides no way to distinguish
+  between reckless overreach and bold-but-successful ambition except
+  in retrospect: if you fell, you were Icarus; if you did not, you
+  were a visionary. This makes the metaphor descriptive (naming
+  failures after they happen) rather than predictive (identifying
+  which ambitious acts will fail).
+- **Icarus is a child, not a decision-maker** -- in the myth, Icarus
+  is young, inexperienced, and caught up in a novel sensation. But the
+  metaphor is typically applied to experienced adults -- CEOs, founders,
+  political leaders -- who make deliberate strategic choices. The
+  structural mismatch between a naive youth overwhelmed by novelty and
+  an experienced leader consciously pushing boundaries weakens the
+  metaphor's explanatory power. Real Icarus-type failures usually
+  involve sophisticated rationalization, not childlike wonder.
+- **The binary of too high and too low is too simple** -- Daedalus's
+  advice defines a safe corridor between two dangers. But real operating
+  environments have many more dimensions of risk than altitude alone.
+  A company can fail by growing too fast, too slow, in the wrong
+  market, with the wrong team, at the wrong time, or with the wrong
+  product. The Icarus metaphor's single axis (height) oversimplifies
+  multidimensional strategic space and can lead to the false belief
+  that the only risk of ambition is excess.
+- **Daedalus also flew and survived** -- the myth contains a
+  counter-example that is usually ignored. Daedalus followed his own
+  advice, flew at the right altitude, and escaped successfully. The
+  metaphor extracts the son's failure and discards the father's
+  success, creating a narrative that is purely cautionary. A fuller
+  reading of the myth would note that the same technology, used within
+  its limits by someone who respects the constraints, works perfectly
+  well. The selective extraction of the failure story biases the
+  metaphor toward pessimism about ambitious endeavors.
+
+## Expressions
+
+- "Flew too close to the sun" -- overreached and was destroyed by the
+  same force that enabled success, used commonly with no reference to
+  the myth
+- "Icarus moment" -- the point at which ambition exceeds the system's
+  structural limits and collapse begins
+- "Icarian" -- adjective for recklessly ambitious undertakings,
+  literary and relatively uncommon
+- "Don't fly too close to the sun" -- cautionary advice against
+  overambition, often used in business and career contexts
+- "Wax wings" -- a system or strategy that works under normal conditions
+  but will fail catastrophically under stress
+- "The sun melted his wings" -- success itself as the cause of failure,
+  used for companies and individuals destroyed by rapid growth or
+  excessive attention
+- "Daedalus warned him" -- the ignored expert whose caution was
+  vindicated by the subsequent disaster
+
+## Origin Story
+
+The Icarus myth appears in Apollodorus's *Bibliotheca* (c. 1st-2nd
+century CE) and Ovid's *Metamorphoses* Book 8 (8 CE), though the story
+was certainly older. In Ovid's telling, the fall is observed by a
+ploughman, a shepherd, and a fisherman who look up in astonishment --
+a detail that Pieter Bruegel the Elder painted in *Landscape with the
+Fall of Icarus* (c. 1555), where the ploughman continues working while
+Icarus's legs disappear into the sea in the corner of the canvas.
+W.H. Auden's poem "Musee des Beaux Arts" (1938) meditates on Bruegel's
+painting and the way suffering occurs while ordinary life continues
+unaware.
+
+The metaphor entered English through classical education and was
+well-established by the Renaissance. "Flying too close to the sun" is
+now a dead metaphor for most English speakers: it means "overreaching"
+without activating any specific mythological content. The deeper
+structural elements -- the wax's material limits, Daedalus's ignored
+expertise, the identity of the success metric and the failure
+mechanism -- are available only to those who return to the source.
+
+In business discourse, Danny Miller's *The Icarus Paradox* (1990)
+formalized the metaphor as a management theory: companies fail not
+despite their strengths but because of them, as the very capabilities
+that drive success are pushed past their operating limits.
+
+## References
+
+- Ovid. *Metamorphoses* 8.183-235 (8 CE) -- the most literary and
+  influential ancient telling
+- Apollodorus. *Bibliotheca* 1.11, 2.6.3 (c. 1st-2nd century CE)
+  -- mythographic source
+- Bruegel, Pieter the Elder. *Landscape with the Fall of Icarus*
+  (c. 1555) -- the painting that reframed Icarus as marginal rather
+  than central
+- Auden, W.H. "Musee des Beaux Arts" (1938) -- poem on Bruegel's
+  painting and the world's indifference to individual catastrophe
+- Miller, Danny. *The Icarus Paradox: How Exceptional Companies Bring
+  About Their Own Downfall* (1990) -- management theory formalizing
+  the Icarus structure


### PR DESCRIPTION
## Summary

- Adds `icarus` entry (metaphor, dead: true, source_frame: mythology)
- Hubris in overreaching; ambition that ignores structural limits
- Covers transfers to overextension failures, the identity of success metrics and failure mechanisms, Danny Miller's Icarus Paradox

Closes #1080

## Validation

```
✓ `uv run scripts/validate.py` — 0 errors, 28 warnings (pre-existing dangling references)
```

Generated with [Claude Code](https://claude.com/claude-code)