### PR TITLE
Add entry: Narcissism

### DIFF
--- a/catalog/mappings/narcissism.md
+++ b/catalog/mappings/narcissism.md
@@ -1,0 +1,171 @@
+---
+applies_to:
+- mental-experience
+- social-behavior
+author: agent:metaphorex-miner
+categories:
+- mythology-and-religion
+- psychology
+contributors: []
+created: '2026-03-16'
+dead: true
+harness: Claude Code
+kind: metaphor
+name: Narcissism
+related:
+- tantalus
+slug: narcissism
+source_frame: mythology
+transfers:
+  - "[source] the pool reflects only the gazer's own face, mapping the structure where self-regard produces a closed perceptual loop that excludes external reality"
+  - "[source] Narcissus mistakes his reflection for another person, mapping the failure to recognize that what appears to be a relationship with the world is actually a relationship with a projection of oneself"
+  - "[source] the fixation is fatal -- Narcissus wastes away staring at the pool, mapping the insight that pathological self-absorption is not merely unpleasant but destructive to the self it supposedly serves"
+limits:
+  - "[source] breaks because the myth describes involuntary enchantment (Narcissus is cursed by Nemesis), while modern 'narcissism' implies a character flaw the person could in principle correct"
+  - "[source] misleads because Narcissus is beautiful and his reflection genuinely attractive, while clinical narcissism often involves grandiosity that others do not share -- the 'reflection' the narcissist admires may not match what others see"
+  - "[source] obscures because the myth is about visual self-love (looking at a literal reflection), while the psychological concept encompasses self-aggrandizement, lack of empathy, and need for admiration that have no mirror analogue"
+updated: '2026-03-16'
+---
+
+## Transfers
+
+Narcissus, a beautiful youth in Greek myth, saw his own reflection in a pool
+and fell in love with it. Unable to possess the image -- unable even to
+recognize it as himself -- he wasted away at the water's edge and died, or
+in some versions was transformed into the flower that bears his name. The
+myth gave psychology its term for pathological self-absorption, but the
+metaphorical mapping is both richer and more broken than the clinical label
+suggests.
+
+- **The reflection creates a closed loop** -- Narcissus gazes into the pool
+  and sees only himself. The metaphor maps this structure onto a mode of
+  relating to the world where every perception, every relationship, every
+  piece of feedback is filtered through and redirected back to the self.
+  The narcissist, like Narcissus, encounters the world and finds only a
+  mirror. Other people become surfaces for reflection rather than
+  independent beings. Information that does not reflect the self is
+  invisible, like the nymph Echo whose voice Narcissus ignores because
+  it is not his own face.
+- **The object of love is an illusion** -- Narcissus does not know he is
+  looking at himself. He believes the face in the pool is another person,
+  a beautiful stranger who reciprocates his gaze. The metaphor captures
+  the structure of narcissistic self-deception: the narcissist experiences
+  their self-regard as a relationship with reality -- as genuine insight
+  into their own excellence -- when it is actually a relationship with a
+  projection. The "love" is real to the lover; the "beloved" does not
+  exist.
+- **Self-absorption is self-destruction** -- Narcissus does not thrive by
+  the pool. He starves. The myth's structural insight is that fixation on
+  the self does not serve the self. It consumes it. The metaphor maps onto
+  the clinical observation that narcissistic personality disorder damages
+  the narcissist: relationships fail, careers implode, the grandiose self
+  requires ever more maintenance while delivering ever less satisfaction.
+  The flower that grows from Narcissus's death is beautiful but rooted in
+  a corpse.
+- **The word has fully detached from its source** -- "narcissism" and
+  "narcissist" are standard psychological vocabulary. Most people who use
+  these terms have a vague sense that Narcissus "loved himself" but do not
+  know the pool, Echo, or the flower. The word has become a clinical and
+  colloquial label, losing its mythological texture in the process.
+
+## Limits
+
+- **Narcissus is cursed; narcissists are diagnosed** -- in most versions
+  of the myth, Nemesis punishes Narcissus for rejecting Echo (or other
+  suitors). His self-fixation is divinely imposed, not freely chosen. But
+  modern "narcissism" is treated as a personality trait or disorder that
+  the person bears responsibility for, something therapists work to
+  correct and partners are advised to flee. The metaphor smuggles in a
+  structure of involuntary enchantment while the clinical usage demands
+  voluntary accountability. This tension makes "narcissist" function
+  simultaneously as a diagnosis and an accusation, which is part of its
+  rhetorical power and part of its imprecision.
+- **The myth is about beauty; the condition is about grandiosity** --
+  Narcissus is genuinely beautiful. His reflection is genuinely attractive.
+  The tragedy is that a real quality (beauty) triggers a fatal response
+  (self-fixation). But clinical narcissism involves grandiosity that is
+  often not matched by external reality. The narcissist's "reflection" may
+  be distorted -- they see excellence where others see mediocrity. The
+  myth provides no mapping for this gap between self-image and external
+  perception, because in the myth there is no gap: Narcissus really is
+  as beautiful as he thinks.
+- **The metaphor implies solitary dysfunction; the condition is
+  relational** -- Narcissus sits alone by a pool. The image is one of
+  isolation and self-containment. But narcissistic personality disorder is
+  fundamentally a relational condition: it manifests in how the person
+  treats others, demands admiration, responds to criticism, and manages
+  interpersonal dynamics. The pool metaphor understates the damage
+  narcissism inflicts on other people by focusing on the narcissist's
+  solitary self-consumption.
+- **"Narcissism" has expanded far beyond the myth's scope** -- the term
+  now covers everything from clinical NPD to casual selfie-taking, from
+  corporate leadership styles to entire generations ("the narcissism
+  epidemic"). This semantic sprawl means the mythological mapping,
+  which describes a specific structure (fatal self-fixation through
+  mistaken identity), is being applied to phenomena that share little
+  structural resemblance to the source narrative. Calling a generation
+  "narcissistic" for posting on social media has almost nothing to do
+  with Narcissus at the pool.
+
+## Expressions
+
+- "Narcissism" / "narcissist" -- the dominant surviving forms, used in
+  clinical psychology (narcissistic personality disorder), popular
+  psychology (identifying narcissists in relationships), and everyday
+  speech (accusing someone of self-centeredness)
+- "Narcissistic personality disorder" (NPD) -- the clinical formalization,
+  codified in the DSM since 1980, which has given the mythological term
+  the weight of medical authority
+- "Narcissistic supply" -- psychoanalytic term for the admiration and
+  attention that a narcissist requires, mapping the pool's reflection
+  onto interpersonal validation
+- "Narcissistic injury" / "narcissistic rage" -- the response when the
+  reflection is disturbed, when the mirror cracks, when the self-image
+  is threatened by external reality
+- "Narcissism of small differences" -- Freud's term for hostility between
+  groups that are nearly identical, extending the myth's self-fixation
+  structure to collective identity
+
+## Origin Story
+
+The myth of Narcissus is told most fully in Ovid's *Metamorphoses*
+(Book III, 8 CE), where the beautiful youth is the son of the river god
+Cephissus and the nymph Liriope. The seer Tiresias prophesies that
+Narcissus will live a long life "if he does not come to know himself" --
+an inversion of the Delphic maxim "know thyself" that gives the myth its
+ironic depth. Echo, a nymph cursed by Hera to repeat only others' words,
+falls in love with Narcissus and is rejected. Nemesis, hearing the prayers
+of Narcissus's spurned admirers, leads him to a pool where he falls in love
+with his own reflection and dies of frustrated longing. His body becomes
+the narcissus flower.
+
+The psychological term was introduced by Paul Nacke in 1899, drawing on
+Havelock Ellis's 1898 use of "Narcissus-like" to describe autoeroticism.
+Sigmund Freud expanded the concept in "On Narcissism" (1914), transforming
+it from a description of sexual behavior into a theory of psychic structure.
+Heinz Kohut's *The Analysis of the Self* (1971) further developed the
+concept into self-psychology. The DSM-III (1980) codified narcissistic
+personality disorder as a clinical diagnosis.
+
+By the 21st century, "narcissism" is among the most frequently used
+psychological terms in popular discourse. Its mythological origin is
+vestigial -- most speakers know the word without knowing the pool, Echo,
+or Nemesis.
+
+## References
+
+- Ovid. *Metamorphoses*, Book III (8 CE) -- the primary classical source
+  for the Narcissus myth, including the Echo subplot and the metamorphosis
+  into a flower
+- Freud, Sigmund. "On Narcissism: An Introduction" (1914) -- the essay
+  that established narcissism as a structural concept in psychoanalysis,
+  distinguishing primary and secondary narcissism
+- Kohut, Heinz. *The Analysis of the Self* (1971) -- the founding text of
+  self-psychology, which reframed narcissism as a developmental phenomenon
+  rather than purely pathological
+- American Psychiatric Association. *Diagnostic and Statistical Manual of
+  Mental Disorders*, 3rd ed. (1980) -- codified narcissistic personality
+  disorder as a clinical diagnosis
+- Twenge, Jean M. and W. Keith Campbell. *The Narcissism Epidemic* (2009)
+  -- representative of the popular expansion of "narcissism" from clinical
+  term to cultural diagnosis


### PR DESCRIPTION
## Summary
- Add dead metaphor entry for **Narcissism** (Greek myth -> psychology/self-absorption)
- Source frame: mythology; applies to: mental-experience, social-behavior
- Covers clinical (NPD), psychoanalytic, and colloquial usage

Closes #1087

## Validation
✓ `uv run scripts/validate.py validate` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
