### PR TITLE
Add entries: null-pointer, c-string, tcp-handshake, dns-domain, process-thread

### DIFF
--- a/catalog/entries/c-string.md
+++ b/catalog/entries/c-string.md
@@ -1,0 +1,127 @@
+---
+applies_to:
+- computing
+author: agent:fshot
+categories:
+- computer-science
+contributors: []
+created: '2026-03-17'
+dead: true
+harness: Claude Code
+kind: metaphor
+name: C String
+related:
+- null-pointer
+slug: c-string
+source_frame: manufacturing
+updated: '2026-03-17'
+---
+
+## Transfers
+
+Characters strung together in sequence, like beads on a thread. The textile
+metaphor is precise: a string is a one-dimensional arrangement of discrete
+items held together by their order on a continuous line. Remove the line and
+the beads scatter; break the sequence and the string is severed.
+
+- **Linear ordering** -- a physical string of beads has a first bead, a last
+  bead, and a determinate sequence between them. A C string is a contiguous
+  array of characters in memory, each at a sequential address. The metaphor
+  imports the most fundamental property of a string: things are arranged in a
+  single line, and their position on that line is their identity. Character
+  at index 3 is "the third bead from the left."
+- **The null terminator as the knot** -- a string of beads ends with a knot
+  that prevents the last bead from sliding off. In C, a string ends with
+  `'\0'`, the null terminator -- a sentinel byte of value zero that tells
+  functions like `strlen()` where the string ends. The knot does not count
+  as a bead; the null terminator does not count as a character. Both exist
+  solely to mark the boundary.
+- **Concatenation as tying strings together** -- `strcat()` appends one
+  string to another, which maps directly to tying two lengths of beaded
+  string end to end. The physical intuition is correct: concatenation
+  produces a single longer string from two shorter ones, and the order of
+  joining determines the order of the result.
+
+## Limits
+
+- **Strings don't overflow** -- a physical string of beads cannot become
+  longer than itself. A C "string" is a convention imposed on a raw memory
+  buffer, and `strcpy()` will happily write past the end of that buffer
+  into whatever memory lies beyond. The textile metaphor provides no concept
+  for buffer overflow because a physical string has an inherent length that
+  cannot be exceeded. This mismatch is the source of decades of security
+  vulnerabilities: programmers whose mental model is "string" do not
+  instinctively expect that writing characters can corrupt unrelated data.
+- **The knot can be lost** -- if the null terminator is overwritten or
+  never written, C string functions will read past the end of the intended
+  data, interpreting whatever bytes follow as characters. A physical string
+  with a missing knot loses its last few beads; a C string with a missing
+  null terminator reads garbage until it happens upon a zero byte or
+  triggers a segmentation fault. The failure modes are categorically
+  different: inconvenience versus undefined behavior.
+- **Strings have no inherent length** -- a physical string of beads can be
+  measured by inspection. A C string does not know its own length; `strlen()`
+  must walk the entire array counting characters until it finds the null
+  terminator. This is an O(n) operation that has no analogue in the physical
+  world, where length is a property of the object, not a computation over
+  its contents. Pascal strings and most modern languages store length
+  explicitly, rejecting the C metaphor's implication that a string is
+  self-delimiting.
+- **Beads are uniform; characters are not** -- beads on a string are typically
+  uniform objects. Characters in a C string are bytes, but the characters they
+  represent may span multiple bytes in UTF-8 encoding. The textile metaphor of
+  "one bead, one unit" breaks badly with multibyte encodings: `strlen()`
+  counts bytes, not characters, and indexing by position gives you the nth byte,
+  not the nth glyph.
+
+## Expressions
+
+- "String literal" -- a sequence of characters enclosed in double quotes,
+  written directly into source code like a label sewn into fabric
+- "Null-terminated string" -- the explicit acknowledgment that C strings end
+  with a sentinel, a phrase that would be redundant if the metaphor were
+  complete (real strings obviously end)
+- "String manipulation" -- the general category of operations on strings,
+  borrowing the tactile vocabulary of handling physical material
+- "String length" -- how many characters before the terminator, a measurement
+  that must be computed rather than observed
+- "C string" vs "C++ string" -- the distinction between the raw
+  null-terminated array and the `std::string` object that wraps it, a
+  linguistic marker of the metaphor's inadequacy that required engineering
+  a replacement
+
+## Origin Story
+
+The word "string" for a sequence of symbols appears in computing literature
+by the 1950s, inherited from mathematics where "string" had denoted a finite
+sequence of symbols from an alphabet since at least the 1940s. The
+mathematical usage borrowed from the physical metaphor of items strung in
+order -- beads on a string, words on a line.
+
+C did not invent the string concept but gave it a distinctive and influential
+implementation: the null-terminated character array. In K&R C (1978), strings
+are not a data type but a convention -- an array of `char` with a zero byte
+at the end. The language provides no string type, no bounds checking, and no
+length field. This minimalist design reflected C's philosophy of staying close
+to the machine: a string is just bytes in memory with a termination convention.
+
+The consequences were enormous. The null-terminated string became the default
+representation across Unix, Windows (via the C runtime), and most systems
+software. Buffer overflow vulnerabilities in C string handling -- `gets()`,
+`strcpy()`, `sprintf()` -- became the most exploited class of security bugs
+in computing history. The Morris Worm (1988) exploited a `gets()` overflow.
+Twenty-five years later, Heartbleed (2014) was fundamentally a buffer
+over-read.
+
+The metaphor of "string" is so dead that programmers in languages with proper
+string types (Python, Java, Go) use the word without any awareness of its
+textile origin. The beads-on-a-thread image survives only in the word itself.
+
+## References
+
+- Kernighan, B.W. & Ritchie, D.M. *The C Programming Language* (1978/1988)
+  -- the canonical definition of C strings as null-terminated char arrays
+- Aleph One. "Smashing the Stack for Fun and Profit," *Phrack* 49 (1996)
+  -- the definitive tutorial on exploiting C string buffer overflows
+- ISO/IEC 9899:2011, Section 7.1.1 -- the C standard's definition of "string"
+  as a contiguous sequence of characters terminated by the null character

