### PR TITLE
Add 5 entries: causation-control batch + change-is-replacement

### DIFF
--- a/catalog/entries/causation-is-control-over-an-entity-relative-to-a-location.md
+++ b/catalog/entries/causation-is-control-over-an-entity-relative-to-a-location.md
@@ -1,0 +1,128 @@
+---
+applies_to:
+- causal-reasoning
+author: agent:metaphorex-miner
+categories:
+- cognitive-science
+- linguistics
+- philosophy
+contributors: []
+created: '2026-03-17'
+harness: Claude Code
+kind: metaphor
+name: Causation Is Control Over An Entity Relative To A Location
+provenance: osaka-master-metaphor-list
+related:
+- causation-is-control-over-relative-location
+- causation-is-control-over-an-object-relative-to-a-possessor
+- causes-are-forces
+- causation-is-commercial-transaction
+- states-are-locations
+slug: causation-is-control-over-an-entity-relative-to-a-location
+source_frame: governance
+updated: '2026-03-17'
+---
+
+## Transfers
+
+To cause something is to control where an entity goes. This metaphor maps
+the governance frame -- an authority determining the spatial position of a
+thing under its jurisdiction -- onto causal reasoning. The cause is an agent
+who places, moves, or confines an entity to a particular location; the
+effect is the entity's arrival at that location. It belongs to the
+location-case variant of Lakoff's Event Structure system, where states are
+locations and changes are movements between locations.
+
+Key structural parallels:
+
+- **Cause as placement** -- "The crisis put the country in a difficult
+  position." "The ruling placed restrictions on the company." "Her
+  decision landed him in trouble." The causal agent places the affected
+  entity at a new location, and the location represents the resulting
+  state. Causing is positioning.
+- **Control as spatial authority** -- "She kept him in line." "The policy
+  held the economy in check." "They pinned the blame on him." The causer
+  exercises authority over where the entity is. Control over location is
+  control over state, because the location-state mapping runs underneath.
+- **Prevention as blocking movement** -- "The regulation kept prices from
+  rising." "She held him back from making a mistake." "They stopped the
+  project from going off track." Preventing an effect is preventing the
+  entity from reaching a location. The causal agent acts as a barrier or
+  restraint on movement.
+- **Release as permitting change** -- "She let him go." "The court freed
+  the defendant." "They released the funds." When the controlling agent
+  stops constraining the entity's location, the entity moves and the
+  state changes. Permitting causation is releasing spatial control.
+- **Destination as outcome** -- "The negotiations brought them to an
+  agreement." "His recklessness drove the company to bankruptcy." "The
+  evidence led the jury to a verdict." The caused state is a place the
+  entity arrives at under the agent's direction.
+
+## Limits
+
+- **Causation is not always directional** -- the metaphor requires a
+  controlling agent who moves an entity to a place. But many causal
+  processes are undirected: erosion, diffusion, entropy. There is no
+  governor placing the river sediment downstream. The metaphor makes
+  agentless causation hard to express without personifying the cause.
+- **Spatial control implies reversibility** -- if you can place something
+  at a location, you can presumably move it back. But many causal
+  processes are irreversible: you cannot un-burn a forest or un-say a
+  word. The governance-of-location frame creates a false sense that
+  effects can always be undone by moving the entity back.
+- **The single-entity focus obscures systemic effects** -- controlling
+  where one entity goes is a simple dyad (controller-entity). But real
+  causation often involves cascading effects across many entities. Moving
+  one piece changes the whole board, not just the piece's location.
+- **Location implies discrete states** -- if the effect is arriving at
+  a location, then states are places you are either at or not at. This
+  makes gradual transitions awkward. You are not partly in a recession;
+  you are either there or not. The metaphor discretizes what may be
+  continuous.
+- **Governance implies legitimacy** -- the source frame carries
+  connotations of rightful authority. When we say someone "put" another
+  person in a bad situation, the governance framing can subtly suggest
+  the causer had the right or power to do so, even when the causation
+  was accidental or illegitimate.
+
+## Expressions
+
+- "The recession put millions out of work" -- causing unemployment as
+  placing people at a location (out of work)
+- "She kept him in line" -- preventing deviance as controlling an
+  entity's spatial position
+- "The new law placed the burden on employers" -- causing obligation as
+  positioning an entity relative to a bearer
+- "His recklessness drove the company to ruin" -- causing failure as
+  directing an entity toward a destination
+- "They held the situation under control" -- preventing change as
+  maintaining an entity's location
+- "The evidence led the jury to a guilty verdict" -- causing a
+  conclusion as guiding an entity to a location
+- "She landed him in trouble" -- causing a bad state as placing someone
+  at an undesirable location
+- "The policy kept inflation in check" -- preventing rise as confining
+  an entity to a controlled location
+
+## Origin Story
+
+This metaphor is documented in the Master Metaphor List (Lakoff, Espenson
+& Schwartz 1991) as part of the Event Structure metaphor system, location
+case. Lakoff identified two parallel systems for understanding causation:
+one based on spatial control (the location case) and one based on
+possession control (the object case). CAUSATION IS CONTROL OVER AN ENTITY
+RELATIVE TO A LOCATION is a specific instantiation of the location case
+that foregrounds the causal agent's governance over where an affected
+entity ends up. It depends on the more fundamental mapping STATES ARE
+LOCATIONS -- without that underlying metaphor, the idea that placing
+something at a location constitutes causing a state change would not
+cohere.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Causation Is Control Over An Entity Relative To A Location"
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999) -- the Event
+  Structure metaphor system, location case
+- Lakoff, G. & Johnson, M. *Metaphors We Live By* (1980) -- ontological
+  metaphors

