### PR TITLE
Add entry: No One Should Judge Their Own Case

### DIFF
--- a/catalog/mappings/no-one-should-judge-their-own-case.md
+++ b/catalog/mappings/no-one-should-judge-their-own-case.md
@@ -1,0 +1,135 @@
+---
+author: agent:metaphorex-miner
+categories:
+- law-and-governance
+- ethics-and-morality
+contributors: []
+created: '2026-03-16'
+harness: Claude Code
+kind: mental-model
+name: No One Should Judge Their Own Case
+related:
+- hear-the-other-side
+slug: no-one-should-judge-their-own-case
+source_frame: governance
+updated: '2026-03-16'
+transfers:
+  - "[model] self-assessment is structurally unreliable because the assessor's interest distorts the assessment"
+  - "[model] fairness requires that the decision-maker be independent of the outcome"
+  - "[model] institutional design must separate the roles of interested party and evaluator"
+limits:
+  - "[model] assumes an independent judge is available, which fails in small groups, startups, or any system with limited personnel"
+  - "[model] treats all self-interest as disqualifying, ignoring that domain expertise often comes with stake in the outcome"
+---
+
+## Transfers
+
+*Nemo judex in causa sua* -- no one should be judge in their own case. One
+of natural justice's two foundational pillars (the other being *audi
+alteram partem*, hear the other side). The principle encodes a structural
+insight about human cognition: self-interest corrupts judgment not through
+malice but through architecture. You cannot simultaneously be the party
+with a stake and the party who evaluates fairly, because interest distorts
+perception before conscious reasoning begins.
+
+Key structural parallels:
+
+- **Conflict of interest as structural, not moral** -- the maxim doesn't
+  say "dishonest people shouldn't judge their own cases." It says *no one*
+  should. The disqualification is positional, not personal. Even the most
+  honest person has blind spots about their own conduct. This is what makes
+  the principle powerful: it doesn't rely on detecting bad character, only
+  on detecting structural conflict.
+- **Separation of roles** -- the maxim implies that evaluation and
+  participation are distinct functions that must be assigned to different
+  actors. This structural pattern recurs everywhere: external auditors
+  review financial statements, peer review evaluates scientific claims,
+  independent directors sit on compensation committees, referees don't
+  play for either team.
+- **Institutional design principle** -- beyond individual cases, the maxim
+  drives the design of entire systems. Separation of powers in government,
+  the distinction between prosecution and judiciary, the creation of
+  ombudsman offices, the requirement for independent ethics boards -- all
+  are institutional expressions of the principle that the judge must be
+  distinct from the judged.
+
+The principle has migrated into domains far from law. In software, code
+review exists because developers cannot objectively evaluate their own
+code. In science, double-blind studies exist because researchers cannot
+objectively evaluate their own hypotheses. In management, 360-degree
+reviews exist because self-assessment is unreliable. The mechanism is
+always the same: insert an independent evaluator to correct for the
+structural bias of self-judgment.
+
+## Limits
+
+- **Independent judges are scarce** -- the principle assumes someone
+  without a stake is available to decide. In small organizations, everyone
+  has a stake. In specialized fields, everyone who understands the issue
+  is also involved in it. Supreme Court justices recuse themselves from
+  cases involving personal connections, but when the pool of qualified
+  judges is small, recusal can become paralysis. The principle tells you
+  *what* to do but not *how* when independence is structurally impossible.
+- **Expertise correlates with interest** -- the people who know the most
+  about a domain are usually the ones invested in it. Requiring perfect
+  independence often means replacing informed judgment with uninformed
+  judgment. An external auditor unfamiliar with the industry may miss
+  what an insider would catch. The maxim assumes independence improves
+  accuracy, but sometimes it trades bias for ignorance.
+- **Infinite regress** -- who judges the judge? If the principle is
+  applied recursively, you need an independent evaluator for the
+  independent evaluator, and so on. Every system that implements this
+  principle must also decide where to stop applying it, and that stopping
+  point is always somewhat arbitrary.
+- **Can be weaponized as a disqualification tool** -- "you can't judge
+  this because you're involved" can be used to silence the people with
+  the most relevant experience. In organizational politics, invoking
+  conflict of interest is sometimes a way to exclude inconvenient voices
+  rather than to ensure fairness.
+
+## Expressions
+
+- "Nemo judex in causa sua" -- the Latin, cited in constitutional law
+  and administrative law worldwide
+- "Conflict of interest" -- the modern institutional term for the
+  condition the maxim identifies
+- "You can't grade your own homework" -- the classroom version, used
+  in education and management alike
+- "Recusal" -- the judicial procedure of stepping aside from a case
+  where one has a personal interest
+- "Independent review" -- the procedural remedy, whether in auditing,
+  science, or HR investigations
+- "The fox guarding the henhouse" -- the folk metaphor for the violation
+  of this principle, where the interested party is also the guardian
+- "Marking your own exam" -- British English variant, common in
+  governance and regulatory discourse
+
+## Origin Story
+
+The principle is ancient, traceable to Roman law and arguably to Athenian
+democratic practice. In English law, its landmark moment is *Dr Bonham's
+Case* (1610), where Chief Justice Coke held that the College of Physicians
+could not simultaneously prosecute and judge a doctor for practicing
+without a license. Coke's reasoning: when the same body is both party and
+judge, their judgment is void -- not because they are corrupt, but because
+the structure is corrupt.
+
+The principle became one of the two pillars of "natural justice" (the
+other being the right to be heard) and was exported throughout the
+British Empire's legal systems. It now appears in the constitutional law
+of dozens of countries, in the procedural rules of international courts,
+and in corporate governance codes worldwide.
+
+Its migration beyond law was inevitable. Any system that needs fair
+evaluation eventually rediscovers this principle, because the failure
+mode it prevents -- self-interested judgment masquerading as objectivity
+-- is universal.
+
+## References
+
+- Broom, H. *A Selection of Legal Maxims* (1845)
+- *Dr Bonham's Case* [1610] 8 Co Rep 107 -- Coke's foundational ruling
+- *Dimes v Grand Junction Canal* [1852] 3 HL Cas 759 -- Lord Chancellor
+  disqualified for holding shares in a party to the case
+- Nolan Committee, *Standards in Public Life* (1995) -- codified the
+  principle for modern UK governance


### PR DESCRIPTION
## Summary
- Adds `no-one-should-judge-their-own-case` (nemo judex in causa sua) as a `mental-model`
- Structural principle about self-assessment unreliability — drives recusal, peer review, separation of powers
- Source: Broom's Legal Maxims project (#1227)

Closes #1377

## Validation
✓ `uv run scripts/validate.py validate` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)