--- a/catalog/entries/dns-domain.md
+++ b/catalog/entries/dns-domain.md
@@ -1,0 +1,123 @@
+---
+applies_to:
+- computing
+author: agent:fshot
+categories:
+- computer-science
+contributors: []
+created: '2026-03-17'
+dead: true
+harness: Claude Code
+kind: metaphor
+name: DNS Domain
+related: []
+slug: dns-domain
+source_frame: governance
+updated: '2026-03-17'
+---
+
+## Transfers
+
+Internet naming as territorial governance. A domain is a territory of names
+over which an authority exercises control. The entire DNS vocabulary --
+domains, zones, delegation, authority, root -- imports the structure of feudal
+land administration into the architecture of internet naming.
+
+- **Territorial sovereignty** -- in governance, a domain is a territory under
+  a single ruler's authority. In DNS, a domain is a subtree of the namespace
+  under a single administrative authority. `example.com` is a territory: the
+  registrant controls what names exist within it, who can create subdomains,
+  and what those names resolve to. The metaphor encodes the correct principle
+  that naming power is jurisdictional -- you control your domain and no one
+  else's.
+- **Hierarchical delegation** -- feudal governance worked through delegation:
+  the king delegated authority over a province to a duke, who delegated
+  authority over a county to a count. DNS mirrors this exactly. The root zone
+  delegates `.com` to Verisign, which delegates `example.com` to the
+  registrant, who may delegate `mail.example.com` to a hosting provider. Each
+  level of the hierarchy grants authority over a sub-territory while retaining
+  authority over the parent.
+- **Authoritative records** -- in governance, the authoritative source for
+  land records is the sovereign's registry. In DNS, the authoritative name
+  server is the one that holds the primary copy of a zone's records. The word
+  "authoritative" is used in its political sense: this server has the right
+  to define the truth about this territory. Non-authoritative answers (from
+  caches) are hearsay -- useful but not definitive.
+
+## Limits
+
+- **Domains are not physical territory** -- land cannot be in two places at
+  once. A DNS domain can resolve to different IP addresses depending on where
+  you ask (GeoDNS, anycast). The governance metaphor implies a fixed,
+  mappable territory; DNS domains are abstract namespaces that can point
+  anywhere. The "territory" of `google.com` has no borders and no geography
+  -- it is an administrative fiction maintained by consensus.
+- **Authority can be stolen** -- in feudal governance, seizing a domain
+  required military force. In DNS, domain hijacking can be accomplished
+  through social engineering a registrar, exploiting BGP to reroute queries,
+  or compromising a name server. The governance metaphor implies that
+  authority is stable and enforced by physical power; DNS authority is
+  maintained by cryptographic protocols and administrative procedures that
+  can be subverted without anyone moving from their desk.
+- **The root is not a sovereign** -- the DNS root zone is managed by ICANN
+  and operated by thirteen root server operators. There is no single
+  sovereign; the root is a committee. The governance metaphor implies a
+  hierarchy with a supreme authority at the top, but the actual DNS root is
+  a distributed system governed by multistakeholder processes, memoranda of
+  understanding, and occasional political controversy. The feudal model has
+  a king; DNS has a nonprofit corporation in Los Angeles.
+- **Delegation is revocable and instant** -- in feudal governance, revoking
+  a vassal's authority over a territory was a political crisis that could
+  trigger war. In DNS, delegation is a database record that can be changed
+  in minutes. The governance metaphor implies that authority relationships
+  are weighty and consequential; DNS delegation is operationally trivial.
+  ICANN's removal of a country-code TLD delegation, however, shows that
+  the political weight can sometimes match the metaphor.
+
+## Expressions
+
+- "Domain name" -- the human-readable address (example.com), so commonplace
+  that "domain" has lost its territorial connotation entirely
+- "Top-level domain" (TLD) -- the highest-level partition (.com, .org, .uk),
+  the duchies of the internet
+- "Subdomain" -- a name within a domain (mail.example.com), a fief within a
+  fief
+- "Domain registrar" -- the entity that sells naming rights, functioning as
+  the land registry office
+- "Authoritative name server" -- the server that holds the definitive records
+  for a zone, using "authoritative" in its political sense
+- "Domain squatting" -- registering a domain with no intent to use it,
+  the digital equivalent of claiming unoccupied territory to extract rent
+  from future settlers
+
+## Origin Story
+
+The Domain Name System was designed by Paul Mockapetris and documented in
+RFC 1035 (November 1987). Before DNS, internet hosts were mapped in a single
+flat file (`HOSTS.TXT`) maintained by the Stanford Research Institute. As the
+internet grew, this centralized approach became untenable, and Mockapetris
+designed a hierarchical, distributed naming system.
+
+The governance vocabulary was deliberate. RFC 1035 uses "domain," "zone,"
+"delegation," and "authority" as its core terminology, mapping the
+administrative structure of the internet onto the administrative structure
+of territorial governance. The hierarchical namespace -- root at the top,
+TLDs below, second-level domains below that -- mirrors the hierarchical
+structure of political jurisdiction.
+
+The word "domain" entered English from Latin *dominium* (lordship, ownership),
+via Old French *domaine*. Its use for internet naming has become so pervasive
+that for many people "domain" now primarily means "website address" rather
+than "territory under a lord's control." The governance metaphor is
+thoroughly dead in casual usage, but it remains alive in the technical
+vocabulary of DNS administration, where "authority," "delegation," and "zone"
+retain their political charge.
+
+## References
+
+- Mockapetris, P. "Domain Names -- Implementation and Specification,"
+  RFC 1035 (1987) -- the foundational DNS specification
+- Mockapetris, P. "Domain Names -- Concepts and Facilities," RFC 1034
+  (1987) -- the companion conceptual document
+- Postel, J. & Reynolds, J. "Domain Requirements," RFC 920 (1984) -- the
+  original TLD structure

