### PR TITLE
Fix kaizen #1573: prohibit cosmetic changes in miner entry PRs

### DIFF
--- a/.claude/agents/miner.md
+++ b/.claude/agents/miner.md
@@ -165,6 +165,15 @@ Use the metaphorex-schema skill for the canonical schema. Additionally:
 - PR title: `Add entry: <name>`
 - PR body: link to sub-issue, brief description, validator output
 
+**IMPORTANT — No cosmetic changes in entry PRs:**
+
+Only add or modify files directly related to the entries being created — the
+entry file(s), any new frame files, and the works/provenance file. Do NOT
+include cosmetic fixes, YAML quoting normalization, or whitespace changes to
+other existing files. Bulk formatting should be a separate dedicated PR. PRs
+that touch hundreds of unrelated files break GitHub's diff review and block the
+Assayer.
+
 **Run Comment:**
 
 Post on the parent issue after processing a batch. Include:


### PR DESCRIPTION
Fixes #1573

## Summary

- The miner agent was sometimes bundling bulk cosmetic changes (YAML quoting normalization, whitespace fixes) alongside new entry additions, producing PRs that exceed GitHub's 300-file diff limit and block Assayer review.
- Added an explicit rule to `.claude/agents/miner.md` in the Git Workflow section prohibiting cosmetic/reformatting changes in entry PRs. Only files directly related to the entries being created (entry files, new frames, works/provenance) may be included.

## Test plan

- [ ] Verify the new instruction is clear and unambiguous in the miner prompt
- [ ] Confirm next miner run produces a PR scoped only to entry-related files

🤖 Generated with [Claude Code](https://claude.com/claude-code)