### PR TITLE
Add entry: Mordor

### DIFF
--- a/catalog/mappings/mordor.md
+++ b/catalog/mappings/mordor.md
@@ -15,7 +15,7 @@ related:
   - golem
 created: '2026-03-16'
 updated: '2026-03-16'
-harness: Claude Code
+harness: "Claude Code"
 transfers:
   - "[source] Mordor is a landscape fully subordinated to a single purpose -- war production -- where every feature serves the ruling will and nothing exists for its own sake"
   - "[source] the land itself is poisoned by the system that occupies it, so that even after the ruling power falls, the territory remains damaged and hostile to life"


### PR DESCRIPTION
## Summary
- Adds `mordor` mapping: Tolkien's dark realm as metaphor for totalitarian systems optimized for control
- Source frame: mythology; applies to: social-control
- Categories: mythology-and-religion, social-dynamics

Closes #1114

## Validation
✓ `uv run scripts/validate.py` — 0 errors

🤖 Smelted by metaphorex-smelter