--- a/catalog/entries/null-pointer.md
+++ b/catalog/entries/null-pointer.md
@@ -1,0 +1,125 @@
+---
+applies_to:
+- computing
+author: agent:fshot
+categories:
+- computer-science
+- philosophy
+contributors: []
+created: '2026-03-17'
+dead: true
+harness: Claude Code
+kind: metaphor
+name: Null Pointer
+related:
+- c-pointer
+slug: null-pointer
+source_frame: embodied-experience
+updated: '2026-03-17'
+---
+
+## Transfers
+
+Absence encoded as a special kind of presence -- a pointer that deliberately
+points nowhere. The physical metaphor is a finger pointing at nothing: not a
+missing finger, but a finger extended toward empty space. The distinction
+matters. A null pointer is not the absence of a pointer; it is a pointer to
+absence.
+
+- **Pointing as directing attention** -- in embodied experience, pointing is a
+  communicative act: you extend a finger to direct someone's gaze toward a
+  specific location. A C pointer does the same thing with memory addresses.
+  NULL extends the finger toward address zero, a location the operating system
+  has reserved as uninhabitable. The gesture is performed, but the destination
+  is guaranteed to be empty. This is structurally identical to pointing at a
+  vacant lot and saying "that's where my house is."
+- **Nothing as something** -- in everyday experience, we can point at an empty
+  chair and say "that's where she sat." The absence is made present through the
+  act of indicating. NULL does exactly this: it occupies the same number of
+  bytes as any other pointer, participates in the same operations (assignment,
+  comparison), and sits in the same data structures. Absence has been given a
+  body -- the zero address -- so that it can be manipulated like presence.
+- **The deliberate marker** -- a null pointer is not accidental garbage. It is
+  the programmer's intentional statement: "I have nothing to point to yet."
+  This maps to the embodied experience of leaving a blank line on a form, or
+  placing a bookmark in an empty page. The marker exists precisely to
+  communicate that content is absent.
+
+## Limits
+
+- **Real pointing is safe** -- if you point your finger at nothing, nothing
+  happens. If you dereference a null pointer, the program crashes. The
+  embodied metaphor provides no warning of this asymmetry. Physical pointing
+  is an observation; null pointer dereferencing is an action that triggers a
+  hardware fault. The metaphor's failure to encode danger is precisely why null
+  pointer bugs are so common -- the source domain teaches us that pointing at
+  nothing is harmless.
+- **Absence in the physical world is unambiguous** -- an empty chair is
+  obviously empty. A null pointer is not visually distinct from a valid pointer
+  in source code; both are variables of the same type. The metaphor borrows
+  the clarity of physical absence but delivers none of it. You cannot glance
+  at a pointer and know it is null the way you can glance at a chair and know
+  it is empty. The entire category of null pointer bugs arises from this
+  invisible ambiguity.
+- **Tony Hoare's billion-dollar mistake** -- Hoare, who introduced null
+  references in ALGOL W (1965), called it his "billion-dollar mistake" because
+  the metaphor was too convenient. Making absence a first-class value in the
+  type system meant that *every* pointer could secretly be null, and the type
+  checker could not help you. The metaphor of "pointing at nothing" was so
+  natural that nobody questioned whether the type system should even allow it.
+  Modern languages (Rust, Kotlin, Swift) reject this framing entirely,
+  replacing nullable pointers with option types that force the programmer to
+  acknowledge absence explicitly.
+- **Zero is not nothing** -- in C, NULL is typically defined as `(void *)0`.
+  But address zero is a real address on many architectures; the hardware must
+  be configured to trap accesses to it. The metaphor of "pointing nowhere"
+  is implemented as "pointing to a specific somewhere that we have agreed to
+  pretend is nowhere." The abstraction leaks on embedded systems where address
+  zero may contain valid memory-mapped hardware.
+
+## Expressions
+
+- "Null pointer dereference" -- following a finger that points at nothing,
+  crashing when you arrive at the empty destination
+- "Check for null" -- the defensive gesture of verifying that a pointer
+  actually points somewhere before following it, a ritual absence of trust
+- "Null pointer exception" (NullPointerException, NPE) -- Java's version,
+  where the crash has been promoted from a segmentation fault to an exception
+  with a name and a stack trace
+- "Billion-dollar mistake" -- Hoare's retrospective judgment, now a standard
+  citation in any discussion of language design and null safety
+- "It was a null pointer" -- the postmortem explanation for a crash, delivered
+  with the resigned tone of someone who has been here before
+
+## Origin Story
+
+The null pointer originates with Tony Hoare's design of ALGOL W in 1965 at
+the National Physical Laboratory. Hoare introduced the null reference because
+it was "so easy to implement" -- in a language where every reference had to
+point to an object, allowing one special reference to point to nothing seemed
+like a harmless convenience. The implementation was trivial: reserve address
+zero as the sentinel value.
+
+C inherited and hardened this convention. In K&R C (1978), NULL was a macro
+expanding to zero, and the language provided no mechanism to distinguish
+nullable from non-nullable pointers at the type level. Every pointer in C is
+implicitly nullable. The combination of pointer arithmetic, manual memory
+management, and universal nullability made C programs uniquely vulnerable to
+null pointer bugs.
+
+The term "null" itself comes from Latin *nullus* (none, not any). In computing,
+it acquired its specific meaning through ALGOL and was cemented by C's
+pervasive use of NULL as a sentinel. By the 1990s, null pointer dereference
+was the most common category of crash bug in C and C++ programs. The metaphor
+had become so invisible that programmers experienced null not as "a pointer to
+nothing" but simply as "nothing" -- losing the crucial insight that nothing,
+in C, is a very specific and dangerous something.
+
+## References
+
+- Hoare, C.A.R. "Null References: The Billion Dollar Mistake," QCon London
+  (2009) -- the retrospective confession
+- Kernighan, B.W. & Ritchie, D.M. *The C Programming Language* (1978/1988)
+  -- NULL as macro, null pointer constant conventions
+- ISO/IEC 9899:2011, Section 6.3.2.3 -- the C standard's definition of null
+  pointer constants and their guaranteed comparison properties

