### PR TITLE
Add entry: Rumpelstiltskin

### DIFF
--- a/catalog/mappings/rumpelstiltskin.md
+++ b/catalog/mappings/rumpelstiltskin.md
@@ -1,0 +1,152 @@
+---
+slug: rumpelstiltskin
+name: Rumpelstiltskin
+kind: metaphor
+source_frame: mythology
+applies_to:
+  - hidden-knowledge
+categories:
+  - mythology-and-religion
+  - social-dynamics
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - emperor-new-clothes
+created: '2026-03-16'
+updated: '2026-03-16'
+harness: Claude Code
+transfers:
+  - "[source] the creature loses its power the moment it is named, making identification the mechanism of control rather than physical force or negotiation"
+  - "[source] the name is hidden deliberately, because the creature's power depends on remaining unclassified -- once categorized, it can be dealt with"
+  - "[source] the bargain was struck under duress when the miller's daughter had no alternatives, making the original contract exploitative regardless of whether its terms were technically honored"
+limits:
+  - "[source] breaks because naming Rumpelstiltskin destroys him completely, while naming a real phenomenon (a bias, a manipulation tactic, a disease) merely begins the work of addressing it rather than ending it"
+  - "[source] misleads because the name is a proper noun -- an arbitrary label discovered by luck -- while the metaphorical use implies that naming means understanding the underlying structure, conflating labeling with comprehension"
+---
+
+## Transfers
+
+Rumpelstiltskin -- the Brothers Grimm fairy tale in which a mysterious
+creature spins straw into gold for a desperate young woman, demands her
+firstborn child as payment, and is defeated only when she discovers his
+name -- mapped onto the power of naming: the idea that identifying and
+labeling a hidden force, manipulation, or problem is the key to
+neutralizing it.
+
+Key structural parallels:
+
+- **Naming as power** -- Rumpelstiltskin's power depends entirely on his
+  anonymity. He can extract impossible bargains, perform supernatural
+  feats, and bind others to contracts precisely because he cannot be
+  categorized. The moment the queen speaks his name, he is defeated. The
+  metaphor imports this structure into psychology, politics, and
+  organizational life: naming the dynamic is the first step to controlling
+  it. Calling a cognitive bias by its name (anchoring, sunk cost fallacy),
+  identifying a manipulation tactic (gaslighting, concern trolling), or
+  diagnosing a disease -- each act of naming converts something
+  mysterious and overwhelming into something that can be studied,
+  discussed, and counteracted.
+- **Hidden identity as leverage** -- the creature's bargaining power comes
+  from asymmetric information. He knows who he is; the queen does not.
+  This maps onto any power relationship where one party's advantage
+  depends on the other party's ignorance: the consultant who mystifies
+  their methodology, the abuser who keeps their tactics unnamed, the
+  financial instrument designed to be opaque, the algorithm that operates
+  as a black box. The metaphor marks information asymmetry as a
+  structural feature of exploitation, not an incidental one.
+- **The exploitative bargain** -- Rumpelstiltskin's deal is struck when the
+  miller's daughter faces execution. She agrees to give up her firstborn
+  because the alternative is death. The contract is technically voluntary
+  but substantively coerced. The metaphor maps onto predatory lending,
+  adhesion contracts, terms of service that no one reads, and any bargain
+  where one party's desperation makes "free choice" a fiction. The fairy
+  tale recognizes that formally consensual agreements can be deeply unjust.
+- **Discovery requires effort and luck** -- the queen does not deduce
+  Rumpelstiltskin's name through analysis. She sends messengers across the
+  kingdom, and one happens to overhear the creature singing his name in
+  the forest. The metaphor imports the insight that uncovering hidden
+  power structures requires active investigation, and that the discovery
+  often depends on fortunate access to information that the powerful
+  party believed was secure. Whistleblowers, leaked documents, and
+  investigative journalism all follow this pattern.
+
+## Limits
+
+- **Naming is not defeating** -- in the fairy tale, speaking the name
+  destroys Rumpelstiltskin instantly and completely. In reality, naming a
+  problem is at best the beginning of addressing it. Identifying a
+  cognitive bias does not eliminate it. Diagnosing a disease does not cure
+  it. Calling out a manipulation tactic does not prevent the manipulator
+  from using it. The metaphor dramatically overstates the efficacy of
+  naming by collapsing the entire process of resolution into a single
+  revelatory act.
+- **The name is arbitrary, not analytical** -- "Rumpelstiltskin" is a
+  proper noun, a meaningless label. Knowing it conveys no understanding
+  of the creature's nature, origins, or mechanics. But the metaphorical
+  use of "naming" typically implies genuine comprehension: to name a bias
+  is to understand its mechanism; to name an illness is to understand its
+  etiology. The fairy tale conflates labeling (attaching a word) with
+  understanding (grasping a structure), and the metaphor inherits this
+  conflation. Giving something a catchy name can create the illusion of
+  understanding while providing none.
+- **The creature acts alone** -- Rumpelstiltskin is a singular antagonist
+  whose power is entirely personal. Most real-world systems of hidden
+  exploitation are institutional, distributed, and impersonal. Naming one
+  corporate lobbying firm does not defeat the lobbying industry. Identifying
+  one bad actor does not dismantle the system that produced them. The fairy
+  tale's individualized villain maps poorly onto structural problems.
+- **The story rewards the person who made the bad bargain** -- the queen
+  agreed to give up her child, then reneges on the deal by discovering
+  the loophole (the name). The fairy tale presents this as justice, but
+  the structure is morally ambiguous: a contract was made and broken. The
+  metaphor inherits this ambiguity when applied to situations where the
+  "naming" party originally participated in and benefited from the
+  arrangement they now seek to escape.
+
+## Expressions
+
+- "Naming it takes away its power" -- the most common invocation of the
+  Rumpelstiltskin structure, used in therapy, organizational psychology,
+  and social criticism
+- "What's the Rumpelstiltskin here?" -- asking what hidden dynamic or
+  unnamed assumption is driving a problematic situation
+- "Name it to tame it" -- a therapeutic maxim (popularized by Daniel
+  Siegel) that directly applies the fairy tale's logic to emotional
+  regulation
+- "Spinning straw into gold" -- used independently of the full
+  Rumpelstiltskin narrative to describe the illusion of creating value
+  from nothing, or performing impossible transformations under pressure
+- "The Rumpelstiltskin principle" -- used in linguistics and cognitive
+  science for the idea that naming a phenomenon is a precondition for
+  thinking clearly about it
+
+## Origin Story
+
+The Brothers Grimm published "Rumpelstilzchen" in the first edition of
+*Kinder- und Hausmärchen* (1812), drawing on Germanic oral tradition.
+The tale type (ATU 500, "The Name of the Supernatural Helper") is
+widespread across European folklore, with variants in England ("Tom Tit
+Tot"), Scotland, and France, all sharing the core structure: a dangerous
+bargain with a supernatural being, defeated by discovering its name.
+
+The "naming as power" motif is far older than any specific tale, rooted
+in widespread magical traditions where knowing a being's true name grants
+power over it (Egyptian magic, Kabbalistic practice, the Norse tradition
+of *galdr*). The Rumpelstiltskin tale became the dominant cultural
+vehicle for this idea in the modern West, and the metaphor entered
+therapeutic and organizational discourse particularly through the
+influence of narrative therapy and cognitive-behavioral frameworks in
+the late 20th century, where "naming the problem" became a recognized
+clinical and management technique.
+
+## References
+
+- Grimm, J. and Grimm, W. "Rumpelstilzchen" in *Kinder- und
+  Hausmärchen* (1812) -- the source text
+- Zipes, J. *The Brothers Grimm: From Enchanted Forests to the Modern
+  World* (2002) -- scholarly context for the Grimm tales
+- Siegel, D. *The Whole-Brain Child* (2011) -- popularized "name it to
+  tame it" as a therapeutic principle drawn from the Rumpelstiltskin
+  structure
+- Frazer, J.G. *The Golden Bough* (1890) -- documents the cross-cultural
+  belief in the magical power of names


### PR DESCRIPTION
## Summary
- Adds `rumpelstiltskin` mapping: naming as power, identifying hidden forces to neutralize them
- Source frame: mythology, applies to: hidden-knowledge
- Categories: mythology-and-religion, social-dynamics

Closes #1105

## Validation
✓ `uv run scripts/validate.py validate --filter="catalog/mappings/rumpelstiltskin.md"` — All content valid