### PR TITLE
Fix kaizen #1363: add historical-figures and military-history frames

### DIFF
--- a/.claude/agents/miner.md
+++ b/.claude/agents/miner.md
@@ -148,6 +148,16 @@ Cognitive biases and effects are `mental-model`. If you're writing 5 entries
 and they're all `metaphor`, stop and re-check — that distribution is almost
 certainly wrong.
 
+**Choosing `source_frame` (history vs. mythology):**
+
+Distinguish mythology (sacred/traditional narratives, gods, mythical heroes)
+from history (documented events/persons). Use `historical-figures` for entries
+derived from real historical persons (Pyrrhus, Machiavelli, etc.) and
+`military-history` for entries derived from real military events or strategy.
+Reserve `mythology` for genuinely mythological content -- gods, demigods,
+mythical heroes, sacred narratives. Classical antiquity does not automatically
+mean mythology.
+
 **Writing Entries:**
 
 Use the metaphorex-schema skill for the canonical schema. Additionally:

--- a/catalog/frames/historical-figures.md
+++ b/catalog/frames/historical-figures.md
@@ -1,0 +1,19 @@
+---
+created: '2026-03-16'
+name: Historical Figures
+related:
+- mythology
+roles:
+- exemplar
+- cautionary-tale
+slug: historical-figures
+updated: '2026-03-16'
+---
+
+Real, documented persons whose actions, decisions, or fates became
+proverbial. Unlike mythology (sacred/traditional narratives about gods
+and mythical heroes), historical figures are attested in the historical
+record. Their stories serve as exemplars or cautionary tales because the
+outcomes actually happened -- Pyrrhus really did win at ruinous cost,
+Machiavelli really did advise princes. The factual grounding makes the
+metaphorical transfer stronger: "this isn't a fable, it's what happens."

--- a/catalog/frames/military-history.md
+++ b/catalog/frames/military-history.md
@@ -1,0 +1,20 @@
+---
+created: '2026-03-16'
+name: Military History
+related:
+- historical-figures
+- war
+roles:
+- strategy
+- cautionary-tale
+slug: military-history
+updated: '2026-03-16'
+---
+
+Real military events, campaigns, and strategic doctrines drawn from the
+historical record. Distinct from the abstract "war" frame (which covers
+conflict-as-structure) and from "mythology" (sacred narratives). Military
+history entries derive their metaphorical force from documented outcomes:
+battles won or lost, strategies that succeeded or failed, costs that were
+actually paid. Use this frame for entries grounded in specific historical
+warfare, not for general conflict metaphors or mythologized accounts.


### PR DESCRIPTION
## Summary

Fixes #1363 — miners were defaulting to `source_frame: mythology` for all classical antiquity content, misclassifying real historical figures (e.g., Pyrrhus of Epirus) as mythological.

- **Added `catalog/frames/historical-figures.md`** — for entries derived from real, documented historical persons (Pyrrhus, Machiavelli, etc.). Roles: `exemplar`, `cautionary-tale`. Related: `mythology`.
- **Added `catalog/frames/military-history.md`** — for entries derived from real military events and strategy. Roles: `strategy`, `cautionary-tale`. Related: `historical-figures`, `war`.
- **Updated `.claude/agents/miner.md`** — added a "Choosing `source_frame`" section before "Writing Entries" that instructs miners to distinguish mythology (sacred narratives, gods, mythical heroes) from history (documented events/persons), and to use the new frames accordingly.

## What was broken

No `historical-figures` or `military-history` frames existed, so miners had no correct option for real historical content and fell back to `mythology`. The miner prompt also had no guidance on this distinction.

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors
- [x] Both new frames parse correctly (validator found no issues)
- [ ] Reviewer confirms frame descriptions accurately distinguish the domains

Generated with [Claude Code](https://claude.com/claude-code)