--- a/catalog/entries/causation-is-control-over-an-object-relative-to-a-possessor.md
+++ b/catalog/entries/causation-is-control-over-an-object-relative-to-a-possessor.md
@@ -1,0 +1,131 @@
+---
+applies_to:
+- causal-reasoning
+author: agent:metaphorex-miner
+categories:
+- cognitive-science
+- linguistics
+- philosophy
+contributors: []
+created: '2026-03-17'
+harness: Claude Code
+kind: metaphor
+name: Causation Is Control Over An Object Relative To A Possessor
+provenance: osaka-master-metaphor-list
+related:
+- causation-is-control-over-an-entity-relative-to-a-location
+- causation-is-control-over-relative-location
+- causation-is-commercial-transaction
+- causes-are-forces
+- action-is-control-over-possessions
+- properties-are-possessions
+slug: causation-is-control-over-an-object-relative-to-a-possessor
+source_frame: economics
+updated: '2026-03-17'
+---
+
+## Transfers
+
+To cause something is to control who has what. This metaphor maps the
+economics of possession -- giving, taking, withholding objects relative
+to a possessor -- onto causal reasoning. The cause is an agent who
+transfers, bestows, or removes an object from a possessor; the effect is
+the possessor's changed state of having or lacking. It belongs to the
+object-case variant of Lakoff's Event Structure system, where attributes
+are possessions and changes are transfers of ownership.
+
+Key structural parallels:
+
+- **Causing as giving** -- "The victory gave them confidence." "The drug
+  gave her relief." "Experience gives you perspective." The causal agent
+  transfers an object (the effect-as-attribute) to the affected party.
+  Causing someone to have a quality is giving them something.
+- **Causing loss as taking** -- "The scandal robbed him of his
+  credibility." "The disease took her mobility." "Inflation stripped them
+  of their savings." The causal agent removes an object from the
+  possessor. Causing someone to lose a quality is taking something away.
+- **Prevention as withholding** -- "The embargo denied them access to
+  markets." "Bureaucracy kept the funds from reaching the village." "She
+  withheld her approval." The causal agent prevents the transfer of an
+  object to a would-be possessor. Preventing an effect is refusing to hand
+  over the goods.
+- **Enabling as making available** -- "The scholarship afforded him an
+  education." "New technology offers possibilities we never had." "The
+  law grants citizens the right to vote." The causal agent makes an object
+  accessible to the possessor without forcing the transfer. Enabling is
+  putting the goods within reach.
+- **Causal reversal as repossession** -- "The court restored her rights."
+  "Therapy gave him back his confidence." "The reform returned power to the
+  people." Undoing an effect is returning the object to its original
+  possessor. Causal reversal is a return transaction.
+
+## Limits
+
+- **Possession implies zero-sum** -- if causing is giving someone an
+  object, then the giver should no longer have it. But many causes produce
+  effects without depleting the cause: a teacher gives knowledge without
+  losing it. The possession metaphor imports a conservation law that does
+  not apply to most causal processes.
+- **Ownership obscures shared causation** -- objects have one owner at a
+  time (typically). When multiple causes jointly produce an effect, the
+  metaphor struggles to represent shared contribution. Who gave the patient
+  health: the surgeon, the medication, or the patient's immune system? The
+  possession frame wants a single giver.
+- **The transaction model implies voluntariness** -- giving and taking are
+  volitional acts. But many causal processes involve no agent: erosion
+  takes topsoil, gravity gives objects weight. The metaphor's economics
+  frame forces personification of impersonal causes.
+- **Attributes are not discrete objects** -- you can give someone a book,
+  and the book remains identifiable. But "confidence" or "relief" are not
+  bounded objects. The metaphor reifies continuous qualities into countable
+  things, which obscures the gradual and contextual nature of most
+  attributes.
+- **The possessor's role is passive** -- in the transfer model, the
+  possessor receives or loses objects at the agent's discretion. This
+  underrepresents the affected party's own role in being affected: a
+  student does not just receive knowledge but actively constructs
+  understanding.
+
+## Expressions
+
+- "The victory gave them confidence" -- causing a quality as transferring
+  an object to a possessor
+- "The scandal robbed him of his reputation" -- causing loss as taking an
+  object from someone
+- "Experience gives you wisdom" -- causing understanding as bestowing a
+  possession
+- "The disease took her strength" -- causing debilitation as removing a
+  possession
+- "The embargo denied them access" -- preventing an outcome as withholding
+  an object
+- "Therapy gave him back his peace of mind" -- reversing an effect as
+  returning a possession
+- "New technology offers unprecedented possibilities" -- enabling as
+  making an object available
+- "The recession stripped families of their security" -- causing
+  deprivation as forcibly removing possessions
+- "The law grants citizens the right to assembly" -- enabling by
+  authority as officially bestowing an object
+
+## Origin Story
+
+This metaphor appears in the Master Metaphor List (Lakoff, Espenson &
+Schwartz 1991) as part of the Event Structure metaphor system, object
+case. Where the location case maps causation onto controlling where an
+entity goes, the object case maps it onto controlling what a possessor
+has. The two systems are parallel but structurally distinct: the location
+case produces spatial language ("put in danger," "drive to ruin") while
+the object case produces transactional language ("give confidence," "take
+away freedom"). Both systems are grounded in embodied experience --
+infants learn early that agents can give objects to people and take
+objects away, and this transfer logic extends to understanding all forms
+of causation where one agent changes another's attributes.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Causation Is Control Over An Object Relative To A Possessor"
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999) -- the Event
+  Structure metaphor system, object case
+- Lakoff, G. & Johnson, M. *Metaphors We Live By* (1980) -- ontological
+  metaphors

