### PR TITLE
Fix kaizen #1364: circular mapping validator warning

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -159,6 +159,12 @@ def validate_entry(path: Path, frame_slugs: set[str], category_slugs: set[str],
                 if at not in frame_slugs:
                     errors.append(f"{prefix}: applies_to frame '{at}' not found in frames/")
 
+    # Circular mapping: source_frame should not appear in applies_to
+    source = meta.get("source_frame")
+    applies = meta.get("applies_to", [])
+    if source and isinstance(applies, list) and source in applies:
+        warnings.append(f"{prefix}: circular mapping — source_frame '{source}' also appears in applies_to")
+
     # dead flag: metaphor only
     if meta.get("dead") and kind != "metaphor":
         errors.append(f"{prefix}: 'dead: true' only valid for metaphor kind")


### PR DESCRIPTION
Closes #1364

## Summary

- Adds a validator warning when an entry's `source_frame` also appears in its `applies_to` list, which indicates a circular mapping (a domain mapping onto itself)
- The check is a **warning**, not an error, per the fix spec -- edge cases may exist
- Caught 5 existing entries with this pattern (e.g., `good-is-up` where `source_frame: embodied-experience` also appears in `applies_to`)

## What was broken

The validator checked that frame slugs exist but never checked whether `source_frame` and `applies_to` referenced the same frame. A mapping like `source_frame: war` with `applies_to: [war]` would pass silently despite being analytically meaningless.

## What changed

Added a 4-line check in `validate_entry()` in `scripts/validate.py` that warns when `source_frame` appears in the `applies_to` list.

## Test plan

- [x] `uv run scripts/validate.py validate` passes with zero errors
- [x] New check correctly identifies 5 existing circular mappings as warnings
- [x] No false positives on non-circular entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)