### PR TITLE
Add entry: Emperor's New Clothes

### DIFF
--- a/catalog/mappings/emperor-new-clothes.md
+++ b/catalog/mappings/emperor-new-clothes.md
@@ -1,0 +1,142 @@
+---
+slug: emperor-new-clothes
+name: Emperor's New Clothes
+kind: metaphor
+source_frame: mythology
+applies_to:
+  - social-control
+categories:
+  - mythology-and-religion
+  - social-dynamics
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - cassandra
+created: '2026-03-16'
+updated: '2026-03-16'
+harness: Claude Code
+transfers:
+  - "[source] the emperor's nakedness is visible to everyone, but social pressure transforms a perceptual fact into a forbidden utterance -- the problem is not blindness but enforced silence"
+  - "[source] the child who speaks the truth is effective precisely because they stand outside the social hierarchy that makes silence rational for adults"
+  - "[source] the swindlers succeed not through deception about cloth but through exploiting a preexisting incentive structure where admitting ignorance carries higher costs than performing knowledge"
+limits:
+  - "[source] breaks because in the tale the truth is simple and perceptual (the emperor is naked), while most real cases of collective silence involve genuinely ambiguous situations where reasonable people can disagree about what they see"
+  - "[source] misleads because the story ends when the child speaks -- it does not depict what happens next, implying that truth-telling alone resolves the problem, when in practice whistleblowers face retaliation and the system often reasserts itself"
+---
+
+## Transfers
+
+"The Emperor's New Clothes" -- Hans Christian Andersen's 1837 fairy tale
+about a vain emperor tricked into parading naked while his subjects pretend
+to see magnificent garments -- mapped onto any situation where an obvious
+falsehood is collectively maintained because the social cost of speaking
+the truth exceeds the cost of going along with the lie.
+
+Key structural parallels:
+
+- **Collective performance of belief** -- the courtiers, ministers, and
+  citizens all claim to see the clothes. Not because they are fooled, but
+  because the swindlers have established that only competent, intelligent
+  people can see the fabric. Each person performs belief to avoid being
+  identified as the incompetent one. The metaphor maps onto organizational
+  and political situations where everyone privately recognizes a problem
+  but publicly endorses the official narrative: the failing project that
+  no one will call failing, the emperor-CEO whose strategy everyone praises
+  while privately preparing their resumes.
+- **The incentive structure rewards silence** -- speaking up carries a
+  specific, personal cost (being judged unfit for your position), while
+  staying silent carries no immediate cost. The metaphor captures how
+  rational self-interest at the individual level produces collective
+  irrationality. Each courtier's silence is locally optimal and globally
+  absurd. This maps onto groupthink, market bubbles, academic consensus
+  enforcement, and any system where the individual cost of dissent
+  exceeds the individual benefit of honesty.
+- **The outsider breaks the spell** -- it takes a child, someone with no
+  status to protect and no understanding of the social rules, to state the
+  obvious. The metaphor imports the structural insight that the person best
+  positioned to tell the truth is the person with the least to lose. This
+  maps onto the role of outsiders, newcomers, and junior employees who
+  can see what insiders cannot say: the intern who asks why the legacy
+  system is still running, the journalist who asks the question everyone
+  in the industry knows is forbidden.
+- **The emperor knows** -- in Andersen's text, the emperor himself suspects
+  the truth but continues the parade. The metaphor captures the particular
+  psychology of a leader who would rather maintain a fiction than admit
+  error, especially when the fiction is already publicly committed to.
+  This maps onto sunk-cost escalation, political doubling-down, and the
+  corporate refusal to kill a publicly announced initiative.
+
+## Limits
+
+- **The truth in the story is trivially simple** -- the emperor is either
+  clothed or naked. There is no ambiguity, no interpretation, no room for
+  legitimate disagreement. Most real situations that get called "emperor's
+  new clothes" involve genuinely complex judgments where reasonable people
+  can differ. A technology that some experts consider transformative and
+  others consider hype is not the same as a naked man claiming to be
+  dressed. The metaphor's power depends on the truth being obvious, and
+  it flatters the speaker by implying that their controversial opinion
+  is as self-evident as nudity.
+- **The child faces no consequences** -- in the story, the child speaks and
+  the spell breaks. In reality, truth-tellers face retaliation. Whistleblowers
+  lose their jobs. Dissenting employees get marginalized. The fairy tale ends
+  at the moment of revelation and does not depict the aftermath, which lets
+  the metaphor imply that speaking truth to power is easy and effective.
+  The real lesson of most "emperor's new clothes" situations is that the
+  courtiers' silence was rational, not cowardly.
+- **The metaphor assumes a single, knowable truth** -- the story works
+  because there is exactly one correct perception (naked) and one incorrect
+  one (clothed). This binary structure maps poorly onto situations where
+  the "obvious truth" that the dissenter claims to see is itself
+  debatable. Conspiracy theorists, contrarian investors, and ideological
+  dissidents all cast themselves as the child in the crowd. The metaphor
+  provides no way to distinguish genuine insight from confident
+  wrongness.
+- **The swindlers are external agents** -- in the story, the deception is
+  initiated by outsiders with a deliberate con. Most collective delusions
+  are not engineered by identifiable tricksters but emerge organically
+  from incentive structures, cognitive biases, and social dynamics. The
+  metaphor can encourage a search for villains where the real problem
+  is systemic.
+
+## Expressions
+
+- "The emperor has no clothes" -- the standard invocation, used to call
+  out an obvious falsehood being collectively maintained, pervasive in
+  political commentary and business journalism
+- "Who's going to be the one to say the emperor has no clothes?" --
+  framing the act of dissent as a question of courage, common in
+  organizational contexts
+- "The emperor's new clothes moment" -- the point at which someone
+  finally states the obvious, breaking the spell of collective pretense
+- "Everyone can see the emperor is naked" -- asserting that a truth is
+  universally recognized but not spoken, often used in financial markets
+  before a bubble bursts
+- "The child in the crowd" -- identifying a truth-teller, particularly
+  one whose outsider status enables honesty that insiders cannot afford
+
+## Origin Story
+
+Hans Christian Andersen published "Kejserens nye Klæder" ("The Emperor's
+New Clothes") in 1837, adapting it from a medieval Spanish story in Don
+Juan Manuel's *El Conde Lucanor* (1335), where the invisible cloth was
+visible only to those of legitimate birth. Andersen shifted the mechanism
+from bloodline to competence -- the fabric is visible only to those fit
+for their office -- which made the satire applicable to any social
+hierarchy where admitting ignorance is career-ending.
+
+The story entered global circulation rapidly and became one of the most
+widely translated and referenced fairy tales. By the 20th century, "the
+emperor has no clothes" had become a standard idiom in English, detached
+from any specific knowledge of Andersen's text. It is used across the
+political spectrum and in every professional domain where collective
+self-deception is a recognized failure mode.
+
+## References
+
+- Andersen, H.C. "The Emperor's New Clothes" (1837) -- the source text,
+  widely available in multiple translations
+- Don Juan Manuel, *El Conde Lucanor* (1335) -- the medieval Spanish
+  source that Andersen adapted
+- Janis, I. *Groupthink* (1982) -- the psychology of collective silence
+  that the fairy tale dramatizes


### PR DESCRIPTION
## Summary
- Adds `emperor-new-clothes` mapping: Andersen fairy tale mapped onto collective delusion maintained by social pressure
- Source frame: mythology, applies to: social-control
- Categories: mythology-and-religion, social-dynamics

Closes #1103

## Validation
✓ `uv run scripts/validate.py validate --filter="catalog/mappings/emperor-new-clothes.md"` — All content valid