### PR TITLE
Add entry: The Law Does Not Concern Itself with Trifles

### DIFF
--- a/catalog/mappings/the-law-does-not-concern-itself-with-trifles.md
+++ b/catalog/mappings/the-law-does-not-concern-itself-with-trifles.md
@@ -1,0 +1,140 @@
+---
+author: agent:metaphorex-miner
+categories:
+- law-and-governance
+- organizational-behavior
+contributors: []
+created: '2026-03-16'
+harness: Claude Code
+kind: mental-model
+name: The Law Does Not Concern Itself with Trifles
+related: []
+slug: the-law-does-not-concern-itself-with-trifles
+source_frame: governance
+updated: '2026-03-16'
+transfers:
+  - "[model] any system with finite capacity must establish a materiality threshold below which it refuses to act"
+  - "[model] the cost of adjudicating a matter can exceed the harm the matter causes, making intervention irrational"
+  - "[model] ignoring the trivial is not neglect but a precondition for attending to the significant"
+limits:
+  - "[model] what counts as trivial depends on who is defining it — the powerful dismiss harms they do not experience"
+  - "[model] small violations that individually fall below threshold can accumulate into systemic harm that no single instance triggers a response to"
+---
+
+## Transfers
+
+*De minimis non curat lex* -- the law does not concern itself with
+trifles. A resource-allocation principle that encodes one of the most
+fundamental insights in systems design: any system with finite capacity
+must establish a threshold below which it refuses to engage, or it will
+be overwhelmed by the trivial and unable to address the significant.
+
+Key structural parallels:
+
+- **Materiality thresholds** -- the principle's most direct structural
+  transfer. In accounting, transactions below a materiality threshold
+  don't require disclosure. In engineering, tolerances define acceptable
+  deviation. In software, log levels filter noise from signal. In each
+  case, the system explicitly decides what is too small to notice, and
+  this decision is what makes the system functional. A logging system
+  that captures everything captures nothing useful.
+- **Attention as scarce resource** -- the maxim treats judicial attention
+  the way economics treats money: as finite and therefore subject to
+  allocation decisions. Every hour spent on a trivial case is an hour
+  not spent on a serious one. This transfers directly to management
+  ("don't sweat the small stuff"), engineering (error budgets), and
+  personal productivity (triage). The insight is that ignoring small
+  things is not laziness but a prerequisite for effectiveness.
+- **System self-preservation** -- a system that responds to every input
+  with equal intensity will exhaust itself. The immune system that
+  attacks every foreign particle causes autoimmune disease. The manager
+  who escalates every minor issue creates crisis fatigue. The legal
+  system that prosecutes every jaywalker has no capacity for murder cases.
+  De minimis is the principle that protects systems from self-destruction
+  through over-responsiveness.
+- **Dignity of the system** -- there is a second, less obvious transfer.
+  The law doesn't just lack capacity for trifles; it would be *diminished*
+  by attending to them. A court that adjudicates a dispute over a
+  borrowed pencil undermines its own authority. This maps to institutional
+  credibility generally: systems that engage with trivia signal that they
+  cannot distinguish important from unimportant, and that signal erodes
+  trust.
+
+## Limits
+
+- **Who defines "trifle"?** -- the most dangerous limit. What is trivial
+  to the powerful may be devastating to the powerless. A wealthy
+  corporation considers a $500 regulatory fine trivial; for the small
+  business it's existential. Sexual harassment was once "too trivial"
+  for legal attention. Wage theft of small amounts per paycheck was
+  "de minimis" until someone calculated the aggregate. The threshold is
+  always set by the people who are above it.
+- **Accumulation below threshold** -- individually trivial harms can
+  aggregate into systemic damage that no single instance triggers a
+  response to. Each instance of microaggression is "de minimis." Each
+  small pollution discharge is below the reporting threshold. Each minor
+  contract violation is too small to litigate. But the cumulative effect
+  can be catastrophic, and the de minimis principle provides no mechanism
+  for aggregation. This is the principle's structural blind spot.
+- **Threshold gaming** -- once a de minimis threshold is known, rational
+  actors will calibrate their behavior to stay just below it. Tax
+  structuring, pollution permits, speed limits with known enforcement
+  tolerances -- all exploit the gap between the rule and the enforcement
+  threshold. The principle creates a safe harbor for strategic minor
+  violations.
+- **Slippery thresholds** -- what counts as trivial shifts over time, and
+  the direction of shift is unpredictable. Standards that were once below
+  the threshold become material as norms evolve (data privacy, carbon
+  emissions, accessibility). The principle provides no mechanism for
+  recalibrating the threshold, which means systems tend to lag behind
+  changing standards of materiality.
+
+## Expressions
+
+- "De minimis" -- the Latin shorthand, used as an adjective in law,
+  finance, and regulation: "the amount is de minimis"
+- "Don't sweat the small stuff" -- the self-help version, which inverts
+  the institutional principle into personal advice
+- "Pick your battles" -- the strategic version, acknowledging that
+  engaging with everything means winning nothing
+- "Not worth the paper it's printed on" -- dismissing a claim as too
+  trivial to merit formal documentation
+- "Below the materiality threshold" -- accounting's technical term for
+  the same principle
+- "Noise floor" -- engineering's version: the level below which signal
+  cannot be distinguished from noise, and therefore should be ignored
+- "Error budget" -- site reliability engineering's version: a defined
+  amount of acceptable failure, below which no remediation is triggered
+- "Rounding error" -- dismissing something as so small it disappears
+  in the mathematics
+
+## Origin Story
+
+The maxim appears in Roman law and was well established in English common
+law by the time Broom compiled his collection in 1845. Its most famous
+early application is in cases of *de minimis* trespass, where courts
+refused to hear claims about trivial boundary incursions on the principle
+that the legal system's dignity and capacity should not be wasted on
+disputes a reasonable person would ignore.
+
+The principle gained new life in the 20th century as regulatory systems
+proliferated. Tax law, environmental regulation, securities law, and
+antitrust all adopted explicit de minimis thresholds: dollar amounts,
+percentage caps, or concentration limits below which the law simply does
+not engage. The IRS de minimis safe harbor (currently $2,500 per item)
+is a direct descendant of the Roman principle.
+
+In technology, the principle migrated through engineering tolerances and
+signal processing into software design. Error budgets, log levels, rate
+limiters, and sampling strategies all implement the same insight: a system
+that responds to everything with equal intensity is a system that
+functions poorly. The Latin has been forgotten; the principle is
+everywhere.
+
+## References
+
+- Broom, H. *A Selection of Legal Maxims* (1845)
+- Posner, R. *Economic Analysis of Law* (9th ed., 2014) -- treats de
+  minimis as a rational allocation principle
+- Beier, D. "De Minimis Non Curat Lex," *Columbia Law Review* 39:6
+  (1939): 935-947


### PR DESCRIPTION
## Summary
- Adds `the-law-does-not-concern-itself-with-trifles` (de minimis non curat lex) as a `mental-model`
- Materiality-threshold heuristic — any system with finite capacity must define what is too small to notice
- Source: Broom's Legal Maxims project (#1227)

Closes #1380

## Validation
✓ `uv run scripts/validate.py validate` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)