### PR TITLE
Add entry: Dragon Hoard

### DIFF
--- a/catalog/mappings/dragon-hoard.md
+++ b/catalog/mappings/dragon-hoard.md
@@ -1,0 +1,146 @@
+---
+slug: dragon-hoard
+name: Dragon Hoard
+kind: metaphor
+source_frame: mythology
+applies_to:
+  - economics
+categories:
+  - mythology-and-religion
+  - economics-and-finance
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - golem
+  - phoenix
+created: '2026-03-16'
+updated: '2026-03-16'
+harness: Claude Code
+transfers:
+  - "[source] the dragon accumulates treasure far beyond any capacity to use it, making the hoard's value consist entirely in possession rather than exchange or consumption"
+  - "[source] the hoard is defended with lethal force disproportionate to any threat, so the cost of guarding exceeds any plausible return on the stored wealth"
+  - "[source] the treasure beneath the dragon is removed from circulation -- it enriches no one, funds no enterprise, and serves no purpose except to exist under the dragon's body"
+limits:
+  - "[source] breaks because the dragon did not earn the hoard through productive activity -- it seized or inherited it -- while real-world wealth accumulators typically built at least some of what they guard, complicating the moral clarity"
+  - "[source] misleads because the dragon is a solitary predator with no social obligations, while human hoarders operate within legal, social, and political systems that constrain and enable their accumulation in ways the myth ignores"
+---
+
+## Transfers
+
+A dragon sits on a mountain of gold it cannot spend, will not share, and
+defends to the death. The image appears across European and Norse mythology --
+Fafnir in the Volsunga Saga, Smaug in Tolkien's reimagining, unnamed
+wyrms in Beowulf -- and the structural logic is always the same: wealth
+accumulated past any point of use, guarded by a creature whose entire
+existence has become organized around the act of guarding.
+
+Key structural parallels:
+
+- **Accumulation beyond use** -- the dragon does not eat gold, wear jewels,
+  or trade with other dragons. The hoard has no function except to be
+  hoarded. This maps onto wealth concentration where assets sit idle in
+  vaults, tax havens, or uninhabited real estate -- where the point is
+  possession, not utility. Smaug's gold enriches no one, including Smaug.
+  The metaphor makes the absurdity of extractive accumulation viscerally
+  legible.
+- **Territorial defense disproportionate to value** -- the dragon will
+  destroy entire armies to protect treasure it cannot use. This maps onto
+  rent-seeking behavior where incumbents spend enormous resources defending
+  monopoly positions: patent trolling, regulatory capture, litigation
+  campaigns designed to exhaust challengers. The cost of defense exceeds
+  any rational return, but rationality is not the operating principle --
+  hoarding is.
+- **Sterilized wealth** -- the gold under the mountain does nothing. It
+  does not circulate, does not fund enterprise, does not pay wages. In
+  economic terms, the dragon hoard is perfectly dead capital. This maps
+  onto the macroeconomic critique of extreme wealth concentration: money
+  sitting in assets rather than flowing through productive economies.
+  The image of a dragon sleeping on gold is the folk-economic version of
+  Keynes's paradox of thrift scaled to a single monstrous agent.
+- **Cursed treasure** -- in many versions (particularly the Nibelung
+  tradition and Tolkien), the hoard itself carries a curse. Those who take
+  it are corrupted. This maps onto the observation that acquiring vast
+  concentrated wealth changes the acquirer: the defensive posture, the
+  paranoia, the inability to relinquish. Thorin Oakenshield reclaims Erebor
+  and immediately becomes a lesser version of Smaug.
+
+## Limits
+
+- **Dragons did not build anything** -- Smaug conquered Erebor; he did not
+  found it. Real-world wealth accumulators typically created at least some
+  value before they became hoarders. Amazon's warehouses are not empty
+  mountains of gold -- they employ people and deliver goods. The metaphor's
+  moral clarity depends on the dragon being purely extractive, which makes
+  it a poor fit for cases where accumulation and production are entangled.
+- **The metaphor implies a single predator** -- the dragon is alone. Real
+  wealth concentration involves institutional systems: corporate structures,
+  inheritance law, tax policy, financial instruments. There is no single
+  beast to slay. The satisfying narrative arc of "kill the dragon, free the
+  gold" has no economic equivalent, and the metaphor can encourage a search
+  for individual villains where structural reform is needed.
+- **The hoard has no legitimate claimant problem** -- in the myths, the
+  treasure was stolen from identifiable owners. Real wealth inequality is
+  not straightforwardly a matter of theft: capital gains, network effects,
+  and compounding returns create concentration through mechanisms that are
+  legal, widely accepted, and genuinely productive for others along the way.
+  The metaphor imports a theft narrative that may not fit.
+- **Cursed treasure is unfalsifiable** -- "wealth corrupts" is a moral
+  claim, not an empirical one. Some wealthy individuals are generous and
+  effective philanthropists. The curse framing can become a thought-stopper
+  that prevents analysis of when concentrated resources are harmful and
+  when they are not.
+
+## Expressions
+
+- "Sitting on a dragon hoard" -- describing a company or individual with
+  large cash reserves deployed for no productive purpose, common in tech
+  industry commentary
+- "Smaug economy" -- informal term for rentier capitalism where incumbents
+  extract value from positions of dominance rather than creating new value
+- "Guarding the hoard" -- defensive corporate behavior: aggressive IP
+  enforcement, talent hoarding through non-competes, acquiring startups
+  to shelve their products
+- "Dragon sickness" -- Tolkien's term for the corruption that comes from
+  proximity to concentrated wealth, used informally to describe the
+  behavioral changes in founders after large liquidity events
+- "Dead capital" -- Hernando de Soto's economic term that maps directly
+  onto the dragon hoard: assets that exist but do not participate in the
+  productive economy
+- "The dragon always comes" -- from Le Guin's Earthsea, used to express the
+  inevitability that accumulated power attracts predatory attention
+
+## Origin Story
+
+The treasure-guarding dragon appears in the earliest Germanic literature.
+In Beowulf (c. 8th century), the dragon guards an ancient hoard in a barrow
+and destroys the surrounding kingdom when a single cup is stolen. The
+Volsunga Saga (13th century) gives us Fafnir, a dwarf who transforms into
+a dragon after murdering his father for the cursed gold of Andvari. The
+structural message is consistent: gold transforms its guardian into something
+monstrous.
+
+Tolkien, a medievalist, synthesized these sources into Smaug (The Hobbit,
+1937), who became the definitive modern dragon-hoarder. Tolkien added the
+economic dimension explicitly: Smaug's occupation of Erebor devastates the
+regional economy, and the dragon's death triggers a political crisis over
+redistribution. The "dragon sickness" that afflicts Thorin in the hoard's
+presence makes the corruption thesis literal.
+
+The metaphor entered economic discourse informally in the 2010s, gaining
+traction during debates about wealth inequality, corporate cash hoarding
+(Apple's $200B+ cash reserves became a recurring example), and the
+concentration of tech platform power.
+
+## References
+
+- *Beowulf* (c. 8th century) -- the original treasure-guarding dragon in
+  English literature
+- *Volsunga Saga* (13th century) -- Fafnir's transformation from dwarf
+  to dragon through gold-lust
+- Tolkien, J.R.R. *The Hobbit* (1937) -- Smaug as the definitive modern
+  dragon-hoarder
+- de Soto, H. *The Mystery of Capital* (2000) -- the concept of "dead
+  capital" that maps onto the dragon hoard structure
+- Piketty, T. *Capital in the Twenty-First Century* (2013) -- the
+  empirical case for wealth concentration as a structural tendency,
+  providing the economic substrate the metaphor addresses


### PR DESCRIPTION
## Summary
- Adds `dragon-hoard` metaphor mapping mythology (treasure-guarding dragons) onto economics (wealth concentration, rentier capitalism, dead capital)
- Cross-domain entry drawing from Norse mythology (Fafnir), Beowulf, and Tolkien (Smaug) as source material
- Links to existing `golem` and `phoenix` entries

## Validation
✓ `uv run scripts/validate.py validate` — 0 errors

Closes #1107