### PR TITLE
Fix kaizen #1676: Add kaizen reporting to surveyor + label flag to all agents

### DIFF
--- a/.claude/agents/assayer.md
+++ b/.claude/agents/assayer.md
@@ -157,6 +157,7 @@ forced a workaround, file a kaizen issue:
 ```bash
 gh issue create -R metaphorex/metaphorex \
   --template kaizen.yml \
+  --label "kaizen:pipeline" \
   --title "kaizen: <short description>" \
   --body "**Area:** <area>
 

--- a/.claude/agents/miner.md
+++ b/.claude/agents/miner.md
@@ -261,6 +261,7 @@ forced a workaround, file a kaizen issue:
 ```bash
 gh issue create -R metaphorex/metaphorex \
   --template kaizen.yml \
+  --label "kaizen:pipeline" \
   --title "kaizen: <short description>" \
   --body "**Area:** <area>
 

--- a/.claude/agents/prospector.md
+++ b/.claude/agents/prospector.md
@@ -223,6 +223,7 @@ forced a workaround, file a kaizen issue:
 ```bash
 gh issue create -R metaphorex/metaphorex \
   --template kaizen.yml \
+  --label "kaizen:pipeline" \
   --title "kaizen: <short description>" \
   --body "**Area:** <area>
 

--- a/.claude/agents/smelter.md
+++ b/.claude/agents/smelter.md
@@ -156,6 +156,7 @@ forced a workaround, file a kaizen issue:
 ```bash
 gh issue create -R metaphorex/metaphorex \
   --template kaizen.yml \
+  --label "kaizen:pipeline" \
   --title "kaizen: <short description>" \
   --body "**Area:** <area>
 

--- a/.claude/agents/surveyor.md
+++ b/.claude/agents/surveyor.md
@@ -134,3 +134,30 @@ After posting your review, update labels on the import-project issue:
 - You don't extract entries (that's the Miner)
 - You don't review entry content (that's the Assayer)
 - You don't merge PRs (pitboss handles merge after approval)
+
+## Kaizen reporting
+
+At the end of your run, if you encountered friction that slowed you down or
+forced a workaround, file a kaizen issue:
+
+```bash
+gh issue create -R metaphorex/metaphorex \
+  --template kaizen.yml \
+  --label "kaizen:pipeline" \
+  --title "kaizen: <short description>" \
+  --body "**Area:** <area>
+
+**What happened:**
+<description of the friction>
+
+**Suggested fix:**
+<what would make this better>"
+```
+
+Rules:
+- Search open kaizen issues first: `gh issue list -R metaphorex/metaphorex --label kaizen:pipeline --state open`
+- One issue per distinct problem — don't bundle unrelated friction
+- File at the end of your run, not mid-task
+- Don't file for transient errors (network blips, rate limits, GitHub 502s)
+- Do file for: schema limitations, missing validation rules, unclear playbook
+  instructions, GitHub API quirks that required workarounds


### PR DESCRIPTION
## Summary

Fixes #1676 (gaps 1 and 4).

- **Gap 1:** Added the standard "Kaizen reporting" section to `.claude/agents/surveyor.md`. The surveyor was the only production agent missing it, meaning any friction it encountered would go unreported.
- **Gap 4:** Added `--label "kaizen:pipeline"` to the `gh issue create` command in all five agent kaizen sections (miner, smelter, assayer, prospector, surveyor). The existing commands relied on `--template kaizen.yml` for label assignment, but GitHub issue templates don't reliably apply labels in non-interactive CLI mode. The explicit `--label` flag is the backup.

## Files changed

- `.claude/agents/surveyor.md` -- added entire kaizen reporting section (with label flag)
- `.claude/agents/miner.md` -- added `--label "kaizen:pipeline"` to existing gh issue create
- `.claude/agents/smelter.md` -- same
- `.claude/agents/assayer.md` -- same
- `.claude/agents/prospector.md` -- same

## Test plan

- [x] Verified diff is minimal: 31 insertions across 5 files, no deletions of existing content
- [x] Verified the surveyor's new kaizen section matches the boilerplate used by all other agents
- [x] Verified all five agents now have `--label "kaizen:pipeline"` in their gh issue create command
- [ ] No script changes, so no validate.py run needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)