### PR TITLE
Add entry: Necromancy

### DIFF
--- a/catalog/mappings/necromancy.md
+++ b/catalog/mappings/necromancy.md
@@ -16,7 +16,7 @@ related:
   - hydra-code
 created: '2026-03-16'
 updated: '2026-03-16'
-harness: Claude Code
+harness: "Claude Code"
 transfers:
   - "[source] the necromancer forces the dead to serve purposes they did not choose in life, violating the boundary between ended and active that normally governs systems"
   - "[source] reanimated beings retain their form but lose their animating intelligence, producing something that looks functional but operates without the understanding that originally guided it"


### PR DESCRIPTION
## Summary
- Adds `necromancy` mapping: dark arts of raising the dead as metaphor for reviving dead code, abandoned projects, and zombie processes
- Source frame: mythology; applies to: software-programs
- Categories: mythology-and-religion, software-engineering

Closes #1116

## Validation
✓ `uv run scripts/validate.py` — 0 errors

🤖 Smelted by metaphorex-smelter