### PR TITLE
Add entries: memory-heap, memory-leak, unix-filter, unix-tee, environment-variable

### DIFF
--- a/catalog/entries/environment-variable.md
+++ b/catalog/entries/environment-variable.md
@@ -1,0 +1,153 @@
+---
+applies_to:
+- software-programs
+author: agent:metaphorex-miner
+categories:
+- computer-science
+contributors:
+- fshot
+created: '2026-03-17'
+dead: true
+harness: Claude Code
+kind: metaphor
+name: Environment Variable
+related:
+- data-flow-is-fluid-flow
+slug: environment-variable
+source_frame: embodied-experience
+updated: '2026-03-17'
+transfers:
+  - "[source] an organism's environment is the surrounding context that influences its behavior without being part of the organism itself"
+  - "[source] offspring inherit their parent's environment by being born into it, not by explicit transfer"
+  - "[source] the environment is ambient -- present everywhere within a context without needing to be explicitly passed from place to place"
+limits:
+  - "[source] breaks because a physical environment is continuous and shared -- all organisms in the same habitat experience the same conditions -- whereas each mapped entity gets its own independent copy that can diverge from its siblings"
+  - "[source] misleads because a natural environment changes dynamically and organisms sense changes in real time, but the mapped context is a snapshot frozen at the moment of creation, invisible to later modifications in the source"
+---
+
+## Transfers
+
+An organism lives in an environment -- the air, temperature, soil,
+light, and chemical conditions that surround it and influence its behavior
+without being part of its body. A Unix process lives in an environment
+defined by key-value pairs: `PATH`, `HOME`, `LANG`, `EDITOR`, `TERM`.
+These variables define the context in which the process operates. They are
+not passed as arguments; they are ambient, present in the surrounding
+context, available to any code that reaches for them.
+
+Key structural parallels:
+
+- **Ambient context** -- a fish does not receive water as an argument; it
+  swims in it. A Unix process does not receive its environment through
+  function parameters; it inherits it from the surrounding context.
+  `getenv("PATH")` is the process looking around at its surroundings,
+  not receiving a message. The ecological metaphor captures this
+  perfectly: the environment is there, and the process either reads it
+  or ignores it.
+- **Inheritance from parent** -- organisms inherit their environment by
+  being born into it. A child process inherits its parent's environment
+  variables at the moment of `fork()`. The genetic metaphor layers on
+  top of the ecological one: the parent does not hand over the
+  environment; the child is born with a copy. `export` in the shell
+  is the act of placing a variable into the environment so that children
+  will inherit it -- making it part of the habitat rather than a private
+  possession.
+- **Influence without direct causation** -- temperature does not tell a
+  plant to grow; it creates conditions where growth happens. `PATH` does
+  not tell a program which executable to run; it defines the directories
+  where executables can be found. `LANG` does not force a program to
+  display French; it creates conditions where French is the default. The
+  environment shapes behavior indirectly, through context rather than
+  command.
+- **Invisible until examined** -- most people do not think about the
+  humidity of their environment until it becomes uncomfortable. Most
+  programs do not think about most environment variables -- they only
+  check the ones relevant to their behavior. `env` or `printenv` is the
+  act of making the invisible environment visible, like checking a
+  thermometer: the conditions were always there, you just were not
+  looking.
+
+## Limits
+
+- **Physical environments are shared; process environments are copied** --
+  all animals in a forest share the same temperature. But each Unix
+  process gets its own copy of the environment at fork time. If the
+  parent changes a variable after forking, the child does not see the
+  change. There is no shared habitat -- each process lives in a private
+  snapshot of the environment as it existed at birth. This fundamentally
+  breaks the ecological metaphor, where environment is a shared commons.
+- **Physical environments change continuously; process environments are
+  static** -- the weather changes, seasons turn, rivers rise and fall.
+  A process's environment is fixed at fork time. You can modify your
+  own environment with `setenv()`, but this affects only your process
+  and your future children -- not your parent, not your siblings. The
+  ecological metaphor suggests a dynamic, responsive context; the
+  reality is a frozen snapshot.
+- **The metaphor hides the security problem** -- an organism's
+  environment is not a secret. But environment variables are frequently
+  used to pass secrets: `API_KEY`, `DATABASE_URL`, `AWS_SECRET_ACCESS_KEY`.
+  The ecological metaphor -- ambient, inherited, visible to anyone who
+  looks -- accurately describes the security properties, which is exactly
+  the problem. Environment variables are visible in `/proc/<pid>/environ`,
+  inherited by child processes that may not need them, and logged by crash
+  reporters. The metaphor normalizes exposure.
+- **"Variable" clashes with the ecological metaphor** -- an environment
+  is not made of variables; it is made of conditions. The compound term
+  "environment variable" mixes an ecological metaphor with a mathematical
+  one, creating a hybrid that is not fully coherent. Is the environment
+  a habitat or a namespace? The answer is both, which means neither
+  metaphor provides complete guidance. Programmers who think "habitat"
+  miss the key-value structure; those who think "namespace" miss the
+  ambient inheritance model.
+
+## Expressions
+
+- "Set the environment" -- configuring variables before running a program,
+  as if preparing the habitat for an organism
+- "Export a variable" -- placing a shell variable into the environment so
+  child processes inherit it; "export" implies sending it outward, into
+  the ambient context
+- "Clean environment" -- running a program with a minimal environment,
+  stripping away inherited pollution; the ecological sanitation metaphor
+- "Environment pollution" -- too many variables cluttering the
+  environment, making it hard to understand what influences a process
+- "Inherited from the parent" -- the standard description of how
+  environment variables propagate, explicitly using the
+  biological/familial metaphor
+- "The environment" -- used as a noun in its own right: "check the
+  environment for the database URL"; the ecological term has become a
+  technical term
+
+## Origin Story
+
+Environment variables appeared in Version 7 Unix (1979), building on
+earlier mechanisms for passing context to programs. The concept was
+formalized with the `environ` external variable in C and the `getenv()`
+/ `setenv()` library functions. The Bourne shell (1977) introduced
+`export` as the mechanism for placing variables into the environment.
+
+The choice of "environment" was deliberate and ecological. Earlier systems
+used terms like "parameters" or "settings," but the Unix designers chose
+a word that implies ambient context rather than explicit configuration.
+The metaphor complemented the existing Unix vocabulary: processes are born
+(`fork`), inherit their parent's environment, and live in it until they
+die (`exit`). The ecological layer sits on top of the biological layer,
+creating a coherent system of metaphors for process lifecycle.
+
+The term became universal across operating systems. Windows has environment
+variables (`%PATH%`), as does every Unix descendant. The twelve-factor app
+methodology (2011) made environment variables the recommended mechanism
+for application configuration, cementing the metaphor's dominance. Today,
+`ENV` is so standard that developers configure databases, API keys,
+feature flags, and deployment targets through environment variables
+without thinking about the ecological metaphor underneath.
+
+## References
+
+- Bourne, S. "The UNIX Shell," Bell System Technical Journal 57(6), 1978
+- Kernighan, B. & Pike, R. *The Unix Programming Environment*,
+  Prentice-Hall, 1984
+- Stevens, W. R. *Advanced Programming in the UNIX Environment* (1992) --
+  environment variables and process inheritance
+- Wiggins, A. "The Twelve-Factor App" (2011) --
+  https://12factor.net/config -- environment variables as configuration