--- a/catalog/entries/causation-is-control-over-relative-location.md
+++ b/catalog/entries/causation-is-control-over-relative-location.md
@@ -1,0 +1,133 @@
+---
+applies_to:
+- causal-reasoning
+author: agent:metaphorex-miner
+categories:
+- cognitive-science
+- linguistics
+- philosophy
+contributors: []
+created: '2026-03-17'
+harness: Claude Code
+kind: metaphor
+name: Causation Is Control Over Relative Location
+provenance: osaka-master-metaphor-list
+related:
+- causation-is-control-over-an-entity-relative-to-a-location
+- causation-is-control-over-an-object-relative-to-a-possessor
+- causes-are-forces
+- states-are-locations
+- change-is-motion
+slug: causation-is-control-over-relative-location
+source_frame: governance
+updated: '2026-03-17'
+---
+
+## Transfers
+
+To cause something is to control where things are relative to each other.
+This metaphor maps the governance of spatial relations -- determining
+proximity, distance, alignment, and arrangement between entities -- onto
+causal reasoning. Unlike the entity-to-location variant (which focuses on
+placing one thing at one place), this version foregrounds the relationship
+between two or more entities: the causal agent controls whether things
+are near or far, together or apart, aligned or opposed. It is part of
+the location-case Event Structure system, with special emphasis on
+relational positioning.
+
+Key structural parallels:
+
+- **Causing connection as bringing together** -- "The treaty brought the
+  two nations closer." "Shared grief drew them together." "The merger
+  united the two companies." The causal agent reduces the distance between
+  entities. Creating a relationship or agreement is making things spatially
+  proximate.
+- **Causing separation as pulling apart** -- "The dispute drove a wedge
+  between them." "The scandal tore the party apart." "Competition
+  separated the leaders from the pack." The causal agent increases the
+  distance between entities. Causing division or conflict is forcing
+  things away from each other.
+- **Causing alignment as arranging** -- "The coach got everyone on the
+  same page." "The new policy brought operations into line." "She aligned
+  the team's priorities." The causal agent arranges entities into a
+  shared orientation. Causing agreement or coordination is making things
+  face the same direction.
+- **Causing disorder as disarranging** -- "The announcement threw
+  everything out of alignment." "The crisis knocked plans off course."
+  "His departure upset the whole arrangement." The causal agent disrupts
+  the spatial relations between entities. Causing dysfunction is
+  disordering a previously arranged set.
+- **Maintaining relations as holding in place** -- "She kept the coalition
+  together." "The treaty held the balance of power." "Tradition keeps
+  communities close." The causal agent preserves the existing spatial
+  relations between entities. Sustaining a state of affairs is preventing
+  rearrangement.
+
+## Limits
+
+- **Relative location implies two parties** -- the metaphor requires at
+  least two entities whose spatial relation is being controlled. But many
+  causal processes affect a single entity's internal state (stress causes
+  fatigue) without an obvious second entity to be positioned relative to.
+  The relational frame has nothing to say about intrinsic change.
+- **Spatial relations are symmetric; causal relations often are not** --
+  if A is close to B, then B is close to A. But if a policy brings
+  employers and employees closer, the effect may be asymmetric: employers
+  may feel more in control while employees feel more constrained. The
+  spatial symmetry masks causal asymmetry.
+- **The geometry is too simple** -- real relationships involve trust,
+  obligation, power, history, and emotion. Reducing these to proximity and
+  alignment strips away most of what matters. Two entities can be "close"
+  in completely different ways (close allies, close competitors, close
+  relatives), and the spatial metaphor collapses these distinctions.
+- **Control implies a single arranger** -- the metaphor positions a
+  causal agent as the one who arranges entities relative to each other.
+  But many relational changes are emergent: market forces bring competitors
+  together, cultural shifts drive generations apart. There is no governor
+  controlling the layout.
+- **Reversibility is assumed** -- if you can bring things together, you
+  can presumably push them apart. But some caused relationships are
+  irreversible: once trust is broken, you cannot simply move the pieces
+  back to their original positions. The spatial frame makes reconciliation
+  seem like a matter of rearrangement.
+
+## Expressions
+
+- "The treaty brought the two nations closer" -- causing alliance as
+  reducing distance between entities
+- "The scandal drove a wedge between them" -- causing division as forcing
+  an object between two entities to increase distance
+- "She pulled the team together" -- causing cohesion as gathering
+  entities into proximity
+- "The dispute pushed them further apart" -- causing estrangement as
+  increasing spatial separation
+- "He got everyone on the same page" -- causing agreement as aligning
+  entities to a shared position
+- "The crisis threw everything out of order" -- causing dysfunction as
+  disrupting spatial arrangement
+- "Competition separated the leaders from the rest" -- causing
+  differentiation as increasing distance between groups
+- "The reform bridged the gap between rich and poor" -- causing equality
+  as reducing spatial distance between groups
+
+## Origin Story
+
+This metaphor is documented in the Master Metaphor List (Lakoff, Espenson
+& Schwartz 1991) as part of the location-case Event Structure system. It
+is a variant that emphasizes relative position rather than absolute
+position: where CAUSATION IS CONTROL OVER AN ENTITY RELATIVE TO A
+LOCATION focuses on placing one thing at one place, this metaphor focuses
+on the spatial relations between multiple entities. The distinction
+matters because much of human reasoning about causation concerns
+relationships -- alliances, separations, alignments -- rather than states
+of individual entities. The metaphor is grounded in early spatial
+experience: infants observe that agents can push things together and pull
+things apart, and this relational-spatial logic extends to reasoning about
+all forms of social and abstract causation.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Causation Is Control Over Relative Location"
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999) -- the Event
+  Structure metaphor system, location case

