### PR TITLE
Add entry: Koan

### DIFF
--- a/catalog/mappings/koan.md
+++ b/catalog/mappings/koan.md
@@ -1,0 +1,143 @@
+---
+slug: koan
+name: Koan
+kind: metaphor
+source_frame: mythology
+applies_to:
+  - hidden-knowledge
+categories:
+  - mythology-and-religion
+  - philosophy
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - gordian-knot
+created: '2026-03-16'
+updated: '2026-03-16'
+harness: Claude Code
+transfers:
+  - "[source] a koan resists logical resolution by design, making the failure of analytical reasoning the mechanism of insight rather than an obstacle to it"
+  - "[source] the teacher poses the koan but cannot transmit the answer, because the insight must arise from the student's own confrontation with the paradox"
+  - "[source] there is a correct response to a koan, but it cannot be arrived at by deduction -- it requires a discontinuous shift in the student's frame of reference"
+limits:
+  - "[source] breaks because a Zen koan operates within a structured teacher-student relationship with years of practice, while calling a business problem 'a koan' strips away the contemplative discipline that makes the paradox productive"
+  - "[source] misleads because koans have recognized responses validated by a lineage of masters, while the metaphorical use implies that any sufficiently puzzling question is a koan, erasing the distinction between genuine paradox and mere confusion"
+---
+
+## Transfers
+
+A koan -- a paradoxical question or statement used in Zen Buddhist practice
+to provoke insight beyond rational thought -- mapped onto any problem that
+resists conventional analysis and seems to require a fundamental shift in
+perspective to resolve. "What is the sound of one hand clapping?" is the
+canonical example: the question is not broken, and the student is not stupid.
+The problem is that the student's current framework of understanding cannot
+contain the answer.
+
+Key structural parallels:
+
+- **The problem is the method** -- in Zen practice, the koan is not an
+  obstacle to enlightenment but the vehicle of it. The student's struggle
+  with the paradox is itself the transformative process. The metaphor
+  imports this structure into secular contexts: calling a design challenge,
+  a strategic dilemma, or a philosophical question "a koan" reframes the
+  inability to find an answer as evidence that the question is doing its
+  work. The frustration is not a bug; it is the feature.
+- **Analytical reasoning is insufficient** -- koans are specifically designed
+  to defeat logical analysis. The student who tries to reason their way to
+  the answer will fail, because the answer exists in a register that logic
+  cannot reach. The metaphor maps onto problems where more data, more
+  analysis, and more expertise do not help -- where the breakthrough requires
+  abandoning the current frame entirely. "How do we grow without hiring?"
+  or "How do we move fast without breaking things?" become koans when the
+  conventional tools for answering them are exhausted.
+- **The answer cannot be taught, only realized** -- a Zen master can confirm
+  that a student has grasped the koan, but cannot simply tell them the
+  answer. Transmission is not informational but experiential. The metaphor
+  maps onto tacit knowledge, design intuition, and any domain where
+  understanding requires personal confrontation with the problem rather
+  than instruction. You cannot explain product-market fit to someone who
+  has never shipped a product; they have to sit with the koan.
+- **Resolution requires a frame shift** -- the koan is answered not by
+  finding the right content within the student's existing worldview but by
+  the worldview itself changing. This maps onto paradigm shifts, creative
+  breakthroughs, and those moments in therapy, strategy, or engineering
+  where the problem dissolves because the framing changes. The koan
+  metaphor marks these moments as structurally different from ordinary
+  problem-solving.
+
+## Limits
+
+- **Koans are curated, not accidental** -- in Zen practice, koans are
+  carefully selected from a canonical collection (the *Mumonkan*, the
+  *Blue Cliff Record*) by a teacher who matches the koan to the student's
+  stage of development. Calling any difficult problem "a koan" erases
+  this curation. Most hard problems are hard because they are poorly
+  specified, under-resourced, or genuinely unsolvable -- not because they
+  contain a hidden insight waiting to be triggered by a shift in
+  consciousness. The metaphor can dignify confusion as depth.
+- **The metaphor strips away the practice** -- sitting with a koan in Zen
+  involves years of meditation, a committed teacher-student relationship,
+  and a monastic or semi-monastic context. The metaphorical use retains
+  the paradox but discards the practice, implying that insight can be
+  produced by cleverness alone. This flatters the secular user while
+  misrepresenting the tradition: the koan works because of the practice
+  surrounding it, not despite it.
+- **Not every frame shift is an insight** -- the koan metaphor implies that
+  the difficulty will resolve into clarity once the right perspective is
+  found. But some problems that resist analysis resist it because they
+  are genuinely intractable, not because the analyst's frame is wrong.
+  Calling an intractable problem "a koan" can delay the recognition that
+  no amount of reframing will help and that the problem must be worked
+  around rather than through.
+- **Cultural flattening** -- Zen Buddhism is a living religious tradition
+  with specific philosophical commitments about the nature of mind,
+  language, and reality. Using "koan" as a casual synonym for "hard
+  question" extracts a technical term from its theological context and
+  empties it of its specific meaning. The metaphor works by borrowing
+  the prestige of Zen while discarding its content.
+
+## Expressions
+
+- "That's a real koan" -- used to describe a problem that seems to defy
+  logical resolution, common in design, strategy, and philosophy discussions
+- "It's one of those zen koans" -- often said half-jokingly about a
+  paradoxical requirement or contradictory set of constraints
+- "What is the sound of one hand clapping?" -- the most widely recognized
+  koan (attributed to Hakuin Ekaku), used as a general shorthand for
+  productive paradox
+- "Sit with it" -- advice derived from koan practice, meaning to resist
+  the urge to resolve a difficult question immediately and instead let
+  the discomfort do its work
+- "If you meet the Buddha on the road, kill him" -- a koan (from Linji)
+  that has entered general circulation as a metaphor for questioning
+  authority and received wisdom
+
+## Origin Story
+
+The koan tradition developed within Chinese Chan Buddhism (the predecessor
+of Japanese Zen) beginning around the Tang dynasty (7th-10th centuries CE).
+The earliest collections -- the *Blue Cliff Record* (Biyan Lu, 1125) and
+the *Gateless Gate* (Wumen Guan, 1228) -- compiled paradoxical dialogues
+between masters and students that were already circulating as teaching
+tools. The Japanese Rinzai school, particularly through Hakuin Ekaku
+(1686-1769), systematized koan practice into a formal curriculum with
+recognized stages of progression.
+
+The term entered English-language popular culture primarily through D.T.
+Suzuki's influential mid-20th century writings on Zen, and was reinforced
+by the Beat generation (Kerouac, Ginsberg, Snyder) and Robert Pirsig's
+*Zen and the Art of Motorcycle Maintenance* (1974). By the late 20th
+century, "koan" had become available as a general metaphor for any
+productively paradoxical question, particularly in technology and design
+communities influenced by California counterculture.
+
+## References
+
+- Aitken, R. *The Gateless Barrier: The Wu-Men Kuan (Mumonkan)* (1991)
+  -- authoritative English translation with commentary
+- Suzuki, D.T. *An Introduction to Zen Buddhism* (1934) -- the text most
+  responsible for introducing koan practice to Western audiences
+- Heine, S. and Wright, D. *The Koan: Texts and Contexts in Zen Buddhism*
+  (2000) -- scholarly treatment of the koan tradition's history and
+  hermeneutics


### PR DESCRIPTION
## Summary
- Adds `koan` mapping: Zen Buddhist paradoxical question mapped onto problems requiring frame shifts
- Source frame: mythology, applies to: hidden-knowledge
- Categories: mythology-and-religion, philosophy

Closes #1102

## Validation
✓ `uv run scripts/validate.py validate --filter="catalog/mappings/koan.md"` — All content valid