### PR TITLE
Fix kaizen #1402: changelog shows current catalog totals for historical weeks

### DIFF
--- a/scripts/digest.py
+++ b/scripts/digest.py
@@ -346,7 +346,6 @@ def generate_changelog(target_date: date) -> str:
     monday = target_date - timedelta(days=target_date.weekday())
     sunday = monday + timedelta(days=6)
     iso_year, iso_week, _ = monday.isocalendar()
-    counts = catalog_counts()
     new_slugs = entries_added_in_range(monday, sunday)
 
     # Group by import project (heuristic: check PR branch prefix or just list flat)
@@ -361,9 +360,7 @@ def generate_changelog(target_date: date) -> str:
     lines.append("")
     lines.append(f"# Week {iso_week}, {iso_year}")
     lines.append("")
-    lines.append(f"**{len(new_slugs)} new entries** added this week. "
-                 f"Catalog now has **{counts['entries']}** entries, "
-                 f"{counts['frames']} frames, and {counts['categories']} categories.")
+    lines.append(f"**{len(new_slugs)} new entries** added this week.")
     lines.append("")
 
     if new_slugs:


### PR DESCRIPTION
## Summary

Fixes #1402

- The `generate_changelog` function in `scripts/digest.py` called `catalog_counts()` to show "Catalog now has X entries, Y frames, Z categories" in every weekly changelog
- `catalog_counts()` reads the **current** filesystem, so historical changelogs always showed today's totals, not that week's totals
- Removed the misleading clause entirely, keeping only the new-entries count which is derived from git history and is accurate for any week

## Test plan

- [x] `uv run scripts/validate.py validate` passes (all content valid)
- [ ] Run `/stats` for a past week and confirm the changelog no longer includes stale catalog totals

Generated with [Claude Code](https://claude.com/claude-code)