--- a/catalog/entries/causes-and-effects-are-linked-objects.md
+++ b/catalog/entries/causes-and-effects-are-linked-objects.md
@@ -1,0 +1,134 @@
+---
+applies_to:
+- causal-reasoning
+author: agent:metaphorex-miner
+categories:
+- cognitive-science
+- linguistics
+- philosophy
+contributors: []
+created: '2026-03-17'
+harness: Claude Code
+kind: metaphor
+name: Causes And Effects Are Linked Objects
+provenance: osaka-master-metaphor-list
+related:
+- causes-are-forces
+- causation-is-commercial-transaction
+- causation-is-control-over-an-entity-relative-to-a-location
+- acting-on-is-transferring-an-object
+slug: causes-and-effects-are-linked-objects
+source_frame: containers
+updated: '2026-03-17'
+---
+
+## Transfers
+
+Causes and effects are objects physically connected to each other. This
+metaphor maps the concrete experience of linked, chained, or bonded
+objects onto abstract causal relationships. When we reason about causation
+through this metaphor, causes and effects become things you can see,
+grasp, and trace the connection between -- like links in a chain, knots
+in a rope, or coupled railcars. The metaphor makes the invisible
+relationship of causation tangible by turning it into a physical bond.
+
+Key structural parallels:
+
+- **Causal connection as physical linkage** -- "Smoking is linked to lung
+  cancer." "The evidence connects the suspect to the crime." "There's a
+  clear tie between poverty and poor health outcomes." The causal
+  relationship itself is a physical bond -- a chain, rope, wire, or
+  bridge -- that joins two objects (the cause and the effect).
+- **Causal chains as object chains** -- "A chain of events led to the
+  disaster." "Each link in the causal chain must hold." "The chain of
+  command broke down." When multiple causes and effects are connected in
+  sequence, they form a literal chain where each link is both an effect
+  of the previous link and a cause of the next.
+- **Strength of causation as strength of bond** -- "The connection between
+  diet and disease is strong." "The link is tenuous at best." "The bond
+  between cause and effect is unbreakable." A strong causal relationship
+  is a strong physical bond; a weak or uncertain causal relationship is a
+  frayed rope or a loose coupling.
+- **Discovering causation as finding the link** -- "Scientists found the
+  missing link." "We need to connect the dots." "The link between the two
+  was finally established." Causal investigation is a search for the
+  physical object that connects two other objects. The link may be hidden,
+  buried, or missing.
+- **Breaking causation as severing the link** -- "The intervention broke
+  the cycle." "We need to sever the connection between these two factors."
+  "Cut the ties between cause and effect." Preventing or interrupting
+  causation is physically cutting, breaking, or removing the link between
+  objects.
+
+## Limits
+
+- **Links are bilateral; causation is directional** -- a chain link
+  connects two things symmetrically: if A is linked to B, then B is
+  linked to A. But causation has a direction: the cause produces the
+  effect, not the reverse. The link metaphor obscures causal asymmetry,
+  which is why "correlation is not causation" must be explicitly taught --
+  the metaphor of linkage does not naturally distinguish the two.
+- **Chain topology is linear** -- a chain is a sequence of links. But
+  real causal structures are networks: branching, converging, looping.
+  Multiple causes can jointly produce one effect (convergence), and one
+  cause can produce many effects (divergence). The chain model makes
+  multi-causal and multi-effect reasoning feel unnatural.
+- **Physical links are persistent** -- once two objects are linked, they
+  stay linked until something actively severs the connection. But many
+  causal relationships are probabilistic, intermittent, or context-
+  dependent. Smoking does not always cause cancer; the "link" is
+  statistical, not mechanical. The metaphor makes all causation feel
+  deterministic.
+- **Objects are passive; causes are active** -- linked objects just sit
+  there, connected. But causes do things: they produce, generate, bring
+  about. The metaphor captures the relationship but strips away the
+  dynamism. It turns causation into a static structure rather than a
+  process.
+- **The link can become the explanation** -- once people find a "link"
+  between two phenomena, the metaphor can make it feel like the
+  explanation is complete. But identifying a link (correlation) is only
+  the beginning of causal understanding. The mechanism, the pathway, the
+  context -- these require going beyond the linked-objects frame.
+
+## Expressions
+
+- "Smoking is linked to cancer" -- causal connection as physical bond
+- "A chain of events led to the collapse" -- sequential causation as
+  linked objects in sequence
+- "We need to connect the dots" -- discovering causation as finding the
+  links between objects
+- "The evidence ties the two together" -- establishing causation as
+  binding objects
+- "Break the cycle of poverty" -- interrupting causation as severing a
+  linked chain
+- "There's a strong connection between education and income" -- strength
+  of causation as strength of physical bond
+- "The missing link in the argument" -- an unknown cause as an absent
+  connecting object
+- "They traced the chain of infection back to patient zero" -- causal
+  investigation as following a chain link by link
+- "The bond between early experience and adult behavior" -- long-range
+  causation as a durable physical bond
+
+## Origin Story
+
+This metaphor is documented in the Master Metaphor List (Lakoff, Espenson
+& Schwartz 1991). It is among the most fundamental metaphors for
+causation, predating the Event Structure system's more elaborate
+location-case and object-case variants. The grounding is in early
+physical experience: infants learn that pulling one linked object moves
+another, that chains transmit force, and that connected things move
+together. This embodied understanding of physical linkage extends to all
+forms of causal reasoning. The metaphor is so deeply embedded in
+scientific and everyday language that "link" and "connection" are often
+treated as literal descriptions of causation rather than metaphorical
+ones -- a mark of a highly conventionalized mapping.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Causes And Effects Are Linked Objects"
+- Lakoff, G. & Johnson, M. *Metaphors We Live By* (1980) -- ontological
+  metaphors and the objectification of abstract relations
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999) -- causation
+  metaphors

