### PR TITLE
Add entry: Let the Buyer Beware

### DIFF
--- a/catalog/mappings/let-the-buyer-beware.md
+++ b/catalog/mappings/let-the-buyer-beware.md
@@ -1,0 +1,120 @@
+---
+author: agent:metaphorex-miner
+categories:
+- law-and-governance
+- economics-and-finance
+contributors: []
+created: '2026-03-16'
+harness: Claude Code
+kind: mental-model
+name: Let the Buyer Beware
+related: []
+slug: let-the-buyer-beware
+source_frame: economics
+updated: '2026-03-16'
+transfers:
+  - "[model] in any exchange, the party acquiring bears primary responsibility for assessing quality"
+  - "[model] information asymmetry between seller and buyer is the default condition, not an anomaly"
+  - "[model] due diligence is a cost the acquirer must pay before the transaction, not after"
+limits:
+  - "[model] assumes buyers have the capacity and access to evaluate what they're acquiring, which fails for complex or opaque goods"
+  - "[model] treats all transactions as arm's-length exchanges between equals, ignoring power asymmetries"
+  - "[model] provides moral cover for fraud by shifting blame from the deceiver to the deceived"
+---
+
+## Transfers
+
+*Caveat emptor* -- the buyer bears the risk. A Roman legal principle that
+became the default rule for common-law sales and then migrated into
+universal advice about due diligence in every domain where someone acquires
+something from someone else.
+
+The structural insight is about information asymmetry as the baseline
+condition of exchange:
+
+- **The seller knows more than the buyer** -- this is not a market failure
+  but the normal state of affairs. The person offering something for sale
+  has lived with it, tested it, seen its flaws. The buyer has only the
+  seller's representation. Caveat emptor says: this asymmetry is your
+  problem, not the seller's.
+- **Inspection is the buyer's duty** -- the maxim creates an obligation to
+  investigate before committing. In law, this meant physically examining
+  goods. In everyday usage, it means doing your homework: reading reviews,
+  checking references, testing assumptions. The cost of due diligence is
+  part of the cost of acquisition.
+- **Risk allocation as default** -- the maxim is a resource-allocation
+  rule. Rather than requiring every seller to warrant every claim, it
+  places the verification burden on the party with the most at stake. This
+  is efficient when inspection is cheap and fraud is expensive to prove.
+
+Beyond commerce, the principle structures reasoning about hiring decisions
+("check references"), technology adoption ("run a proof of concept"),
+information consumption ("verify before sharing"), and relationships
+("trust but verify").
+
+## Limits
+
+- **Breaks for complex goods** -- caveat emptor assumes the buyer *can*
+  inspect meaningfully. This works for a horse at market; it fails for
+  pharmaceuticals, financial derivatives, or software-as-a-service. When
+  the thing being sold requires expertise to evaluate, the maxim becomes
+  "let the buyer be an expert or suffer." Consumer protection law exists
+  precisely because this limit was reached.
+- **Enables fraud by omission** -- the maxim draws no line between "the
+  seller didn't volunteer information" and "the seller actively concealed
+  defects." Under pure caveat emptor, both are the buyer's problem. Modern
+  law has retreated from this position because it incentivizes concealment
+  over disclosure.
+- **Assumes equal bargaining power** -- a sophisticated buyer negotiating
+  with a distressed seller is a different situation from a first-time
+  homebuyer facing a developer's legal team. The maxim treats all
+  transactions as symmetrical, which they almost never are. Consumer
+  protection, securities regulation, and truth-in-lending laws all exist
+  to correct this fiction.
+- **Creates a victim-blaming frame** -- when invoked after a bad outcome,
+  caveat emptor becomes "you should have known better," redirecting
+  moral judgment from the party who sold something defective to the party
+  who trusted. This is the maxim at its most corrosive: it transforms
+  a rule about prudence into an excuse for predation.
+
+## Expressions
+
+- "Caveat emptor" -- the Latin form, used in contracts and casual
+  conversation alike, often by people who know no other Latin
+- "Buyer beware" -- the English translation, standard in consumer advice
+  columns and real estate listings
+- "You get what you pay for" -- the folk corollary, implying that low
+  price signals low quality and the buyer accepted that bargain
+- "Due diligence" -- the procedural expression of the maxim, now a term of
+  art in finance, M&A, and venture capital
+- "Read the fine print" -- caveat emptor applied to contracts, where the
+  thing to beware of is buried in clause 14(b)
+- "Let the buyer beware" -- invoked after a bad purchase, usually by
+  someone other than the buyer
+
+## Origin Story
+
+The phrase traces to Roman law, though the Romans applied it narrowly to
+sales of land and slaves. English common law adopted it wholesale,
+establishing caveat emptor as the default rule for all sales by the 16th
+century. The principle reached its zenith in the 19th century, when
+laissez-faire economics and caveat emptor reinforced each other: the
+market works best when buyers are vigilant and sellers are free.
+
+The 20th century eroded the legal doctrine. The Uniform Commercial Code
+(1952) introduced implied warranties. Consumer protection statutes shifted
+the burden back to sellers. The EU's consumer acquis went further,
+establishing a presumption that sellers warrant fitness for purpose.
+
+But as the legal principle retreated, the folk maxim advanced. "Buyer
+beware" is now invoked in contexts the Romans never imagined: downloading
+free software, evaluating political promises, choosing a therapist. The
+legal doctrine is mostly dead; the reasoning pattern is thriving.
+
+## References
+
+- Broom, H. *A Selection of Legal Maxims* (1845), maxim on caveat emptor
+- Hamilton, W. "The Ancient Maxim Caveat Emptor," *Yale Law Journal* 40:8
+  (1931): 1133-1187
+- Atiyah, P.S. *The Rise and Fall of Freedom of Contract* (1979) -- traces
+  the arc of caveat emptor through English law


### PR DESCRIPTION
## Summary
- Adds `let-the-buyer-beware` (caveat emptor) as a `mental-model` entry
- Legal maxim encoding information-asymmetry heuristic for due diligence
- Source: Broom's Legal Maxims project (#1227)

Closes #1375

## Validation
✓ `uv run scripts/validate.py validate` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)