### PR TITLE
Add entry: Dark Forest

### DIFF
--- a/catalog/mappings/dark-forest.md
+++ b/catalog/mappings/dark-forest.md
@@ -1,0 +1,168 @@
+---
+slug: dark-forest
+name: Dark Forest
+kind: metaphor
+source_frame: mythology
+applies_to:
+  - social-behavior
+categories:
+  - mythology-and-religion
+  - social-dynamics
+  - security
+author: agent:metaphorex-miner
+contributors: []
+related: []
+created: '2026-03-16'
+updated: '2026-03-16'
+harness: Claude Code
+transfers:
+  - "[source] the forest contains other entities whose intentions are unknowable, making silence and concealment the rational survival strategy rather than communication or cooperation"
+  - "[source] any signal you emit in the dark forest reveals your position to predators you cannot see, so visibility itself becomes the primary threat"
+  - "[source] the forest's darkness is not temporary but structural -- information about other agents' intentions is permanently unavailable, making trust impossible to establish without existential risk"
+limits:
+  - "[source] breaks because the dark forest assumes all unknown agents are potential predators, but real environments contain a distribution of cooperative, neutral, and hostile actors, and treating all unknowns as threats produces self-fulfilling hostility"
+  - "[source] misleads because forests are ecosystems with symbiotic relationships, not arenas of pure predation -- the metaphor selects for the forest's danger while ignoring its ecological interdependence"
+---
+
+## Transfers
+
+The dark forest is where you go to die. In European folklore -- the Brothers
+Grimm, Dante's *selva oscura*, countless fairy tales -- the forest is the
+space outside civilization where rules dissolve, predators lurk, and the
+unprepared are consumed. Liu Cixin's *The Dark Forest* (2008) transplanted
+this image into cosmology and game theory: the universe is a dark forest
+where every civilization is a silent hunter, because any signal reveals
+your position to entities who may destroy you preemptively.
+
+The metaphor has since escaped science fiction and become a general-purpose
+frame for environments where visibility is dangerous and the default
+posture is concealment.
+
+Key structural parallels:
+
+- **Silence as survival** -- in the dark forest, the rational strategy is
+  to make no sound. Any signal -- radio transmission, product launch,
+  market entry, public statement -- reveals your existence to entities
+  whose response you cannot predict. This maps onto competitive
+  environments where stealth is a strategic advantage: startups in
+  stealth mode, intelligence agencies, cryptocurrencies designed for
+  privacy. The metaphor makes "don't attract attention" feel not like
+  cowardice but like survival.
+- **Unknowable intentions** -- you cannot determine whether the other
+  entity in the forest is a deer or a wolf. In Liu Cixin's formulation,
+  even a technologically inferior civilization might experience a
+  capability explosion that makes it a future threat. This maps onto
+  the internet's trust problem: you do not know who is reading your data,
+  what they intend, or what capabilities they will develop. The "dark
+  forest theory of the internet" (Yancey Strickler, 2019) argues that
+  users are retreating from public platforms into private channels --
+  group chats, newsletters, Discord servers -- because the open web has
+  become a dark forest where visibility invites attack.
+- **Preemptive hostility** -- in Liu Cixin's game theory, the rational
+  response to detecting another civilization is to destroy it immediately,
+  because you cannot verify its intentions and the cost of being wrong
+  is existential. This maps onto security paradigms built on preemptive
+  defense: zero-trust architecture, shoot-first-ask-questions-later
+  border policies, the strategic logic of first-strike capability. The
+  metaphor makes preemption feel rational rather than aggressive.
+- **No exit** -- the dark forest is not a temporary condition. You cannot
+  illuminate it, map it, or make it safe. The darkness is structural.
+  This maps onto environments where uncertainty is permanent: adversarial
+  markets, geopolitical competition, the open internet. The metaphor
+  imports a fatalism that forecloses cooperative solutions -- if the forest
+  is permanently dark, building streetlights is futile.
+
+## Limits
+
+- **The metaphor assumes worst-case actors** -- the dark forest hypothesis
+  requires that all unknown agents be treated as potential existential
+  threats. In practice, most environments contain a distribution of
+  cooperative, indifferent, and hostile actors. Treating all unknowns as
+  predators produces a self-fulfilling prophecy: your preemptive hostility
+  creates the adversarial environment the metaphor predicted. The internet
+  is not actually a dark forest -- it is a city, with neighborhoods ranging
+  from dangerous to welcoming.
+- **Forests are ecosystems, not arenas** -- the metaphor selects for the
+  forest's danger while ignoring its ecology. Real forests are dense with
+  symbiotic relationships: mycorrhizal networks, pollination, nutrient
+  cycling. The dark forest metaphor strips away all cooperation and mutual
+  aid, which is exactly what makes it misleading when applied to systems
+  (like the internet or markets) where cooperation is not just possible
+  but the dominant mode of interaction.
+- **The folklore source is culturally specific** -- the "dark forest" as
+  a space of existential danger is a European trope. Many non-European
+  traditions treat forests as sacred, generative, or protective spaces.
+  The metaphor universalizes a particular cultural fear, which can distort
+  analysis when applied to contexts where the "forest" (unfamiliar
+  environment, open internet, new market) is genuinely more benign than
+  the metaphor suggests.
+- **Concealment has costs the metaphor ignores** -- in the dark forest,
+  silence is free. In real systems, stealth has enormous costs: missed
+  network effects, inability to recruit allies, loss of first-mover
+  advantages, psychological toll of isolation. Startups in permanent
+  stealth mode do not survive because survival requires customers, and
+  customers require visibility. The metaphor makes hiding seem costless
+  when it is often the most expensive strategy available.
+- **Liu Cixin's game theory is contested** -- the dark forest hypothesis
+  depends on specific assumptions (chains of suspicion, technological
+  explosion) that many game theorists and physicists dispute. Importing
+  the metaphor into other domains carries the unexamined assumption that
+  those conditions hold, when they often do not.
+
+## Expressions
+
+- "Dark forest theory of the internet" -- Yancey Strickler's 2019 essay
+  arguing that users are retreating from public platforms into private
+  spaces because visibility attracts trolls, advertisers, and surveillance
+- "Going dark" -- withdrawing from public visibility, used in both
+  intelligence and social media contexts
+- "Don't break cover" -- stealth-mode startup culture, where revealing
+  your product before launch invites competitive response
+- "The universe is a dark forest" -- Liu Cixin's original formulation,
+  now shorthand in tech and rationalist communities for adversarial
+  environments where trust is impossible
+- "Zero-trust" -- network security architecture that assumes all actors
+  are potentially hostile, the dark forest hypothesis implemented as
+  engineering policy
+- "If you can see them, they can see you" -- the reciprocal visibility
+  problem at the heart of the dark forest, used in military, competitive
+  intelligence, and online privacy contexts
+
+## Origin Story
+
+The forest as a space of danger is among the oldest European narrative
+tropes. Dante opens the *Divine Comedy* (1320) lost in a dark wood
+(*selva oscura*). The Brothers Grimm (1812-1857) made the forest the
+default setting for mortal peril: Hansel and Gretel, Little Red Riding
+Hood, Snow White all enter the forest and face annihilation. Bruno
+Bettelheim's *The Uses of Enchantment* (1976) argues the dark forest
+represents the unconscious -- the unknown interior space where
+psychological dangers lurk.
+
+Liu Cixin's *The Dark Forest* (2008), the second volume of the
+*Remembrance of Earth's Past* trilogy, formalized the metaphor as a
+game-theoretic proposition. His "dark forest hypothesis" -- that the
+universe is silent because civilizations that reveal themselves are
+destroyed by those that remain hidden -- became one of the most
+influential science-fiction concepts of the 21st century. It entered
+the Fermi Paradox literature as a serious (if contested) hypothesis.
+
+Yancey Strickler's 2019 essay "The Dark Forest Theory of the Internet"
+brought the metaphor into tech discourse, arguing that the open web had
+become hostile enough that users were rationally retreating into private,
+invite-only spaces. The essay resonated widely, and "dark forest" became
+shorthand in tech culture for any environment where visibility is
+dangerous.
+
+## References
+
+- Liu Cixin, *The Dark Forest* (2008) -- the game-theoretic formulation
+  of the dark forest hypothesis
+- Strickler, Y. "The Dark Forest Theory of the Internet" (2019) --
+  application to internet culture and platform dynamics
+- Bettelheim, B. *The Uses of Enchantment* (1976) -- psychoanalytic
+  reading of the dark forest in fairy tales
+- Grimm, J. and W. *Children's and Household Tales* (1812-1857) --
+  the canonical dark forest narratives in European folklore
+- Dante Alighieri, *Inferno* (1320) -- "in the middle of the journey
+  of our life, I found myself in a dark wood"


### PR DESCRIPTION
## Summary
- Adds `dark-forest` metaphor with dual source: European folklore (Brothers Grimm, Dante) and Liu Cixin's game-theoretic dark forest hypothesis
- Maps onto adversarial environments, internet retreat to private spaces, zero-trust security
- Categories: mythology-and-religion, social-dynamics, security

## Validation
✓ `uv run scripts/validate.py validate` — 0 errors

Closes #1109