--- a/catalog/entries/memory-heap.md
+++ b/catalog/entries/memory-heap.md
@@ -1,0 +1,145 @@
+---
+applies_to:
+- memory-management
+author: agent:metaphorex-miner
+categories:
+- computer-science
+contributors:
+- fshot
+created: '2026-03-17'
+dead: true
+harness: Claude Code
+kind: metaphor
+name: Memory Heap
+related:
+- memory-stack
+- buffer-overflow
+- memory-leak
+slug: memory-heap
+source_frame: embodied-experience
+updated: '2026-03-17'
+transfers:
+  - "[source] a heap is a disordered pile where items can be added or removed from any position, not just the top"
+  - "[source] retrieving a specific item from a heap requires searching because there is no ordering principle"
+  - "[source] a heap grows and shrinks irregularly, leaving gaps where items were removed"
+limits:
+  - "[source] breaks because a physical heap has no bookkeeping -- items are simply piled -- whereas the mapped system requires elaborate metadata structures (free lists, size headers) that have no analog in a pile of objects"
+  - "[source] misleads because a physical heap implies negligible cost to toss something on top, but the mapped operation involves searching for a suitable gap, which can be expensive and unpredictable"
+---
+
+## Transfers
+
+A disordered pile of objects where you grab what you need from wherever it
+happens to be. The heap in memory management borrows from the everyday
+image of a heap of things -- a woodpile, a junk heap, a heap of laundry.
+Unlike a stack, which enforces strict last-in-first-out order, a heap has
+no ordering discipline. You allocate a chunk from wherever there is room,
+and you free it whenever you are done, regardless of what was allocated
+before or after.
+
+Key structural parallels:
+
+- **No ordering constraint** -- a physical heap is defined by the absence
+  of arrangement. You throw things on a heap and retrieve them in whatever
+  order suits you. Dynamic memory allocation works the same way: `malloc()`
+  finds a suitably sized block anywhere in the heap region, and `free()`
+  releases it back regardless of allocation order. The contrast with the
+  stack is deliberate and structural -- the stack is disciplined, the heap
+  is not.
+- **Variable-sized items** -- a heap of objects contains things of
+  different sizes: large logs, small sticks, medium boxes. The memory heap
+  likewise holds allocations of arbitrary size. A program can allocate 16
+  bytes, then 4 megabytes, then 32 bytes, and the heap accommodates all
+  of them. The stack, by contrast, grows and shrinks in frames whose sizes
+  are determined at compile time. The heap's flexibility comes from the
+  same source as a physical heap's: no structural constraint on what goes
+  where.
+- **Fragmentation as entropy** -- a physical heap that has items removed
+  from the middle develops gaps. A memory heap that has blocks freed in
+  arbitrary order develops fragmentation: small free regions scattered
+  among allocated blocks, too small to satisfy large requests even though
+  the total free space is sufficient. This is the disorder the metaphor
+  predicts. Like a woodpile with odd-shaped gaps, the heap becomes
+  increasingly disorganized over time.
+- **Persistence beyond scope** -- items on a heap stay there until someone
+  explicitly removes them. Heap-allocated memory persists until the
+  programmer explicitly calls `free()`. Unlike stack memory, which vanishes
+  when the function returns, heap memory outlives the context that created
+  it. The metaphor captures this: a physical heap does not clean itself up.
+
+## Limits
+
+- **A physical heap has no allocator** -- you toss things on a heap
+  without thinking about placement. But a memory heap requires a
+  sophisticated allocator (malloc, jemalloc, tcmalloc) that maintains free
+  lists, coalesces adjacent free blocks, and balances speed against
+  fragmentation. The physical metaphor imports a simplicity that the
+  implementation absolutely does not have. The heap looks disordered from
+  the programmer's perspective, but internally it is carefully managed --
+  more like a well-run warehouse than a junk pile.
+- **The metaphor hides the cost of disorder** -- grabbing something from a
+  physical heap is quick if the heap is small. But heap allocation in
+  software can be expensive: the allocator must search for a free block of
+  the right size, potentially walking a free list or consulting a bitmap.
+  The casual "just grab what you need" image conceals the performance cost,
+  which is why real-time systems avoid heap allocation. The pile metaphor
+  suggests that disorder is free; in practice, it has a price.
+- **"Heap" in computer science has a conflicting meaning** -- in data
+  structures, a "heap" is a partially ordered binary tree used for
+  priority queues (min-heap, max-heap). This is a completely different
+  meaning from the memory region. The two uses coexist in the same field,
+  causing persistent confusion. A student who learns "heap sort" and then
+  encounters "heap corruption" must realize that two different metaphors
+  share the same word.
+- **The physical metaphor makes garbage collection seem obvious** -- if a
+  heap gets too messy, you clean it up. This makes garbage collection
+  (automatic heap cleanup) seem like a natural consequence of the
+  metaphor. But garbage collection is computationally expensive and
+  introduces pauses, latency, and complexity that the "just clean up the
+  pile" image does not convey. Languages with garbage collection (Java, Go,
+  Python) pay a real cost that the pile metaphor trivializes.
+
+## Expressions
+
+- "Heap allocation" -- allocating memory from the heap region, contrasted
+  with stack allocation; the standard term in C and systems programming
+- "Heap corruption" -- overwriting heap metadata or allocated blocks,
+  producing unpredictable crashes; the pile collapsing
+- "Heap fragmentation" -- the accumulation of unusable gaps in the heap
+  after many allocations and frees; the entropy the metaphor predicts
+- "On the heap" -- colloquial for dynamically allocated, as opposed to
+  "on the stack"; the spatial preposition imports the pile metaphor directly
+- "Heap exhaustion" -- running out of heap space, analogous to the pile
+  growing until it fills the room
+- "malloc() and free()" -- the C standard library functions for heap
+  management; "malloc" itself is a contraction of "memory allocate," the
+  only non-metaphorical term in this cluster
+
+## Origin Story
+
+The use of "heap" for unstructured dynamic memory dates to the 1960s. The
+term appears in early operating system literature as a contrast to the
+orderly stack: if the stack is the disciplined, automatic memory region,
+the heap is everything else -- the region where memory is allocated and
+freed in no particular order. The choice of "heap" (a disordered pile)
+over alternatives like "pool" or "arena" was deliberate: it emphasizes the
+lack of structure.
+
+In C, heap memory is managed through `malloc()` and `free()`, introduced
+in the earliest versions of the language. The K&R book (1978) describes
+dynamic allocation matter-of-factly, without explaining the metaphor --
+by then, "heap" was already a dead term in the same way "stack" was. The
+metaphor lives on in "heap corruption," "heap fragmentation," and the
+enduring contrast between stack and heap that every systems programmer
+learns as a fundamental distinction.
+
+## References
+
+- Kernighan, B. & Ritchie, D. *The C Programming Language* (1978/1988) --
+  heap allocation via malloc() and free()
+- Knuth, D. *The Art of Computer Programming*, Vol. 1 (1968) --
+  dynamic storage allocation algorithms
+- Wilson, P. R. et al. "Dynamic Storage Allocation: A Survey and
+  Critical Review" (1995) -- comprehensive survey of heap allocators
+- Stevens, W. R. *Advanced Programming in the UNIX Environment*
+  (1992) -- Unix process memory layout: text, data, heap, stack

