### PR TITLE
Add entry: Sorcerer's Apprentice

### DIFF
--- a/catalog/mappings/sorcerer-apprentice.md
+++ b/catalog/mappings/sorcerer-apprentice.md
@@ -1,0 +1,148 @@
+---
+slug: sorcerer-apprentice
+name: Sorcerer's Apprentice
+kind: metaphor
+source_frame: mythology
+applies_to:
+  - social-control
+categories:
+  - mythology-and-religion
+  - systems-thinking
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - golem
+  - frankenstein
+created: '2026-03-16'
+updated: '2026-03-16'
+harness: Claude Code
+transfers:
+  - "[source] the apprentice can start the process but cannot stop it, separating the ability to initiate automation from the ability to control it"
+  - "[source] the broom follows its instructions correctly -- the catastrophe arises not from malfunction but from the apprentice's inability to specify termination conditions"
+  - "[source] splitting the broom multiplies the problem, because the apprentice's intervention operates within the same framework as the original mistake rather than stepping outside it"
+limits:
+  - "[source] breaks because the master returns and restores order with superior knowledge, implying that every runaway process has a more competent authority who can intervene -- a comforting fiction that does not hold for emergent global systems like climate change or financial contagion"
+  - "[source] misleads because the apprentice's motive is laziness, reducing the cautionary tale to a morality play about shortcuts, when most real automation disasters stem from competent engineers facing genuinely complex systems"
+---
+
+## Transfers
+
+The Sorcerer's Apprentice -- a narrative in which a magician's student
+enchants a broom to carry water, only to find he cannot stop the process
+and nearly drowns -- mapped onto any situation where automation or
+delegation exceeds the operator's ability to control it. The story's
+power as a metaphor comes from a specific structural insight: the
+apprentice's problem is not that the magic fails but that it succeeds
+too well, too literally, and without a stop condition.
+
+Key structural parallels:
+
+- **Initiation is easier than termination** -- the apprentice knows the
+  spell to start the broom but not the spell to stop it. The metaphor
+  captures a pattern endemic to automation, institutional processes, and
+  technological deployment: it is far easier to launch a process than to
+  halt it. A company can automate customer service with chatbots in weeks
+  but may spend years trying to restore human touchpoints. A government
+  can start a war more easily than it can end one. The metaphor marks the
+  asymmetry between activation energy and deactivation energy as a
+  fundamental hazard.
+- **Correct execution produces catastrophe** -- the broom does exactly what
+  it was told to do: carry water. It does not malfunction, rebel, or
+  misunderstand. The catastrophe arises from the gap between the instruction
+  given and the outcome intended. This maps precisely onto algorithmic
+  systems that optimize their objective function perfectly while producing
+  disastrous side effects: the recommendation engine that maximizes
+  engagement by promoting outrage, the trading algorithm that exploits a
+  spread until the market crashes, the bureaucratic process that follows
+  every rule while producing absurd outcomes.
+- **Intervention amplifies the problem** -- when the apprentice chops the
+  broom in half, each half becomes a new water-carrying broom. His attempt
+  at a solution operates within the same paradigm as the original mistake
+  (physical force against magical process) and doubles the problem. The
+  metaphor maps onto situations where naive interventions in complex
+  systems backfire: hiring more people to fix a coordination problem,
+  adding more rules to fix regulatory complexity, applying more technology
+  to fix technology-created problems.
+- **The master has the knowledge the apprentice lacks** -- the sorcerer
+  returns and stops the brooms with a word. The metaphor imports a
+  comforting hierarchy: somewhere, someone has the deeper knowledge needed
+  to control the forces that have been unleashed. This maps onto the
+  belief that senior engineers can debug runaway systems, that regulators
+  can tame markets, that adults in the room can restore order. Whether
+  this belief is justified is precisely the question the metaphor raises.
+
+## Limits
+
+- **The master always returns** -- in the story, the sorcerer comes back
+  and fixes everything. This implies that runaway processes are
+  fundamentally recoverable if the right authority intervenes. But many
+  real-world automation catastrophes have no master: climate change has
+  no sorcerer who knows the counter-spell, financial contagion has no
+  single authority who can halt the cascade, and emergent AI behaviors
+  may exceed any individual's understanding. The metaphor's built-in
+  rescue undermines its cautionary force.
+- **The apprentice is a fool, not an engineer** -- the story frames the
+  problem as one of hubris and laziness: the apprentice uses magic to
+  avoid carrying water himself. This moral framing maps poorly onto
+  real automation, where the operators are typically competent
+  professionals making reasonable decisions in complex environments.
+  Calling a real engineering failure "a sorcerer's apprentice situation"
+  can unfairly impute laziness or incompetence where the actual cause
+  was irreducible complexity.
+- **The problem is singular and contained** -- one broom, one house, one
+  flood. Real automation disasters are typically distributed, cascading,
+  and multi-causal. The metaphor's containment (one room, one afternoon)
+  understates the scale and interconnectedness of modern systems. A
+  flash crash is not one broom carrying too much water; it is millions
+  of interacting algorithms producing emergent behavior that no single
+  actor initiated or can stop.
+- **The metaphor implies magic is real** -- calling automation "sorcery"
+  or "magic" imports an aura of mystery and incomprehensibility that
+  can discourage analysis. Real automated systems are not magical; they
+  are engineered artifacts that can be studied, understood, and (in
+  principle) controlled. The sorcery framing can foster learned
+  helplessness, encouraging people to treat technology as an inscrutable
+  force rather than a human creation subject to human governance.
+
+## Expressions
+
+- "Sorcerer's apprentice problem" -- used in technology, policy, and
+  management to describe a process that has escaped its operator's control
+- "We've created a sorcerer's apprentice" -- acknowledging that an
+  automated system is producing unintended consequences faster than they
+  can be addressed
+- "Who's the sorcerer here?" -- asking who has the authority or knowledge
+  to stop a runaway process
+- "Chopping the broom in half" -- describing an intervention that
+  multiplies rather than solves the problem
+- "Fantasia moment" -- referencing the Disney adaptation (1940), often
+  used in technology contexts when automation runs away from its creator
+
+## Origin Story
+
+The narrative originates in Lucian of Samosata's *Philopseudes* ("The
+Lover of Lies," c. 150 CE), where the magician Pancrates animates a
+pestle to fetch water during a journey up the Nile. The story was
+revived by Goethe in his 1797 ballad "Der Zauberlehrling," which
+established the canonical version with the apprentice, the broom, and
+the master's return.
+
+The metaphor achieved global cultural penetration through Disney's
+*Fantasia* (1940), in which Mickey Mouse plays the apprentice. The
+Fantasia sequence -- set to Paul Dukas's 1897 symphonic poem, itself
+inspired by Goethe -- became one of the most recognized animations in
+cinema history and made "sorcerer's apprentice" available as a universal
+shorthand for automation gone wrong. The metaphor gained renewed
+currency in the 21st century as AI systems, algorithmic trading, and
+automated decision-making created real-world instances of the pattern
+the story describes.
+
+## References
+
+- Goethe, J.W. von. "Der Zauberlehrling" (1797) -- the canonical
+  literary version of the tale
+- Lucian of Samosata. *Philopseudes* (c. 150 CE) -- the earliest known
+  written version of the animated servant narrative
+- Tenner, E. *Why Things Bite Back: Technology and the Revenge of
+  Unintended Consequences* (1996) -- discusses the sorcerer's apprentice
+  pattern in the context of technological blowback


### PR DESCRIPTION
## Summary
- Adds `sorcerer-apprentice` mapping: automation that exceeds its operator's control, from Goethe/Disney
- Source frame: mythology, applies to: social-control
- Categories: mythology-and-religion, systems-thinking
- Related: golem, frankenstein

Closes #1104

## Validation
✓ `uv run scripts/validate.py validate --filter="catalog/mappings/sorcerer-apprentice.md"` — All content valid