### PR TITLE
Fix kaizen #1262: Smelter uses wrong label ready-for-assay

### DIFF
--- a/.claude/agents/smelter.md
+++ b/.claude/agents/smelter.md
@@ -41,7 +41,7 @@ transform raw mining output into clean, validated content.
 
 1. Find PRs labeled `needs-smelting` (up to 2 per invocation)
 2. Run mechanical checks and push fixup commits
-3. Advance PRs to `ready-for-assay` or flag as `needs-miner-fix`
+3. Advance PRs to `needs-assay` or flag as `needs-miner-fix`
 
 **Process:**
 
@@ -61,7 +61,7 @@ transform raw mining output into clean, validated content.
       for every sub-issue in the batch
    f. Run `uv run scripts/validate.py validate`
    g. If issues found: push fixup commits to the PR branch
-   h. If all fixed: remove `smelting`, add `ready-for-assay`
+   h. If all fixed: remove `smelting`, add `needs-assay`
    i. If unfixable (e.g., missing frame that doesn't exist, broken entry
       structure): remove `smelting`, add `needs-miner-fix`, post comment
       explaining the specific error


### PR DESCRIPTION
Fixes #1262

## Summary
- The smelter agent prompt used `ready-for-assay` as the label to apply after successful smelting, but the correct pipeline label is `needs-assay`
- Replaced both occurrences (line 44 in the responsibility list, line 64 in the process steps) with `needs-assay`

## Test plan
- [x] `grep ready-for-assay .claude/agents/smelter.md` returns 0 matches
- [x] `grep needs-assay .claude/agents/smelter.md` returns 2 matches (lines 44 and 64)

Generated with [Claude Code](https://claude.com/claude-code)