### PR TITLE
Add entry: The Chosen One

### DIFF
--- a/catalog/mappings/chosen-one.md
+++ b/catalog/mappings/chosen-one.md
@@ -1,0 +1,149 @@
+---
+slug: chosen-one
+name: The Chosen One
+kind: archetype
+source_frame: mythology
+applies_to:
+  - governance
+  - social-roles
+categories:
+  - mythology-and-religion
+  - organizational-behavior
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - the-trickster
+created: '2026-03-16'
+updated: '2026-03-16'
+harness: Claude Code
+transfers:
+  - "[source] the chosen one is selected by forces outside the ordinary system of merit, making legitimacy derive from destiny rather than competence or consent"
+  - "[source] the narrative requires the chosen one to be initially reluctant or unaware, so that the power appears to seek the person rather than the person seeking power"
+  - "[source] the chosen one's success validates the selection retroactively -- the prophecy is confirmed by the outcome it helped produce, creating a self-fulfilling loop"
+limits:
+  - "[source] breaks because the archetype assumes a single irreplaceable individual, while real systemic challenges typically require distributed effort and institutional capacity rather than individual heroism"
+  - "[source] misleads because the narrative erases the support structure -- the chosen one's companions, mentors, and institutional backing -- attributing collective achievement to singular destiny"
+---
+
+## Transfers
+
+Every culture tells a version of the same story: an ordinary person is
+singled out by fate, prophecy, or divine selection to accomplish what no
+one else can. Moses, Arthur, Luke Skywalker, Neo, Harry Potter, Frodo --
+the pattern recurs with such consistency across unrelated traditions that
+it functions less as a narrative choice and more as a cognitive template
+for how humans understand legitimacy, leadership, and historical change.
+
+Key structural parallels:
+
+- **Selection by external authority** -- the chosen one does not choose
+  themselves. They are selected by prophecy, divine intervention, magical
+  artifact, or narrative destiny. This maps onto how organizations and
+  cultures construct founder myths: the visionary who was "meant" to lead,
+  the CEO who was "born for this," the political leader whose rise feels
+  inevitable in retrospect. The archetype converts contingent outcomes into
+  destiny narratives, making what happened look like what had to happen.
+- **Reluctance as legitimation** -- the chosen one resists the call. Moses
+  protests at the burning bush. Luke refuses Obi-Wan. Frodo offers to give
+  the Ring away. This reluctance is structurally essential: it proves the
+  power sought the person, not the reverse. In leadership narratives, this
+  maps onto the mythology of reluctant founders ("I never wanted to be CEO")
+  and draft movements ("the people demanded it"). The reluctance
+  authenticates the selection.
+- **Singular agency in complex systems** -- the chosen one alone can defeat
+  the dark lord, pull the sword, fulfill the prophecy. This maps onto the
+  attribution of systemic outcomes to individual actors: "Steve Jobs saved
+  Apple," "Churchill won the war," "Satoshi created Bitcoin." The archetype
+  compresses distributed causation into a single protagonist, which makes
+  good stories and bad organizational theory.
+- **Retroactive validation** -- prophecies are confirmed by the outcomes they
+  set in motion. The chosen one succeeds, which proves they were chosen,
+  which explains why they succeeded. In organizations, this maps onto
+  survivorship bias dressed as destiny: the founder who succeeded was
+  clearly the right person, as evidenced by their success. The circular
+  logic is invisible inside the narrative.
+
+## Limits
+
+- **The archetype is anti-democratic** -- "chosen one" narratives
+  concentrate legitimacy in a single individual selected by forces beyond
+  popular control. Applied to governance, this is the structure of divine
+  right, not democratic mandate. Organizations that adopt this framing
+  -- the visionary founder who cannot be questioned -- create fragile,
+  personality-dependent systems. When the chosen one leaves or fails,
+  there is no succession mechanism because the narrative did not need one.
+- **It erases the ensemble** -- Frodo had Sam, Aragorn, Gandalf, and the
+  entire Fellowship. Moses had Aaron and Miriam. Luke had Han, Leia, and
+  the Rebel Alliance. The myths themselves acknowledge the support
+  structure, but the "chosen one" label collapses all credit onto a
+  single figure. In organizations, this maps onto the erasure of
+  co-founders, early employees, and institutional conditions that made
+  individual success possible.
+- **Prophecy is unfalsifiable** -- if the chosen one succeeds, the
+  prophecy was right. If they fail, they were not actually the chosen
+  one. This makes the archetype epistemically closed: it can explain
+  any outcome after the fact but predicts nothing in advance. Applied
+  to leadership selection, it offers the comfort of certainty without
+  the discipline of criteria.
+- **The archetype demands a singular threat** -- the chosen one is
+  chosen *for* something specific: defeat Voldemort, destroy the Ring,
+  free the Israelites. Real challenges -- climate change, institutional
+  dysfunction, systemic inequality -- do not have a single antagonist
+  that a singular hero can confront. The archetype misframes structural
+  problems as boss fights.
+
+## Expressions
+
+- "The chosen one" -- used seriously in tech journalism about founders
+  and ironically about anyone anointed for a role they did not earn through
+  normal channels
+- "The one we've been waiting for" -- political rhetoric (applied to
+  Obama's 2008 campaign, among others), importing messianic chosen-one
+  structure into democratic elections
+- "Founder mythology" -- the narrative that a startup's success traces
+  to a single visionary's unique gifts, erasing co-founders, early
+  employees, market timing, and luck
+- "10x engineer" -- tech culture's chosen-one figure: the singular
+  individual whose output exceeds all normal human capacity, selected
+  by talent rather than prophecy but structurally identical
+- "He's the one" -- The Matrix's literal chosen-one declaration, now
+  used ironically for anyone who demonstrates unexpected competence
+- "Born for this" -- sports and business commentary that retrofits
+  destiny onto achievement, converting hard work and luck into
+  narrative inevitability
+
+## Origin Story
+
+The chosen-one archetype is arguably the oldest story structure in human
+culture. Joseph Campbell codified it in *The Hero with a Thousand Faces*
+(1949) as the monomyth, tracing the pattern across mythological traditions
+from Gilgamesh to the Buddha. Campbell argued the pattern reflects
+universal psychological processes of individuation, though his universalism
+has been criticized for flattening cultural differences.
+
+The archetype gained enormous cultural reinforcement through Star Wars
+(1977), which Lucas explicitly designed using Campbell's template. The
+Matrix (1999) made the chosen-one structure self-aware and ironic. Harry
+Potter (1997-2007) gave it to a generation of readers. In each case, the
+structure is identical: an ordinary person discovers they are extraordinary,
+resists the call, accepts it, and fulfills a destiny that validates their
+selection.
+
+The application to business and politics is largely implicit but
+structurally pervasive. "Founder mythology" in Silicon Valley recapitulates
+the chosen-one arc: the dropout in a garage who was destined to change
+the world. The archetype's grip on leadership narratives is so strong that
+questioning it -- suggesting that success is distributed, contingent, and
+institutional -- feels like heresy.
+
+## References
+
+- Campbell, J. *The Hero with a Thousand Faces* (1949) -- the definitive
+  analysis of the monomyth/chosen-one pattern across cultures
+- Raglan, Lord. *The Hero: A Study in Tradition, Myth, and Drama* (1936)
+  -- earlier systematic treatment of the hero pattern
+- Vogler, C. *The Writer's Journey* (1992) -- Campbell's structure
+  adapted for Hollywood screenwriting, which reinforced the archetype's
+  dominance in popular culture
+- Rosenzweig, P. *The Halo Effect* (2007) -- how business narratives
+  retroactively construct chosen-one founder myths from contingent outcomes


### PR DESCRIPTION
## Summary
- Adds `chosen-one` archetype — the messianic selection narrative that recurs across mythology, religion, fantasy, film, and tech founder culture
- Kind set to `archetype` (recurs across 3+ unrelated domains with consistent structure)
- Applies to `governance` and `social-roles` frames

## Validation
✓ `uv run scripts/validate.py validate` — 0 errors

Closes #1108