### PR TITLE
Add entry: Cassandra

### DIFF
--- a/catalog/mappings/cassandra.md
+++ b/catalog/mappings/cassandra.md
@@ -1,0 +1,136 @@
+---
+slug: cassandra
+name: Cassandra
+kind: metaphor
+source_frame: mythology
+applies_to:
+  - social-behavior
+categories:
+  - mythology-and-religion
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - nemesis
+  - trojan-war
+created: '2026-03-16'
+updated: '2026-03-16'
+dead: false
+harness: Claude Code
+transfers:
+  - "[source] Cassandra's prophecies are always accurate, making the curse operate not on the quality of knowledge but on the social reception of knowledge -- truth and credibility are decoupled"
+  - "[source] the curse is divine and irrevocable, framing the gap between having correct information and being believed as a structural condition rather than a correctable communication failure"
+  - "[source] disbelief is guaranteed regardless of evidence, so no amount of track record, argument quality, or presentation skill can bridge the credibility gap"
+limits:
+  - "[source] breaks because Cassandra's curse is externally imposed and absolute, while real-world credibility gaps result from contingent social factors (status, gender, institutional position) that can in principle be changed"
+  - "[source] misleads because invoking the Cassandra metaphor preemptively validates the speaker's predictions -- calling yourself a Cassandra asserts that you are right and others are wrong, which is often not the case"
+---
+
+## Transfers
+
+Cassandra -- the Trojan priestess cursed by Apollo to speak true prophecies
+that no one would believe -- mapped onto anyone who correctly warns of
+danger but is systematically ignored. The metaphor names a specific
+structural problem: the decoupling of truth from credibility, where the
+quality of the information is irrelevant because the social conditions for
+being believed are absent.
+
+Key structural parallels:
+
+- **Truth without credibility** -- Cassandra's prophecies are perfect.
+  She knows exactly what will happen: Troy will fall, Agamemnon will be
+  murdered. The curse does not affect her knowledge; it affects others'
+  capacity to believe her. The metaphor imports this crucial distinction:
+  a "Cassandra" is not someone who might be right; she is someone who is
+  right but whose rightness cannot penetrate the social barrier of
+  disbelief. The problem is not epistemic but social.
+- **Structural, not incidental, disbelief** -- Cassandra is not ignored
+  because she communicates poorly, presents bad evidence, or lacks a
+  track record. She is ignored because a divine curse makes belief
+  impossible. The metaphor imports this structural quality: calling
+  someone a Cassandra implies that the disbelief is not a correctable
+  communication failure but a systemic condition -- institutional
+  incentives, cognitive biases, power dynamics -- that no amount of
+  evidence can overcome.
+- **Prophetic accuracy confirmed by disaster** -- Cassandra's predictions
+  are vindicated, but only when it is too late. The metaphor imports this
+  temporal structure: the Cassandra is proven right by the very disaster
+  they warned about. This creates a painful irony that the metaphor
+  captures precisely -- the warning was available, the warning was correct,
+  and the warning was useless.
+- **Emotional suffering of the prophet** -- Cassandra does not deliver
+  her prophecies calmly. She is anguished, frantic, desperate. The curse
+  includes the torment of knowing what is coming and being unable to
+  prevent it. The metaphor imports this affective dimension: being a
+  Cassandra is not merely being unheard; it is the specific suffering of
+  watching a preventable disaster unfold while your warnings go unheeded.
+
+## Limits
+
+- **Self-serving application** -- the Cassandra metaphor is almost always
+  self-applied: "I was the Cassandra who warned them." This usage
+  presupposes that the speaker was correct, which may or may not be true.
+  The metaphor provides no mechanism for distinguishing a genuine
+  Cassandra (right but ignored) from a false one (wrong and rightly
+  ignored). Invoking it is an assertion of vindication, not evidence of it.
+- **The curse is supernatural; real credibility gaps are social** --
+  Cassandra's disbelief is absolute and divinely imposed. Real-world
+  credibility failures are contingent: they depend on the speaker's
+  institutional position, gender, race, communication style, and the
+  audience's incentive structure. These factors can be changed -- not
+  easily, but they are not curses. The metaphor can encourage fatalism
+  ("no one will listen") when the actual problem is addressable.
+- **Binary outcome** -- in the myth, Cassandra is either believed (never)
+  or not believed (always). Real warnings operate on a spectrum: partially
+  heeded, taken seriously by some audiences but not others, acted on too
+  late or too weakly. The metaphor flattens this spectrum into total
+  rejection, which misrepresents how most ignored warnings actually play
+  out.
+- **The metaphor flatters the prophet and condemns the audience** --
+  calling someone a Cassandra allocates all the moral weight to the
+  warner and all the blame to the audience. This can obscure cases where
+  the warning was genuinely ambiguous, where the evidence was not as
+  strong as the warner believed, or where the audience had legitimate
+  reasons for skepticism. The metaphor has no room for "they were partly
+  right and partly wrong."
+
+## Expressions
+
+- "She was a Cassandra" -- the standard usage, meaning someone who
+  warned correctly and was ignored
+- "Cassandra complex" -- psychological term for the anxiety of
+  possessing knowledge that others refuse to accept
+- "Playing Cassandra" -- the performative variant, sometimes used
+  dismissively to suggest someone enjoys the role of ignored prophet
+- "Cassandra warnings" -- in risk management and intelligence analysis,
+  warnings that were available but not acted upon prior to a disaster
+- "No one listened" -- the core Cassandra narrative compressed to its
+  emotional essence, used as a retrospective lament
+
+## Origin Story
+
+Cassandra appears in the earliest strata of the Troy myth cycle. In the
+most common version (Aeschylus's *Agamemnon*, 458 BCE), Apollo grants
+her the gift of prophecy to win her love; when she refuses him, he
+curses her so that her prophecies will never be believed. She warns the
+Trojans about the wooden horse, about the fall of Troy, about
+Agamemnon's murder -- and every warning is dismissed.
+
+The metaphorical use of "Cassandra" for ignored prophets is attested in
+English from at least the 17th century and has been productive ever
+since. It appears frequently in political analysis, intelligence studies,
+and climate discourse. The "Cassandra" framing was notably applied to
+pre-9/11 intelligence warnings, pre-2008 financial crisis warnings, and
+climate scientists' decades of unheeded predictions. The metaphor remains
+alive (not dead) because speakers who use it typically intend the mythic
+reference -- calling someone a "Cassandra" consciously invokes the
+prophetic narrative rather than functioning as a generic term.
+
+## References
+
+- Aeschylus, *Agamemnon* 1072-1330 -- the canonical portrayal of
+  Cassandra's prophetic anguish
+- Clarke, R. A. *Against All Enemies* (2004) -- post-9/11 memoir that
+  exemplifies the Cassandra narrative in intelligence analysis
+- Mason, R. "The Cassandra Problem in Intelligence Analysis,"
+  *Intelligence and National Security* (2012) -- formal treatment of
+  the structural conditions that produce ignored warnings


### PR DESCRIPTION
## Summary

- Adds `catalog/mappings/cassandra.md` -- mythology-derived metaphor for ignored but correct warnings
- Source frame: mythology; applies to: social-behavior
- `dead: false` -- speakers consciously invoke the Trojan prophetess when using this metaphor

Closes #1086

## Validation

✓ `uv run scripts/validate.py validate` — 0 errors

Generated with [Claude Code](https://claude.com/claude-code)