--- a/catalog/entries/memory-leak.md
+++ b/catalog/entries/memory-leak.md
@@ -1,0 +1,151 @@
+---
+applies_to:
+- memory-management
+author: agent:metaphorex-miner
+categories:
+- computer-science
+- systems-thinking
+contributors:
+- fshot
+created: '2026-03-17'
+dead: true
+harness: Claude Code
+kind: metaphor
+name: Memory Leak
+related:
+- data-flow-is-fluid-flow
+- memory-heap
+- memory-stack
+- buffer-overflow
+slug: memory-leak
+source_frame: fluid-dynamics
+updated: '2026-03-17'
+transfers:
+  - "[source] fluid escaping through a small hole drains a container gradually, not catastrophically"
+  - "[source] a leak is invisible until the container is nearly empty or the escaped fluid causes secondary damage"
+  - "[source] the rate of loss is proportional to the size of the defect, not to the total volume"
+limits:
+  - "[source] breaks because leaked fluid leaves the system entirely, whereas the mapped resource remains physically present but becomes unreachable -- nothing actually escapes the machine"
+  - "[source] misleads because a physical leak can be found by following the trail of escaped fluid, but the mapped defect leaves no visible trace at the point of loss"
+---
+
+## Transfers
+
+A bucket with a small hole: the water does not vanish all at once, but
+drip by drip, the bucket empties. A memory leak occurs when a program
+allocates memory and never releases it. The memory is not destroyed or
+corrupted -- it is simply lost to the program's control, accumulating
+silently until the system runs out. The fluid metaphor makes the failure
+mode vivid: a slow, invisible drain on a finite resource.
+
+Key structural parallels:
+
+- **Gradual depletion** -- a physical leak loses fluid slowly. A memory
+  leak loses memory slowly: each iteration of a loop, each request
+  handled, each event processed adds a small unreleased allocation. The
+  program works fine for minutes, hours, or days before the cumulative
+  loss becomes visible. The metaphor captures the insidiousness perfectly:
+  leaks are dangerous precisely because they are gradual.
+- **Invisibility until crisis** -- you do not notice a small leak in a
+  pipe until the floor is wet or the tank is empty. You do not notice a
+  memory leak until the process's resident set size has grown to gigabytes,
+  the system starts swapping, or the OOM killer terminates the process.
+  The metaphor imports the delayed detection that makes leaks so
+  frustrating to diagnose: the symptom appears far from the cause, both
+  in time and in code location.
+- **The resource is finite** -- a tank holds a fixed volume. Physical
+  memory and address space are finite. A leak that would be harmless in
+  an infinite system becomes fatal in a bounded one. The metaphor imports
+  the scarcity constraint: leaks matter because the container is not
+  infinitely large.
+- **The defect is in the container, not the contents** -- a leaking pipe
+  is a plumbing problem, not a water problem. A memory leak is a program
+  defect, not a memory defect. The metaphor correctly assigns blame to
+  the vessel (the code) rather than the substance (the memory). The
+  program failed to release the memory; the memory did nothing wrong.
+
+## Limits
+
+- **Nothing actually escapes** -- when a pipe leaks, water leaves the
+  pipe and puddles on the floor. When memory leaks, nothing leaves the
+  machine. The allocated bytes are still in RAM, still at their original
+  addresses. They are simply unreachable: the program has lost all
+  pointers to them. "Leak" implies material escaping a container, but the
+  real problem is lost references, not lost material. The memory is
+  trapped, not escaped.
+- **Physical leaks leave a trail; memory leaks do not** -- you can find a
+  plumbing leak by following the water stains, tracing moisture back to
+  the crack. Memory leaks leave no visible trail at the point of loss.
+  The allocation happened somewhere in the code, the pointer was dropped
+  somewhere else, and by the time the symptom manifests, there is no
+  moisture trail to follow. This is why memory leak debugging requires
+  specialized tools (Valgrind, AddressSanitizer, heap profilers) that
+  have no analog in the plumbing metaphor.
+- **The metaphor suggests the fix is patching the hole** -- a plumbing
+  leak is fixed by sealing the crack. But "sealing" a memory leak often
+  requires restructuring ownership semantics, changing data structures,
+  or rethinking object lifetimes. The metaphor's simplicity -- find the
+  hole, patch it -- understates the architectural difficulty of fixing
+  leaks in complex software. The "hole" may be a design decision, not a
+  localized defect.
+- **"Leak" implies waste; sometimes it is intentional** -- not all
+  unreleased memory is a bug. A program that allocates memory at startup
+  and uses it for the entire process lifetime has no reason to free it --
+  the OS reclaims everything at exit. Calling this a "leak" imports moral
+  judgment from the plumbing domain where leaks are always waste. In
+  software, the calculation is more nuanced: freeing memory just before
+  exit is ceremony, not engineering.
+
+## Expressions
+
+- "Memory leak" -- the canonical term; so standard that it appears without
+  explanation in bug reports, code reviews, and postmortems
+- "Leaking memory" -- the verbal form, used as a diagnosis: "this service
+  is leaking memory at about 50 MB per hour"
+- "Slow leak" -- a small leak that takes hours or days to become visible,
+  imported directly from plumbing terminology
+- "Plugging the leak" -- fixing the code that fails to free memory; the
+  plumbing repair metaphor applied to software maintenance
+- "Leaky abstraction" -- Joel Spolsky's coinage (2002), extending the leak
+  metaphor from memory to abstraction layers; implementation details
+  "seep through" the abstraction like water through a wall
+- "Resource leak" -- generalization beyond memory to file handles, sockets,
+  database connections; any finite resource that is acquired but never
+  released
+
+## Origin Story
+
+The term "memory leak" emerged in the C programming community in the 1970s
+and 1980s, where manual memory management made unreleased allocations a
+common defect. C gives the programmer full control over allocation
+(`malloc()`) and deallocation (`free()`), and the language provides no
+safety net: if you lose the pointer, the memory is gone. The fluid
+metaphor was natural given Unix's existing plumbing vocabulary -- pipes,
+streams, filters, drains, and now leaks.
+
+The term gained broader currency as long-running server processes became
+common. A leak in a short-lived program is harmless -- the OS reclaims
+everything at exit. But a web server, database, or daemon that runs for
+weeks accumulates leaked memory until it crashes or is restarted. The
+"slow leak" image from plumbing maps precisely onto this failure mode:
+a small defect that is tolerable in the short term and catastrophic in
+the long term.
+
+Garbage-collected languages (Java, Python, Go) were supposed to eliminate
+memory leaks, but they introduced a new variant: the "logical leak," where
+objects are still reachable (so the GC cannot collect them) but are no
+longer needed. The plumbing metaphor adapted: now the leak is not a hole
+in the pipe but a pipe that leads nowhere -- still connected, still
+holding water, but serving no purpose.
+
+## References
+
+- Kernighan, B. & Ritchie, D. *The C Programming Language* (1978) --
+  manual memory management that makes leaks possible
+- Stevens, W. R. *Advanced Programming in the UNIX Environment* (1992) --
+  process memory layout and long-running daemon patterns
+- Nethercote, N. & Seward, J. "Valgrind: A Framework for Heavyweight
+  Dynamic Binary Instrumentation" (2007) -- the primary tool for detecting
+  memory leaks in C/C++ programs
+- Spolsky, J. "The Law of Leaky Abstractions" (2002) -- extension of the
+  leak metaphor beyond memory to abstraction layers