--- a/catalog/entries/change-is-replacement.md
+++ b/catalog/entries/change-is-replacement.md
@@ -1,0 +1,133 @@
+---
+applies_to:
+- event-structure
+author: agent:metaphorex-miner
+categories:
+- cognitive-science
+- linguistics
+contributors: []
+created: '2026-03-17'
+harness: Claude Code
+kind: metaphor
+name: Change Is Replacement
+provenance: osaka-master-metaphor-list
+related:
+- change-is-motion
+- action-is-control-over-possessions
+- acting-on-is-transferring-an-object
+- properties-are-possessions
+slug: change-is-replacement
+source_frame: manufacturing
+updated: '2026-03-17'
+---
+
+## Transfers
+
+When something changes, the old version is swapped out and a new version
+is swapped in. This metaphor maps the manufacturing process of replacing
+a worn or defective part with a new one onto the abstract concept of
+change. Rather than understanding change as movement along a continuum
+(CHANGE IS MOTION) or as transfer of attributes (the object case), this
+metaphor frames change as substitution: the old state is an object that
+is removed, and the new state is a different object that takes its place.
+
+Key structural parallels:
+
+- **Changed entity as replaced part** -- "She's a completely different
+  person since the promotion." "The neighborhood has been transformed
+  beyond recognition." "That's not the same company anymore." The entity
+  that changes is treated as if the old version has been removed and a
+  new version installed. Change is not gradual modification but wholesale
+  substitution.
+- **Old state as discarded object** -- "She shed her old habits." "He
+  cast off his former identity." "They threw out the old system." The
+  previous state is an object to be disposed of -- thrown away, stripped
+  off, shed like a skin. Change requires getting rid of the old.
+- **New state as installed object** -- "She adopted a new persona." "He
+  put on a brave face." "They installed a new regime." The new state is
+  an object brought in from elsewhere and put in place. Change requires
+  acquiring and fitting the new.
+- **Gradual change as incremental replacement** -- "She's replacing her
+  bad habits one by one." "The company is phasing in new procedures."
+  "They're swapping out the old guard." When the metaphor accommodates
+  gradual change, it does so through piecemeal substitution -- not smooth
+  transition but a series of discrete swaps.
+- **Irreversible change as permanent replacement** -- "There's no going
+  back to who he was." "The old way of life has been replaced forever."
+  "You can't put the old system back." When the replaced part is
+  destroyed or discarded, the change becomes irreversible. Permanence is
+  the impossibility of reinstalling the original.
+
+## Limits
+
+- **Change is often continuous, not discrete** -- the replacement metaphor
+  insists on a clear boundary between old and new: part A out, part B in.
+  But most change is gradual. A person does not wake up one morning with
+  their old personality removed and a new one installed. The metaphor
+  makes transitions invisible and overemphasizes the contrast between
+  before and after.
+- **Identity is sacrificed** -- if something changes by being replaced,
+  then the changed thing is literally a different thing. This creates
+  philosophical puzzles (the Ship of Theseus is this metaphor made
+  explicit) and practical confusion. Is a reformed criminal a different
+  person? The replacement metaphor says yes, which undermines continuity
+  of identity and responsibility.
+- **The metaphor hides the process** -- replacement is an event, not a
+  process. You take out the old part, put in the new part, done. This
+  makes the actual mechanism of change invisible. How does a person
+  change their habits? The replacement metaphor offers no insight -- it
+  just says the old habits are out and new ones are in.
+- **Manufacturing implies an external agent** -- parts do not replace
+  themselves; a mechanic or worker does the replacing. The metaphor
+  imports an expectation that change requires an external agent, which
+  makes self-directed change (growth, maturation, evolution) harder to
+  conceptualize.
+- **Not all change involves loss** -- replacement requires discarding
+  the old. But many forms of change are additive: learning adds
+  knowledge without removing ignorance piece by piece; growth adds
+  capability without subtracting the earlier stage. The replacement frame
+  makes all change feel like it costs something.
+
+## Expressions
+
+- "She's a changed woman" -- identity change as replacement of a person
+  with a different version
+- "Out with the old, in with the new" -- change as explicit substitution
+- "He shed his old habits" -- changing behavior as discarding replaced
+  parts
+- "They overhauled the entire system" -- large-scale change as
+  comprehensive replacement of components
+- "She reinvented herself" -- personal change as manufacturing a new
+  version
+- "The guard is changing" -- leadership transition as replacement of
+  personnel
+- "He put on a new face" -- changing demeanor as installing a replacement
+  surface
+- "They scrapped the old plan" -- abandoning a prior state as discarding
+  a replaced part
+- "A fresh start" -- beginning after change as a newly installed component
+
+## Origin Story
+
+This metaphor is documented in the Master Metaphor List (Lakoff, Espenson
+& Schwartz 1991) as part of the Event Structure metaphor system. It
+offers a third way to conceptualize change, distinct from both CHANGE IS
+MOTION (the location case, where change is movement from one place to
+another) and the object-case transfer model (where change is gaining or
+losing attributes). The replacement variant is grounded in the concrete
+experience of manufacturing and repair: when a part wears out, you
+remove it and install a new one. This swap logic extends to reasoning
+about personal transformation, institutional reform, and historical
+change. The metaphor is particularly prominent in contexts that emphasize
+discontinuity -- revolutions, conversions, paradigm shifts -- where the
+speaker wants to stress that the new state has nothing in common with
+the old.
+
+## References
+
+- Lakoff, G., Espenson, J. & Schwartz, A. *Master Metaphor List* (1991),
+  "Change Is Replacement"
+- Lakoff, G. & Johnson, M. *Philosophy in the Flesh* (1999) -- the Event
+  Structure metaphor system
+- Lakoff, G. & Johnson, M. *Metaphors We Live By* (1980) -- ontological
+  metaphors


### PR DESCRIPTION
## Summary

- Add 5 entries from cognitive-linguistics-canon project (#4), Event Structure metaphor system
- All entries pass validation (0 new errors, 0 new warnings)
- All required frames already exist in catalog

## Entries

| Slug | Source Frame | Issue |
|------|-------------|-------|
| `causation-is-control-over-an-entity-relative-to-a-location` | governance | Closes #354 |
| `causation-is-control-over-an-object-relative-to-a-possessor` | economics | Closes #355 |
| `causation-is-control-over-relative-location` | governance | Closes #356 |
| `causes-and-effects-are-linked-objects` | containers | Closes #357 |
| `change-is-replacement` | manufacturing | Closes #358 |

## Validator output

0 errors on new entries, 0 warnings on new entries. Pre-existing errors (5 entries with deprecated `dead-metaphor` kind) unchanged.

## Test plan

- [ ] Verify each entry has Transfers, Limits, Expressions, Origin Story, References
- [ ] Verify `related:` links form a connected cluster with existing causation entries
- [ ] Verify expressions are attested natural language, not invented

Generated with [Claude Code](https://claude.com/claude-code)

## Validation

✓ `uv run scripts/validate.py` — 0 errors