### PR TITLE
Fix kaizen #1363: add history frames to prevent mythology misclassification

### DIFF
--- a/.claude/agents/miner.md
+++ b/.claude/agents/miner.md
@@ -148,6 +148,23 @@ Cognitive biases and effects are `mental-model`. If you're writing 5 entries
 and they're all `metaphor`, stop and re-check — that distribution is almost
 certainly wrong.
 
+**Choosing `source_frame` — mythology vs. history:**
+
+The `mythology` frame is for sacred or traditional narratives (Prometheus,
+Icarus, Sisyphus). Do NOT use it for real historical persons or documented
+military events. Use these frames instead:
+
+- `historical-figures` — real persons whose decisions became proverbial
+  (Pyrrhus, Machiavelli, Caesar). The metaphor draws on documented biography,
+  not myth.
+- `military-history` — documented battles, campaigns, and strategic outcomes
+  (Pyrrhic victory, Cannae, Maginot Line). The metaphor draws on
+  historiography, not sacred narrative.
+
+Rule of thumb: if the person or event appears primarily in chronicles and
+historical records rather than in sacred/origin narratives, it is history, not
+mythology.
+
 **Writing Entries:**
 
 Use the metaphorex-schema skill for the canonical schema. Additionally:

--- a/catalog/frames/historical-figures.md
+++ b/catalog/frames/historical-figures.md
@@ -1,0 +1,22 @@
+---
+slug: historical-figures
+name: Historical Figures
+roles:
+- figure
+- era
+- action
+- consequence
+- legacy
+related:
+- mythology
+- military-history
+created: '2026-03-16'
+updated: '2026-03-16'
+---
+
+Real, documented persons whose decisions and fates became proverbial. Unlike
+mythology (sacred or traditional narratives), historical-figures entries draw
+on the documented record: biographies, chronicles, and historiography. The
+metaphorical weight comes from what actually happened to these people and how
+posterity interpreted it, not from supernatural transformation or divine
+intervention.

--- a/catalog/frames/military-history.md
+++ b/catalog/frames/military-history.md
@@ -1,0 +1,21 @@
+---
+slug: military-history
+name: Military History
+roles:
+- combatant
+- battle
+- strategy
+- outcome
+- cost
+related:
+- war
+- historical-figures
+created: '2026-03-16'
+updated: '2026-03-16'
+---
+
+Documented military events, campaigns, and strategic doctrines drawn from the
+historical record. Distinct from the `war` frame (which covers war as an
+abstract source domain) and from `mythology` (which covers sacred narratives).
+Military-history entries are grounded in specific battles, commanders, and
+outcomes that became proverbial through historiography, not myth.


### PR DESCRIPTION
## Summary

Fixes #1363 — validator does not catch source_frame semantic mismatches (historical vs. mythological).

**What was broken:** Miners defaulted to `source_frame: mythology` for all classical antiquity content because no clearly distinct alternative frames existed. This caused entries like `pyrrhic-victory` (derived from Pyrrhus of Epirus, a documented historical figure) to be tagged with `mythology` (sacred/traditional narratives). The mismatch was only caught by human Assayer review, which doesn't scale.

**What this PR does:**

- Adds `catalog/frames/historical-figures.md` — for entries derived from real, documented persons (Pyrrhus, Machiavelli, Caesar)
- Adds `catalog/frames/military-history.md` — for entries derived from documented battles, campaigns, and strategic outcomes
- Updates `.claude/agents/miner.md` with explicit guidance on when to use `historical-figures` or `military-history` instead of `mythology`

**Why this approach:** The Pitboss fix spec (option 1) identified that the root cause is a missing vocabulary problem, not a validation logic problem. By giving miners clearly named frame alternatives, the gravitational pull of `mythology` as a catch-all for classical content is broken. The miner prompt update makes the distinction explicit.

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors
- [ ] Verify new frames have correct frontmatter (slug, name, roles[])
- [ ] Verify miner.md guidance is clear and unambiguous

Generated with [Claude Code](https://claude.com/claude-code)