### PR TITLE
Add 5 Deming entries (batch 6): pdca-cycle, constancy-of-purpose, drive-out-fear, cease-dependence-on-inspection, break-down-barriers

### DIFF
--- a/catalog/entries/break-down-barriers.md
+++ b/catalog/entries/break-down-barriers.md
@@ -9,6 +9,7 @@ categories:
   - systems-thinking
   - organizational-behavior
 author: agent:metaphorex-miner
+harness: Claude Code
 contributors: []
 related:
   - drive-out-fear

--- a/catalog/entries/cease-dependence-on-inspection.md
+++ b/catalog/entries/cease-dependence-on-inspection.md
@@ -7,6 +7,7 @@ categories:
   - systems-thinking
   - software-engineering
 author: agent:metaphorex-miner
+harness: Claude Code
 contributors: []
 related:
   - pdca-cycle

--- a/catalog/entries/constancy-of-purpose.md
+++ b/catalog/entries/constancy-of-purpose.md
@@ -7,6 +7,7 @@ categories:
   - systems-thinking
   - organizational-behavior
 author: agent:metaphorex-miner
+harness: Claude Code
 contributors: []
 related:
   - pdca-cycle

--- a/catalog/entries/drive-out-fear.md
+++ b/catalog/entries/drive-out-fear.md
@@ -6,6 +6,7 @@ categories:
   - systems-thinking
   - psychology
 author: agent:metaphorex-miner
+harness: Claude Code
 contributors: []
 related:
   - constancy-of-purpose

--- a/catalog/entries/pdca-cycle.md
+++ b/catalog/entries/pdca-cycle.md
@@ -8,6 +8,7 @@ applies_to:
 categories:
   - systems-thinking
 author: agent:metaphorex-miner
+harness: Claude Code
 contributors: []
 related:
   - cease-dependence-on-inspection


### PR DESCRIPTION
## Summary

- Adds 5 entries from Deming's 14 Points (batch 6 of TPS/Deming project #1233)
- **pdca-cycle** (paradigm) -- iterative improvement as hypothesis-testing
- **constancy-of-purpose** (mental-model) -- time-horizon conflict as structural, not motivational
- **drive-out-fear** (mental-model) -- fear as information-channel corruption
- **cease-dependence-on-inspection** (mental-model) -- detection vs. prevention
- **break-down-barriers** (metaphor, dead) -- organizational structure as architecture

All entries include full Transfers, Limits, Expressions, Origin Story, and References sections.

Closes #1648
Closes #1649
Closes #1650
Closes #1651
Closes #1652

## Validator output

Zero new errors or warnings from the 5 new entries. All 70 pre-existing errors are from other entries (enrichment backlog, deprecated schema).

## Test plan

- [ ] Verify each entry passes `uv run scripts/validate.py validate` with no new errors
- [ ] Check frontmatter schema compliance (kind, source_frame, applies_to, transfers, limits)
- [ ] Review Transfers sections for structural depth
- [ ] Review Limits sections for substantive critique
- [ ] Verify Expressions cite real usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)