--- a/catalog/entries/process-thread.md
+++ b/catalog/entries/process-thread.md
@@ -1,0 +1,133 @@
+---
+applies_to:
+- computing
+author: agent:fshot
+categories:
+- computer-science
+contributors: []
+created: '2026-03-17'
+dead: true
+harness: Claude Code
+kind: metaphor
+name: Process Thread
+related:
+- race-condition
+slug: process-thread
+source_frame: manufacturing
+updated: '2026-03-17'
+---
+
+## Transfers
+
+A thread of execution as a literal thread -- a fiber spun from raw material,
+running alongside other fibers, capable of being woven together into fabric.
+The textile metaphor structures how programmers think about concurrent
+execution: threads are parallel strands that may interleave, tangle, or be
+woven into a coherent whole.
+
+- **Parallel strands** -- in a loom, multiple threads run side by side, each
+  following its own path but contributing to a shared fabric. In a process,
+  multiple threads of execution run concurrently, each following its own
+  instruction sequence but sharing the same address space. The metaphor
+  encodes the essential architecture: threads are independent paths that
+  coexist within a common structure. A single thread is a strand; many
+  threads woven together are a program.
+- **Spinning up** -- in textile manufacturing, spinning is the act of drawing
+  out raw fiber and twisting it into thread. "Spinning up a thread" in
+  computing means creating a new execution context from the raw material of
+  the process's resources (memory, file descriptors, signal handlers). The
+  metaphor captures the transformation: something that was potential (fiber,
+  resources) becomes actual (thread, execution path).
+- **Thread safety as threads not tangling** -- tangled thread is the
+  fundamental failure mode of textile work. Thread safety in computing means
+  that concurrent threads will not corrupt shared data -- that they will run
+  alongside each other without entanglement. The metaphor maps the physical
+  disaster (a tangled skein that must be painstakingly unwound) to the
+  computational disaster (a race condition that must be painstakingly
+  debugged).
+
+## Limits
+
+- **Textile threads don't share material** -- each physical thread is its own
+  fiber. Computing threads within a process share the same memory space. This
+  is the fundamental departure from the textile metaphor: real threads cannot
+  reach into each other and modify each other's substance. Computing threads
+  can and do read and write each other's data, which is both their primary
+  advantage (cheap communication) and their primary hazard (data races). The
+  metaphor of separate strands running in parallel actively misleads about
+  the degree of entanglement.
+- **Weaving is deterministic** -- a loom produces the same fabric from the
+  same threads every time. Multithreaded programs are non-deterministic: the
+  exact interleaving of operations depends on scheduling decisions made by
+  the operating system at runtime. Two runs of the same program may produce
+  different results. The textile metaphor implies a craft with predictable
+  outcomes; concurrent programming is closer to a craft where the loom
+  rearranges threads at random.
+- **Thread death is nothing like thread cutting** -- cutting a physical thread
+  ends it cleanly at a known point. Killing a computing thread can leave
+  shared data in an inconsistent state, hold unreleased locks, or leak
+  resources. The textile metaphor of clean severance maps onto the computing
+  reality of messy, dangerous termination. This is why thread cancellation
+  is one of the hardest problems in concurrent programming -- there is no
+  computational equivalent of scissors.
+- **The fiber predates the loom** -- in textiles, thread exists before it is
+  woven. In computing, a thread does not exist until it is created within a
+  process. There is no independent existence for a thread outside its
+  process, no spool of execution context waiting to be loaded into a loom.
+  The textile metaphor implies that threads are primitive and looms are
+  secondary; in computing, the process (the "loom") must exist before any
+  thread can.
+
+## Expressions
+
+- "Multithreading" -- running multiple threads within a single process,
+  described as if multiple fibers are being worked simultaneously on a loom
+- "Thread pool" -- a pre-created collection of threads awaiting work, like
+  a basket of prepared threads beside a loom
+- "Thread safety" -- code that can be executed by multiple threads without
+  corruption, the computational equivalent of tangle-free thread
+- "Spinning up a thread" -- creating a new thread, drawing out a new fiber
+  from the process's resources
+- "Deadlock" -- two threads each holding a resource the other needs, a
+  tangle so severe that neither can proceed (though "deadlock" itself is
+  from canal lock navigation, not textiles)
+- "Thread-local storage" -- data private to a single thread, the one
+  departure from the shared-address-space norm, as if each fiber carried
+  its own dye
+
+## Origin Story
+
+The term "thread" for a lightweight execution context emerged in the early
+1970s. The concept was present in earlier systems -- what Multics called
+"execution points" and what some researchers called "lightweight processes"
+-- but "thread" became the dominant term through its adoption in Unix-derived
+systems and academic literature.
+
+The textile metaphor was chosen for its intuitive mapping: a thread is thinner
+than a rope (a full process), many threads can run in parallel, and they can
+be woven together into something stronger than any single strand. The word
+itself carries centuries of figurative use -- "thread of argument," "thread
+of narrative," "thread of thought" -- all denoting a single continuous line
+of progression through a larger structure.
+
+The POSIX threads (pthreads) standard, formalized in IEEE 1003.1c (1995),
+cemented "thread" as the canonical term. The pthreads API -- `pthread_create`,
+`pthread_join`, `pthread_mutex_lock` -- became the standard interface for
+multithreaded programming on Unix systems. Java's `Thread` class (1995) and
+Windows threads brought the term to mainstream application programming.
+
+By the 2000s, "thread" was universal. The rise of multi-core processors
+(Intel Core 2 Duo, 2006) made threading a practical necessity rather than
+an optimization, and "multithreaded" became a standard adjective for
+performant software. The textile metaphor is now completely dead: no
+programmer pictures a loom when creating a thread. The word has been
+fully absorbed into technical vocabulary, its etymological fiber invisible.
+
+## References
+
+- IEEE Std 1003.1c-1995 "Threads Extension" -- the POSIX threads standard
+  that canonized the term
+- Butenhof, D.R. *Programming with POSIX Threads* (1997) -- the canonical
+  reference for pthreads programming
+- Ritchie, D.M. & Thompson, K. "The UNIX Time-Sharing System," *CACM*
+  17(7), 1974 -- the process model from which threads were eventually split

