### PR TITLE
Fix kaizen #1548: eval-driven insights for pipeline agent prompts

### DIFF
--- a/.claude/agents/assayer.md
+++ b/.claude/agents/assayer.md
@@ -66,6 +66,11 @@ value. You do the same for extracted entries.
      At least 3 expressions per entry.
    - **Tone**: matches the seed entries? Clear, structural, grounded,
      slightly irreverent?
+   - **Analytical value**: Does this entry add analytical value beyond what a
+     frontier model would produce without the catalog? The strongest entries
+     recover discarded structural features, name specific misuse patterns, or
+     make non-obvious cross-domain connections. Flag entries that merely
+     restate common knowledge.
    - **Frames**: roles are meaningful and structural, not just keywords?
 4. For mechanical issues (formatting, missing field, typo), push a fixup
    commit directly to the PR branch

--- a/.claude/agents/miner.md
+++ b/.claude/agents/miner.md
@@ -158,6 +158,19 @@ Use the metaphorex-schema skill for the canonical schema. Additionally:
 - Include Origin Story and References when the source provides them
 - Frames and categories created in the same PR must also pass validation
 
+**Analytical Value:**
+
+The catalog's defensible value is in the long tail — non-obvious structural
+parallels, precise limits, and naming that frontier models don't already know.
+When writing entries, prioritize:
+
+(a) structural insights the source myth/concept contains that modern usage has
+    discarded
+(b) limits that name specific misuse patterns rather than generic caveats
+(c) cross-references to unexpected domains
+
+Avoid restating what any educated reader already knows about the metaphor.
+
 **Git Workflow:**
 
 - Create a branch: `mine/<project-name>/<slug>`


### PR DESCRIPTION
Fixes #1548

## What was broken

Eval analysis showed the catalog's defensible value is in non-obvious structural insights — discarded structural features, specific misuse patterns, non-obvious cross-domain connections — not common knowledge. Neither the Miner nor the Assayer had guidance to prioritize this.

## What this changes

**`.claude/agents/miner.md`** — Added an "Analytical Value" section after "Writing Entries" guidance. Tells the Miner to prioritize: (a) structural insights that modern usage has discarded, (b) limits naming specific misuse patterns rather than generic caveats, (c) cross-references to unexpected domains. Explicitly says to avoid restating what any educated reader already knows.

**`.claude/agents/assayer.md`** — Added an "Analytical value" criterion to the quality checks list (step 3). Tells the Assayer to flag entries that merely restate common knowledge and to look for recovered structural features, specific misuse patterns, and non-obvious cross-domain connections.

## Test plan

- [x] `uv run scripts/validate.py validate` passes clean (zero errors)
- [x] Both prompts read coherently with the new sections in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)