--- a/catalog/entries/unix-filter.md
+++ b/catalog/entries/unix-filter.md
@@ -1,0 +1,144 @@
+---
+applies_to:
+- data-processing
+author: agent:metaphorex-miner
+categories:
+- computer-science
+contributors:
+- fshot
+created: '2026-03-17'
+dead: true
+harness: Claude Code
+kind: metaphor
+name: Unix Filter
+related:
+- data-flow-is-fluid-flow
+- unix-pipe
+- unix-tee
+- the-pipeline-pattern
+slug: unix-filter
+source_frame: fluid-dynamics
+updated: '2026-03-17'
+transfers:
+  - "[source] a filter passes material that meets a criterion and blocks what does not, producing a subset of the input"
+  - "[source] filters are passive inline components -- they do not generate flow, only transform it"
+  - "[source] filters are interchangeable because they connect via standard fittings at both ends"
+limits:
+  - "[source] breaks because a physical filter only removes material, whereas the mapped component can add, rearrange, or transform content -- sed and awk are called filters but they produce output that was never in the input"
+  - "[source] misleads because physical filters degrade as they accumulate blocked material, but the mapped component processes unlimited volume without clogging or requiring replacement"
+---
+
+## Transfers
+
+A water filter: fluid enters one end, passes through a medium that
+removes impurities, and exits the other end cleaner than it entered. A
+Unix filter is a program that reads from standard input, transforms or
+selects the data, and writes to standard output. `grep`, `sort`, `uniq`,
+`awk`, `sed`, `cut`, `tr`, `wc` -- the core Unix toolkit is a
+collection of filters, each performing one transformation on the stream.
+
+Key structural parallels:
+
+- **Selection by criterion** -- a physical filter passes particles
+  smaller than its mesh and blocks larger ones. `grep` passes lines
+  matching a pattern and blocks the rest. `uniq` passes the first
+  occurrence of each line and blocks duplicates. The metaphor maps
+  precisely: the filter defines a criterion, and data either passes or
+  does not.
+- **Inline passivity** -- a physical filter does not pump water. It sits
+  in the flow path and acts on whatever passes through. A Unix filter
+  does not open files, connect to networks, or initiate I/O. It reads
+  stdin and writes stdout. The data source and data sink are someone
+  else's responsibility. This passivity is the architectural principle:
+  filters are components, not applications.
+- **Composability through standard interfaces** -- filters in a plumbing
+  system connect via standard pipe fittings. Unix filters connect via
+  stdin and stdout. Because every filter reads text lines and writes text
+  lines, any filter can connect to any other. `grep pattern | sort |
+  uniq -c | sort -rn` is a four-filter pipeline, and each filter is
+  oblivious to what comes before or after it. The standard interface is
+  the enabling constraint.
+- **Single-purpose design** -- a sediment filter removes sediment. A
+  carbon filter removes chemicals. Each filter does one thing. `grep`
+  selects lines. `sort` orders them. `cut` extracts columns. The Unix
+  philosophy of "do one thing well" is the filter metaphor applied to
+  software design: a filter that does too many things is a bad filter.
+
+## Limits
+
+- **Physical filters only subtract; Unix filters also transform** -- a
+  water filter removes contaminants and passes the rest unchanged. But
+  `sed` rewrites lines, `awk` computes new values, `sort` reorders the
+  entire stream, and `tr` translates characters. These programs are
+  called "filters" but they are really transformers: their output can
+  contain content that was not in their input. The filter metaphor
+  captures selection (`grep`) perfectly but distorts transformation
+  (`awk`) by implying that only removal is happening.
+- **Physical filters clog; Unix filters do not** -- a physical filter
+  accumulates the material it blocks. Over time, flow decreases and the
+  filter must be cleaned or replaced. A Unix filter processes an
+  unlimited stream without degradation. `grep` does not slow down after
+  filtering a million lines. The metaphor imports an expectation of
+  wear that does not apply. This is actually a strength of the digital
+  version, but the metaphor does not celebrate it -- it simply fails to
+  mention it.
+- **The metaphor obscures state** -- a physical filter is stateless: each
+  drop of water is filtered independently. But `sort` must read the
+  entire input before producing any output. `uniq` must remember the
+  previous line. `awk` can maintain counters and accumulators across
+  lines. These stateful behaviors violate the filter metaphor's implicit
+  promise of line-by-line, memoryless processing. Debugging a pipeline
+  stall caused by `sort` waiting for EOF is confusing precisely because
+  the filter metaphor suggests that data should flow through immediately.
+- **Text lines are not a universal interface** -- the filter metaphor
+  works because Unix standardized on newline-delimited text. But binary
+  data, structured formats (JSON, XML), and records with embedded
+  newlines break the model. The plumbing metaphor assumes a homogeneous
+  fluid; real data is heterogeneous. This is why Unix filter pipelines
+  struggle with structured data and why tools like `jq` must define
+  their own framing.
+
+## Expressions
+
+- "Unix filter" -- any program that reads stdin and writes stdout; the
+  canonical description in *The Unix Programming Environment*
+- "Filter pipeline" -- a chain of filters connected by pipes, each
+  transforming the stream in sequence
+- "grep is a filter" -- the most commonly cited example; the name itself
+  (Global Regular Expression Print) describes what passes through
+- "Write programs that do one thing and do it well" -- McIlroy's
+  formulation of the Unix philosophy, which is the filter principle
+  stated as a design rule
+- "Everything is a filter" -- the aspirational version of Unix
+  philosophy, where every program is designed to participate in pipelines
+- "Text stream as universal interface" -- the assumption that makes
+  filters composable, analogous to standard pipe diameters in plumbing
+
+## Origin Story
+
+The filter concept in Unix emerged from Doug McIlroy's pipe design and was
+codified in the earliest Unix documentation. The 1974 Thompson and Ritchie
+CACM paper describes the shell's ability to connect programs, and the
+programs designed to be connected -- grep, sort, uniq, wc -- were the
+original filters. Kernighan and Pike's *The Unix Programming Environment*
+(1984) made the filter pattern explicit, devoting chapters to building
+programs that read stdin, process, and write stdout.
+
+The term "filter" was borrowed from the plumbing vocabulary that Unix had
+already established with "pipe." If data flows through pipes, then programs
+that sit in the flow and transform it are filters. The naming was not
+accidental but systematic: McIlroy and the Bell Labs team were building a
+coherent metaphor system, not just naming individual tools. The filter
+metaphor gave Unix its compositional character -- the idea that complex
+data processing is best achieved by chaining simple, single-purpose
+programs.
+
+## References
+
+- Thompson, K. & Ritchie, D. "The UNIX Time-Sharing System," CACM 17(7),
+  1974
+- Kernighan, B. & Pike, R. *The Unix Programming Environment*,
+  Prentice-Hall, 1984 -- canonical description of the filter pattern
+- McIlroy, M.D. "A Research UNIX Reader," Bell Labs, 1987
+- Raymond, E.S. *The Art of Unix Programming*, Addison-Wesley, 2003 --
+  "Rule of Composition" and filter design

