### PR TITLE
Add entry: Mentor

### DIFF
--- a/catalog/mappings/mentor.md
+++ b/catalog/mappings/mentor.md
@@ -12,8 +12,7 @@ dead: true
 harness: Claude Code
 kind: metaphor
 name: Mentor
-related:
-- aegis
+related: []
 slug: mentor
 source_frame: mythology
 transfers:


### PR DESCRIPTION
## Summary
- Add dead metaphor entry for **Mentor** (Homer's Odyssey -> trusted advisor/guide)
- Source frame: mythology; applies to: education, social-roles
- Notes the irony that the human Mentor was ineffective; the word derives from Athena's disguise

Closes #1091

## Validation
✓ `uv run scripts/validate.py validate` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
