### PR TITLE
Fix kaizen #1364: detect circular source_frame in applies_to

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -148,6 +148,12 @@ def validate_mapping(path: Path, frame_slugs: set[str], category_slugs: set[str]
     if "source_frame" in meta and meta["source_frame"] not in frame_slugs:
         errors.append(f"{prefix}: source_frame '{meta['source_frame']}' not found in frames/")
 
+    # Circular mapping: source_frame should not also appear in applies_to
+    source_frame = meta.get("source_frame")
+    applies_to = meta.get("applies_to", [])
+    if source_frame and isinstance(applies_to, list) and source_frame in applies_to:
+        warnings.append(f"{prefix}: circular mapping — source_frame '{source_frame}' also appears in applies_to")
+
     # applies_to: forbidden for mental-model, must be list when present
     if kind == "mental-model" and "applies_to" in meta:
         errors.append(f"{prefix}: mental-model kind must not have 'applies_to'")


### PR DESCRIPTION
## Summary

- Adds a validator warning when `source_frame` also appears in `applies_to`, catching circular mappings where source and target share the same domain
- This is a WARNING, not an error, so it does not break the zero-errors precedent

## What was broken

Entries could set `source_frame` to the same frame listed in `applies_to`, creating circular mappings (e.g., "embodied-experience maps onto embodied-experience"). The validator had no check for this.

## What the fix does

After the existing `source_frame` reference check in `validate_mapping()`, a new block compares `source_frame` against each entry in `applies_to`. If a match is found, it emits a warning like:

```
catalog/mappings/good-is-up.md: circular mapping — source_frame 'embodied-experience' also appears in applies_to
```

The check guards against non-list `applies_to` values to avoid false positives on entries that already have a type error.

## Test results

`uv run scripts/validate.py validate` passes with zero errors. The new check surfaces 5 existing circular mappings as warnings.

Fixes #1364

🤖 Generated with [Claude Code](https://claude.com/claude-code)