### PR TITLE
Add entries: broadcast, stakeholder, stock, pipeline, red-tape

### DIFF
--- a/catalog/entries/broadcast.md
+++ b/catalog/entries/broadcast.md
@@ -13,6 +13,7 @@ contributors: []
 related: []
 created: '2026-03-17'
 updated: '2026-03-17'
+harness: Claude Code
 transfers:
   - "[source] seeds are scattered widely by hand across a field without selecting individual landing spots, mapping onto signals or messages distributed to all receivers without choosing specific recipients"
   - "[source] the sower walks a path and casts outward in arcs, covering ground systematically but imprecisely, mapping onto transmitters radiating in patterns that blanket a geographic area"

--- a/catalog/entries/pipeline.md
+++ b/catalog/entries/pipeline.md
@@ -16,6 +16,7 @@ related:
   - bottleneck
 created: '2026-03-17'
 updated: '2026-03-17'
+harness: Claude Code
 transfers:
   - "[source] fluid flows through a pipe in one direction from source to destination, with each section carrying the same material forward, mapping onto sequential stages that move items (deals, candidates, code) from start to finish"
   - "[source] a pipe has fixed capacity determined by its diameter, and exceeding that capacity causes pressure buildup or rupture, mapping onto process stages with throughput limits that create backlogs when overloaded"

--- a/catalog/entries/red-tape.md
+++ b/catalog/entries/red-tape.md
@@ -14,6 +14,7 @@ contributors: []
 related: []
 created: '2026-03-17'
 updated: '2026-03-17'
+harness: Claude Code
 transfers:
   - "[source] physical ribbon binds documents together and must be untied before any paper can be accessed, mapping onto procedural requirements that must be completed before action can be taken"
   - "[source] the red color of the binding tape marks documents as official government or legal records, distinguishing them from ordinary papers, mapping onto the idea that bureaucratic procedures signal institutional authority"

--- a/catalog/entries/stakeholder.md
+++ b/catalog/entries/stakeholder.md
@@ -14,6 +14,7 @@ contributors: []
 related: []
 created: '2026-03-17'
 updated: '2026-03-17'
+harness: Claude Code
 transfers:
   - "[source] a neutral third party holds the wagered stakes until the outcome is decided, mapping onto organizational actors who hold interest in a venture whose outcome is uncertain"
   - "[source] every gambler who places a stake has something to lose, mapping onto the assumption that legitimate organizational participants must have something at risk"

--- a/catalog/entries/stock.md
+++ b/catalog/entries/stock.md
@@ -14,6 +14,7 @@ contributors: []
 related: []
 created: '2026-03-17'
 updated: '2026-03-17'
+harness: Claude Code
 transfers:
   - "[source] a split tally stick creates two unique halves that must physically rejoin to verify a debt, mapping onto financial instruments that pair a creditor's record with a debtor's obligation"
   - "[source] the stock (larger half) is held by the creditor as proof of the debt, mapping onto equity certificates held by investors as proof of ownership"


### PR DESCRIPTION
## Summary

Five dead metaphor entries from the dead-metaphors project (batch 1, issues #927, #935, #936, #937, #940):

- **broadcast** — horticulture (scattering seeds) -> communication; source_frame: horticulture
- **stakeholder** — gambling (holder of wagered stakes) -> governance; source_frame: gambling
- **stock** — materials (split tally sticks) -> economics; source_frame: materials
- **pipeline** — fluid-dynamics (oil/water pipes) -> systems-performance; source_frame: fluid-dynamics
- **red-tape** — materials (red ribbon binding legal documents) -> governance; source_frame: materials

All entries include full body sections (Transfers, Limits, Expressions, Origin Story, References) and frontmatter `transfers`/`limits` propositions for vector search. All use `kind: metaphor` with `dead: true`.

Closes #927, Closes #935, Closes #936, Closes #937, Closes #940

## Validator output

Zero errors from new entries. 39 pre-existing errors (empty Transfers sections in other entries) and 32 pre-existing warnings (dangling references) — none introduced by this PR.

## Test plan

- [ ] Verify each entry has correct frontmatter (slug matches filename, frames exist, categories exist)
- [ ] Verify Transfers sections have substantive structural parallels
- [ ] Verify Limits sections are substantive (not throwaway)
- [ ] Verify Expressions cite real usage, not invented examples
- [ ] Verify Origin Story sections document etymological chain
- [ ] Run `uv run scripts/validate.py validate` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Validation

✓ `uv run scripts/validate.py` — 0 errors