### PR TITLE
Add entry: World Tree

### DIFF
--- a/catalog/mappings/world-tree.md
+++ b/catalog/mappings/world-tree.md
@@ -1,0 +1,172 @@
+---
+slug: world-tree
+name: World Tree
+kind: archetype
+source_frame: mythology
+applies_to:
+  - governance
+  - ontological-hierarchy
+categories:
+  - mythology-and-religion
+  - systems-thinking
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - ragnarok
+  - the-great-mother
+created: '2026-03-16'
+updated: '2026-03-16'
+harness: Claude Code
+transfers:
+  - "[source] the world tree connects distinct cosmic realms (heavens, earth, underworld) through a single vertical structure, making traversal between levels possible only via the trunk"
+  - "[source] the tree is simultaneously the support structure holding the cosmos together and a living organism that grows, suffers parasites, and can die, coupling system health to infrastructure health"
+  - "[source] roots, trunk, and canopy occupy different zones with different inhabitants, establishing that position within the hierarchy determines what kind of existence you have"
+limits:
+  - "[source] breaks because the world tree has a single trunk with no branching alternative paths between realms, while real hierarchical systems typically offer multiple routes between levels"
+  - "[source] misleads because the world tree is rooted and immobile -- it cannot be restructured, rerouted, or replaced -- importing a permanence that most organizational and data hierarchies do not possess"
+---
+
+## Transfers
+
+The world tree -- a cosmic tree whose roots, trunk, and branches connect
+the layers of the universe -- appears independently in Norse (Yggdrasil),
+Hindu (Ashvattha), Mesoamerican (Wacah Chan), Siberian shamanic,
+Kabbalistic (Tree of Life), and numerous other traditions. Its recurrence
+across unrelated cultures marks it as an archetype: a structural pattern
+that humans generate independently when trying to model how distinct
+levels of reality connect.
+
+Key structural parallels:
+
+- **Vertical hierarchy with connected levels** -- the world tree's
+  fundamental structure is vertical: roots in the underworld, trunk in
+  the middle world, canopy in the heavens. Each level is distinct but
+  connected through the tree itself. This maps directly onto hierarchical
+  data structures (filesystem trees, DOM trees, organizational charts),
+  where each node exists at a level and connects to nodes above and
+  below through defined relationships. The tree is not merely a
+  metaphor for hierarchy; it is the archetype from which hierarchical
+  thinking may derive.
+- **Single infrastructure, multiple realms** -- Yggdrasil supports nine
+  worlds. The Kabbalistic Tree of Life connects ten sefirot. The
+  underlying structure serves as the shared infrastructure for radically
+  different domains. This maps onto platforms, operating systems, and
+  network backbones: a single infrastructure that supports multiple
+  distinct use cases, communities, or applications. When the tree is
+  healthy, all realms function. When it suffers, all realms suffer.
+- **The center holds everything together** -- the world tree is always
+  at the center of the cosmos, the axis mundi. Remove it and the realms
+  collapse into each other or into void. This maps onto critical
+  dependencies in any system: the load-bearing service, the key person,
+  the foundational assumption. The archetype encodes the insight that
+  complex systems often depend on a single central structure whose
+  failure is catastrophic.
+- **Living infrastructure** -- unlike a pillar or a mountain, the world
+  tree is alive. Yggdrasil has an eagle in its crown, a serpent gnawing
+  its roots, and a squirrel (Ratatoskr) running messages between them.
+  The tree grows, suffers, and can die. This maps onto the recognition
+  that infrastructure is not static: networks degrade, organizations
+  evolve, codebases accumulate technical debt. The world tree archetype
+  encodes the insight that the thing holding everything together is
+  itself subject to growth, decay, and attack.
+- **Traversal as transformation** -- in shamanic traditions, traveling
+  the world tree changes you. The shaman who descends to the roots or
+  ascends to the canopy returns altered. In Norse myth, Odin hangs on
+  Yggdrasil for nine days and gains the runes. This maps onto the idea
+  that moving between levels of a hierarchy is not merely navigation but
+  transformation: the engineer who becomes a manager, the student who
+  becomes a teacher, the user who becomes an administrator. The
+  archetype suggests that changing your position in the structure
+  changes what you are.
+
+## Limits
+
+- **Single path vs. multiple routes** -- the world tree provides one
+  connection between realms. Real hierarchies typically offer multiple
+  paths: skip-level meetings, cross-functional teams, network shortcuts.
+  The archetype's single-trunk model imports a simplicity that
+  overstates how constrained real traversal between levels is. It also
+  misrepresents network topologies, which are graphs, not trees.
+- **Immutability** -- the world tree cannot be redesigned, moved, or
+  replaced. It is a given of the cosmos. Real hierarchical structures
+  -- organizational charts, file systems, taxonomies -- are regularly
+  restructured. The archetype imports a sense of permanence and
+  inevitability that makes hierarchies feel natural and unchangeable,
+  which serves the interests of those at the top more than those at
+  the roots.
+- **The center-periphery assumption** -- the world tree places itself
+  at the center of everything. This is cosmologically convenient but
+  structurally misleading for distributed systems, peer-to-peer
+  networks, and decentralized organizations that have no center. The
+  archetype cannot model systems where there is no axis mundi, no
+  single critical infrastructure. Applying it to such systems imports
+  a centralization that does not exist.
+- **Vertical implies value** -- in the world tree, up is better. The
+  gods live in the canopy; the dead and the serpent live in the roots.
+  This vertical value mapping is so deeply embedded in the archetype
+  that it infects every hierarchical structure modeled on it: higher
+  in the org chart is better, upper management outranks lower, the
+  root directory is the most privileged. The archetype naturalizes a
+  value hierarchy that may have no basis in the actual domain.
+- **Biological metaphor smuggles in organic assumptions** -- because
+  the world tree is a living thing, it implies that hierarchies grow
+  "naturally," have a "natural" shape, and die of "natural" causes.
+  This organic framing can obscure the fact that most real hierarchies
+  are designed, imposed, and maintained by power. Calling an
+  organizational structure a "tree" makes it sound like it grew that
+  way, when in fact someone built it that way for their own reasons.
+
+## Expressions
+
+- "Tree structure" -- the dominant expression in computer science,
+  completely dead as a metaphor; programmers do not picture Yggdrasil
+  when they say "binary tree"
+- "Root" and "branch" -- fundamental vocabulary in computing, botany,
+  organizational design, and genealogy, all traceable to the tree
+  archetype
+- "Axis mundi" -- scholarly term for the world tree concept, used in
+  religious studies, architecture, and urban planning for any central
+  organizing structure
+- "Yggdrasil" -- used as a proper noun in tech projects (the Rust
+  compiler's module system, various network tools), invoking the
+  world-tree's connotation of foundational infrastructure
+- "Tree of Knowledge" -- the Biblical variant, mapping the world
+  tree onto epistemology; productive in knowledge management and
+  taxonomy design
+- "Going to the root of the problem" -- everyday expression that
+  uses the tree archetype's spatial logic to mean reaching the
+  fundamental cause
+
+## Origin Story
+
+The world tree appears to be among the oldest human conceptual
+structures. Mircea Eliade's *Shamanism: Archaic Techniques of Ecstasy*
+(1951) documents it across Siberian, Central Asian, and North American
+shamanic traditions as the axis mundi that the shaman climbs to reach
+other worlds. The Norse Yggdrasil is described in the *Voluspa* and
+*Grimnismal* (Poetic Edda, c. 10th century CE) and elaborated in
+Snorri Sturluson's *Prose Edda* (c. 1220). The Hindu Ashvattha
+(cosmic fig tree, inverted with roots above) appears in the *Bhagavad
+Gita* (15.1-4) and the *Katha Upanishad*. The Kabbalistic Tree of Life
+was formalized in the *Sefer Yetzirah* (3rd-6th century CE) and the
+*Zohar* (13th century).
+
+In computer science, the tree data structure was formalized by
+mathematicians in the 19th century (Cayley, 1857) and became
+foundational to computing through hierarchical file systems (Multics,
+1965), the DOM, and countless algorithms. Whether the computer
+scientists who named these structures were conscious of the mythological
+archetype is unclear, but the structural parallel is exact: a rooted
+hierarchy of nodes connected by edges, with traversal from root to leaf
+as the primary operation.
+
+## References
+
+- Eliade, M. *Shamanism: Archaic Techniques of Ecstasy* (1951) -- the
+  definitive cross-cultural study of the world tree in shamanic practice
+- Cook, R. *The Tree of Life: Image for the Cosmos* (1974) -- comparative
+  study of the world tree across mythological traditions
+- Sturluson, S. *Prose Edda* (c. 1220), trans. Byock (2005) -- primary
+  source for Yggdrasil
+- Knuth, D. *The Art of Computer Programming*, Vol. 1 (1968) -- foundational
+  treatment of tree data structures in computer science


### PR DESCRIPTION
## Summary

- Adds `world-tree` entry: cross-cultural cosmic tree archetype (Yggdrasil, Ashvattha, Wacah Chan, Tree of Life)
- Kind: `archetype` (recurs independently across 5+ unrelated cultures), source frame: `mythology`, applies to: `governance`, `ontological-hierarchy`
- Uses existing frames and categories; no new frames needed

Closes #1095

## Validator output

```
All content valid.
```

Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.6, 1M context)