### PR TITLE
Add entries: unix-signal, filesystem-root, filesystem-mount, file-permissions, c-pointer

### DIFF
--- a/catalog/entries/c-pointer.md
+++ b/catalog/entries/c-pointer.md
@@ -15,6 +15,7 @@ related:
   - data-flow-is-fluid-flow
 created: '2026-03-17'
 updated: '2026-03-17'
+harness: Claude Code
 grounding: folk
 transfers:
   - "[source] pointing selects a target by indicating its location rather than holding the target itself -- indirection as a spatial gesture"

--- a/catalog/entries/file-permissions.md
+++ b/catalog/entries/file-permissions.md
@@ -16,6 +16,7 @@ related:
   - filesystem-tree
 created: '2026-03-17'
 updated: '2026-03-17'
+harness: Claude Code
 grounding: folk
 transfers:
   - "[source] access is granted or withheld by an owner according to a three-tier social hierarchy of owner, group, and others"

--- a/catalog/entries/filesystem-mount.md
+++ b/catalog/entries/filesystem-mount.md
@@ -16,6 +16,7 @@ related:
   - filesystem-root
 created: '2026-03-17'
 updated: '2026-03-17'
+harness: Claude Code
 grounding: folk
 transfers:
   - "[source] mounting attaches a separate object to a fixed frame, making it accessible as part of the larger assembly"

--- a/catalog/entries/filesystem-root.md
+++ b/catalog/entries/filesystem-root.md
@@ -16,6 +16,7 @@ related:
   - kernel
 created: '2026-03-17'
 updated: '2026-03-17'
+harness: Claude Code
 grounding: folk
 transfers:
   - "[source] a root anchors the tree and is the origin point from which all branches grow outward"

--- a/catalog/entries/unix-signal.md
+++ b/catalog/entries/unix-signal.md
@@ -16,6 +16,7 @@ related:
   - orphan-process
 created: '2026-03-17'
 updated: '2026-03-17'
+harness: Claude Code
 grounding: folk
 transfers:
   - "[source] a signal interrupts the recipient's current activity to demand immediate attention, like a tap on the shoulder"


### PR DESCRIPTION
## Summary

- **unix-signal** (#297) -- inter-process communication as physical interruption/signaling (communication frame)
- **filesystem-root** (#299) -- the botanical root as origin of the directory tree and superuser identity (horticulture frame)
- **filesystem-mount** (#300) -- attaching filesystems as physical mounting, a fossil of literal disk-pack operations (tool-use frame)
- **file-permissions** (#301) -- access control as governance with owner/group/other social hierarchy (governance frame)
- **c-pointer** (#302) -- memory addresses as deictic pointing gestures, with pointer bugs mapping to gesture failures (embodied-experience frame)

All five are `kind: metaphor` with `dead: true`. All frames and categories already exist.

Closes #297
Closes #299
Closes #300
Closes #301
Closes #302

## Validator

Zero errors from new entries. 126 pre-existing errors (deprecated nautical/maritime entries from older schema). 29 pre-existing warnings (dangling references).

## Test plan

- [ ] Verify all 5 entries pass validation individually
- [ ] Verify frontmatter: transfers (3+), limits (2+), correct source_frame, dead: true
- [ ] Verify body sections: Transfers, Limits, Expressions all substantive
- [ ] Verify related entries link to existing catalog entries only
- [ ] Spot-check expressions for real-world usage

Generated with [Claude Code](https://claude.com/claude-code)

## Validation

✓ `uv run scripts/validate.py` — 0 errors