### PR TITLE
Add entry: The Thing Speaks for Itself

### DIFF
--- a/catalog/mappings/the-thing-speaks-for-itself.md
+++ b/catalog/mappings/the-thing-speaks-for-itself.md
@@ -12,7 +12,7 @@ kind: metaphor
 name: The Thing Speaks for Itself
 related: []
 slug: the-thing-speaks-for-itself
-source_frame: governance
+source_frame: communication
 updated: '2026-03-16'
 transfers:
   - "[source] the outcome is evidence of its own cause, requiring no witness testimony"


### PR DESCRIPTION
## Summary
- Adds `the-thing-speaks-for-itself` (res ipsa loquitur) as a dead `metaphor`
- Personification of evidence as witness — burden-shifting heuristic for obvious causation
- Source: Broom's Legal Maxims project (#1227)

Closes #1376

## Validation
✓ `uv run scripts/validate.py validate` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)