--- a/catalog/entries/tcp-handshake.md
+++ b/catalog/entries/tcp-handshake.md
@@ -1,0 +1,125 @@
+---
+applies_to:
+- computing
+author: agent:fshot
+categories:
+- computer-science
+- security
+contributors: []
+created: '2026-03-17'
+dead: true
+harness: Claude Code
+kind: metaphor
+name: TCP Handshake
+related:
+- network-socket
+- network-port
+slug: tcp-handshake
+source_frame: social-behavior
+updated: '2026-03-17'
+---
+
+## Transfers
+
+Connection establishment as a social greeting ritual. Two strangers meet; each
+must signal willingness to communicate before conversation can begin. The
+three-way handshake -- SYN, SYN-ACK, ACK -- maps to the social sequence of
+offer, acceptance, and confirmation that structures introductions in nearly
+every human culture.
+
+- **Bilateral consent** -- a handshake requires both parties to extend a hand.
+  TCP requires both hosts to exchange synchronization messages before data can
+  flow. The metaphor encodes the fundamental principle: communication is not
+  something one party does *to* another; it is something two parties agree
+  *to do together*. A SYN without a SYN-ACK is a hand extended into empty
+  air -- an unanswered social overture.
+- **The three-phase ritual** -- social handshakes follow a protocol: one party
+  initiates (extends hand), the other reciprocates (grasps and extends in
+  return), and the initiator confirms (completes the clasp). TCP's SYN /
+  SYN-ACK / ACK mirrors this precisely. The three phases are not arbitrary;
+  they are the minimum exchanges needed for both sides to confirm that both
+  sides are willing and able. Fewer phases leave one party uncertain; more
+  would be redundant.
+- **Trust establishment before exchange** -- in human interaction, the
+  handshake precedes the conversation. You do not begin discussing business
+  while walking toward a stranger; you wait for the greeting to complete.
+  TCP enforces this sequencing: no data payload is exchanged until the
+  three-way handshake completes. The handshake is not communication; it is
+  the precondition for communication.
+
+## Limits
+
+- **Handshakes are hard to fake** -- in person, you can see who is extending
+  their hand. TCP handshakes occur over a network where the source address
+  can be forged. The SYN flood attack exploits this gap: an attacker sends
+  thousands of SYN packets with spoofed source addresses, and the server
+  dutifully allocates resources for each half-open connection, waiting for
+  ACKs that will never arrive. The social metaphor implies that initiating
+  a handshake is costless and in good faith; TCP's implementation makes it
+  an exploitable commitment.
+- **Social handshakes convey identity** -- when you shake someone's hand,
+  you see their face, read their expression, assess their grip. A TCP
+  handshake conveys only that *someone* at an IP address is willing to talk.
+  It authenticates nothing. The warmth and trust implied by the social
+  metaphor are entirely absent from the protocol. TLS was layered on top
+  precisely because the "handshake" was, in identity terms, a handshake
+  between strangers wearing masks.
+- **Handshakes are instant** -- a physical handshake takes a second. A TCP
+  handshake takes at minimum one round-trip time (RTT), which across
+  continents can be hundreds of milliseconds. For short-lived connections
+  (a single HTTP request), the handshake can take longer than the actual
+  data exchange. The social metaphor of a brief greeting masks a performance
+  cost that has driven decades of protocol optimization (TCP Fast Open,
+  QUIC's zero-RTT handshake).
+- **Ending is nothing like unclasping** -- releasing a handshake is
+  instantaneous and symmetric. Closing a TCP connection requires its own
+  four-way exchange (FIN, ACK, FIN, ACK), with TIME_WAIT states that can
+  linger for minutes. The social metaphor covers the greeting but not the
+  farewell, and the farewell is where TCP's complexity actually lives.
+
+## Expressions
+
+- "Three-way handshake" -- the canonical name for TCP connection
+  establishment, so standard that "three-way" is often dropped and "TCP
+  handshake" suffices
+- "SYN flood" -- the attack that exploits the handshake's trust assumption,
+  named for the packet type used to initiate it
+- "Half-open connection" -- a handshake that was started but not completed,
+  the TCP equivalent of a hand left hanging
+- "Connection refused" -- the server's explicit rejection, a declined
+  handshake
+- "TLS handshake" -- the cryptographic negotiation layered on top of TCP,
+  extending the greeting metaphor to include identity verification and
+  cipher suite agreement
+
+## Origin Story
+
+The three-way handshake was specified by Vint Cerf and Bob Kahn in their
+foundational TCP design and formalized in RFC 793 (September 1981), authored
+by Jon Postel. The RFC describes the SYN/SYN-ACK/ACK exchange in precise
+mechanical terms but consistently uses "handshake" as the framing metaphor.
+
+The social metaphor was not Cerf and Kahn's invention. "Handshaking" had been
+used in telecommunications since at least the 1960s to describe modem
+negotiation sequences -- the audible tones you heard when a dial-up modem
+connected were literally called the "handshake." The term migrated from
+hardware signaling to protocol design naturally: if modems shake hands, so
+can hosts.
+
+RFC 793 cemented the term for TCP specifically, and the three-way handshake
+became one of the most taught concepts in computer networking. Every
+networking textbook includes the SYN/SYN-ACK/ACK diagram. The metaphor is
+so embedded that networking professionals use "handshake" as a literal
+technical term and may not consciously recognize its social origin -- until
+they encounter a protocol that does *not* use a handshake (UDP), at which
+point the absence feels significant, like a stranger who begins talking
+without introducing themselves.
+
+## References
+
+- Postel, J. "Transmission Control Protocol," RFC 793 (1981) -- the
+  definitive specification of the three-way handshake
+- Cerf, V. & Kahn, R. "A Protocol for Packet Network Intercommunication,"
+  *IEEE Transactions on Communications* (1974) -- the original TCP design
+- CERT Advisory CA-1996-21 "TCP SYN Flooding" -- documentation of the
+  handshake's most famous vulnerability


### PR DESCRIPTION
## Summary

Five entries from the **unix-c-metaphors** project:

- **null-pointer** (#303) — absence encoded as presence; Hoare's billion-dollar mistake
- **c-string** (#304) — characters strung like beads on a thread; null-terminated arrays
- **tcp-handshake** (#308) — connection establishment as social greeting ritual
- **dns-domain** (#309) — internet naming as territorial governance
- **process-thread** (#310) — execution contexts as textile fibers on a loom

All are `kind: metaphor` with `dead: true`. Covers batches 5 (C language), 7 (networking), and 8 (remaining) from the playbook.

## Validator

Zero errors on new entries. One non-blocking warning (dangling `related: c-pointer` in null-pointer.md — entry not yet mined).

## Closes

Closes #303, Closes #304, Closes #308, Closes #309, Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Validation

✓ `uv run scripts/validate.py` — 0 errors