--- a/catalog/entries/unix-tee.md
+++ b/catalog/entries/unix-tee.md
@@ -1,0 +1,136 @@
+---
+applies_to:
+- data-processing
+author: agent:metaphorex-miner
+categories:
+- computer-science
+contributors:
+- fshot
+created: '2026-03-17'
+dead: true
+harness: Claude Code
+kind: metaphor
+name: Unix Tee
+related:
+- data-flow-is-fluid-flow
+- unix-pipe
+- unix-filter
+slug: unix-tee
+source_frame: fluid-dynamics
+updated: '2026-03-17'
+transfers:
+  - "[source] a tee fitting splits a single flow into two paths without altering the fluid in either"
+  - "[source] the T-shaped junction is passive -- it does not pump, redirect, or decide; it simply provides two outlets where there was one"
+  - "[source] both output paths receive identical fluid at the same rate"
+limits:
+  - "[source] breaks because a physical tee divides flow volume between the two paths, whereas the mapped command duplicates the full stream to both destinations -- nothing is split, everything is copied"
+  - "[source] misleads because physical tee orientation and pressure dynamics determine flow distribution, but the mapped command always sends identical complete output to both paths regardless of downstream conditions"
+---
+
+## Transfers
+
+A T-shaped pipe fitting in a plumbing system: fluid flows in from one
+end and exits from both branches of the T. The Unix `tee` command does
+the same thing with data: it reads from standard input and writes
+simultaneously to standard output and to one or more files. The name is
+explicitly borrowed from plumbing -- one of the most transparently
+metaphorical commands in Unix.
+
+Key structural parallels:
+
+- **Flow splitting** -- a plumbing tee takes a single stream and divides
+  it into two. The `tee` command takes a single data stream and sends it
+  two places: the terminal (or the next command in the pipeline) and a
+  file. The structural mapping is exact: one input, two outputs, and the
+  data continues flowing in both directions.
+- **Inline operation** -- a plumbing tee is installed in the middle of a
+  pipe run, not at the end. The `tee` command is used in the middle of a
+  pipeline: `make 2>&1 | tee build.log | grep error`. It does not
+  terminate the flow; it siphons off a copy while the main stream
+  continues. This inline character is the whole point -- `tee` exists to
+  observe the flow without interrupting it.
+- **Passivity** -- a plumbing tee does not pump, heat, or filter the
+  fluid. It merely provides a junction. The `tee` command does not
+  transform the data. Every byte that enters exits unchanged through both
+  paths. This passivity distinguishes `tee` from filters: filters
+  transform, tees duplicate.
+- **The name teaches the concept** -- unlike "grep" or "awk," which
+  require explanation, "tee" is immediately comprehensible to anyone who
+  knows plumbing terminology. The metaphor is not just naming; it is
+  documentation. A programmer who understands T-fittings understands
+  `tee` without reading the man page.
+
+## Limits
+
+- **Physical tees divide flow; `tee` duplicates it** -- this is the
+  most significant break. When water hits a T-fitting, the volume splits:
+  some goes left, some goes right, and the total flow is conserved. When
+  data hits `tee`, every byte goes to both destinations in full. There
+  is no division -- there is duplication. The plumbing metaphor implies
+  conservation of volume; the digital reality is free copying. This
+  difference is fundamental but invisible in the naming.
+- **Physical tees are bidirectional; `tee` is not** -- a plumbing
+  T-fitting can receive flow from any of its three openings and
+  distribute to the others, depending on pressure gradients. The `tee`
+  command has a fixed topology: one input (stdin), two outputs (stdout
+  and file). You cannot send data backward through `tee` or use it to
+  merge two streams. The plumbing fitting is more flexible than the
+  software it inspired.
+- **The metaphor does not scale** -- a plumber can install a four-way
+  cross fitting, a manifold, or a header to split flow into many paths.
+  The `tee` command writes to stdout plus one or more files, but it
+  cannot split a pipeline into multiple parallel pipelines. For true
+  multiway splitting, you need process substitution or named pipes --
+  mechanisms that are outside the plumbing metaphor's vocabulary. The
+  metaphor promises a fitting for every topology but delivers only the
+  simplest T.
+- **Pressure and backpressure disappear** -- in plumbing, a tee's
+  behavior depends on downstream pressure. If one branch is blocked,
+  flow goes to the other. If the `tee` command's file write blocks
+  (full disk), the entire pipeline stalls. There is no automatic
+  rerouting, no pressure equalization. The plumbing metaphor suggests
+  a physical system that adapts to conditions; the digital
+  implementation is rigid.
+
+## Expressions
+
+- "Tee it to a file" -- the standard idiom: `command | tee output.log`
+- "Tee off the output" -- using `tee` to capture a copy of pipeline data
+  for debugging or logging, borrowing from the plumbing sense of "tap off"
+- "Pipe tee" -- describing the command by its plumbing equivalent,
+  reinforcing the metaphor
+- "tee /dev/null" -- a no-op tee that discards the copy, demonstrating
+  the command's composability with Unix's other plumbing metaphors
+- "tee -a" -- append mode, extending the metaphor: the file is a tank
+  that accumulates rather than being refilled each time
+
+## Origin Story
+
+The `tee` command first appeared in Version 5 Unix (1974) at Bell Labs.
+The name was chosen by the Unix developers explicitly because the command
+does what a plumbing T-fitting does: splits a stream into two paths. It
+is part of the systematic plumbing vocabulary that McIlroy, Thompson,
+and Ritchie built into Unix -- pipes, filters, streams, sinks, drains,
+and tees.
+
+The command was a direct response to a practical problem: how do you
+observe data flowing through a pipeline without disrupting it? Before
+`tee`, you had to break the pipeline, write to a file, and then construct
+a second pipeline to continue processing. `tee` solved this by making the
+T-fitting available as a command, maintaining the fiction that a Unix
+pipeline is a plumbing system you can tap into at any point.
+
+The man page has always been terse -- `tee` is one of the simplest Unix
+commands. Its power comes not from internal complexity but from its
+position in the plumbing vocabulary: it fills the gap between linear pipes
+and the need to observe or record intermediate data. It is the debugging
+fitting in Unix's metaphorical plumbing system.
+
+## References
+
+- Thompson, K. & Ritchie, D. "The UNIX Time-Sharing System," CACM 17(7),
+  1974
+- Kernighan, B. & Pike, R. *The Unix Programming Environment*,
+  Prentice-Hall, 1984
+- McIlroy, M.D. "A Research UNIX Reader," Bell Labs, 1987
+- tee(1) man page, man7.org -- https://man7.org/linux/man-pages/man1/tee.1.html


### PR DESCRIPTION
## Summary

Five entries from the **unix-c-metaphors** project (batches 4 and 6):

- **memory-heap** — dynamic memory as a disordered pile; contrast with stack's discipline
- **memory-leak** — unreleased memory as fluid escaping a container; gradual, invisible depletion
- **unix-filter** — stdin/stdout programs as water filters in the plumbing system
- **unix-tee** — the tee command as a T-shaped pipe fitting that splits data flow
- **environment-variable** — process execution context as ecological surroundings

All entries include full Transfers, Limits, Expressions, Origin Story, and References sections. Frontmatter includes `transfers:` and `limits:` propositions.

Closes #312
Closes #313
Closes #315
Closes #316
Closes #317

## Validator output

No new errors. All 20 pre-existing errors are in unrelated files (brand, capital, companion, salary, window — deprecated `dead-metaphor` kind).

## Frames / Categories

No new frames or categories needed — all referenced frames (`fluid-dynamics`, `embodied-experience`, `software-programs`, `data-processing`) and categories (`computer-science`, `systems-thinking`, `security`) already exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Validation

✓ `uv run scripts/validate.py` — 0 errors