### PR TITLE
Fix kaizen #1576: use ?ref= query param in gh api contents calls

### DIFF
--- a/.claude/agents/assayer.md
+++ b/.claude/agents/assayer.md
@@ -41,6 +41,23 @@ value. You do the same for extracted entries.
 3. Push fixup commits for mechanical issues
 4. Post GitHub reviews (approve / request changes)
 
+**Reading files from PR branches:**
+
+When you need to read a file from a PR branch via the GitHub API, pass the
+branch ref as a URL query parameter. The `--ref` flag does not exist on
+`gh api`:
+
+```bash
+# Correct — branch as query param:
+gh api "repos/metaphorex/metaphorex/contents/catalog/entries/some-slug.md?ref=branch-name" --jq '.content' | base64 -d
+
+# WRONG — --ref is not a gh api flag:
+# gh api repos/.../contents/path --ref branch-name
+```
+
+Prefer checking out the PR branch locally (`gh pr checkout <N>`) when you
+need to read multiple files or run the validator.
+
 **Review Process:**
 
 1. Read the PR diff — entry files, frame files, category files

--- a/.claude/agents/smelter.md
+++ b/.claude/agents/smelter.md
@@ -43,6 +43,23 @@ transform raw mining output into clean, validated content.
 2. Run mechanical checks and push fixup commits
 3. Advance PRs to `needs-assay` or flag as `needs-miner-fix`
 
+**Reading files from PR branches:**
+
+When you need to read a file from a PR branch via the GitHub API, pass the
+branch ref as a URL query parameter. The `--ref` flag does not exist on
+`gh api`:
+
+```bash
+# Correct — branch as query param:
+gh api "repos/metaphorex/metaphorex/contents/catalog/entries/some-slug.md?ref=branch-name" --jq '.content' | base64 -d
+
+# WRONG — --ref is not a gh api flag:
+# gh api repos/.../contents/path --ref branch-name
+```
+
+Prefer checking out the PR branch locally (`gh pr checkout <N>`) when you
+need to read multiple files or run the validator.
+
 **Process:**
 
 1. Query: `gh pr list -R metaphorex/metaphorex --label needs-smelting --limit 2`


### PR DESCRIPTION
## Summary
- Add "Reading files from PR branches" guidance to assayer and smelter agent prompts
- Documents correct `?ref=<branch>` query param pattern (the `--ref` flag does not exist on `gh api`)
- Preventive fix: agents were improvising the wrong pattern at runtime because no canonical example existed in their prompts

## What was broken
The `gh api` command does not support a `--ref` flag. To fetch file contents from a specific branch, the ref must be passed as a URL query parameter: `?ref=<branch>`. Agents (assayer, smelter) that need to read catalog files from PR branches had no guidance on the correct pattern, so they generated the non-existent `--ref` flag, causing API calls to fail.

## What the fix does
Adds a "Reading files from PR branches" section to both `.claude/agents/assayer.md` and `.claude/agents/smelter.md` with the correct pattern and a commented-out counter-example showing the wrong pattern.

Closes #1576

## Test plan
- [x] Grep confirms no uncommented `gh api ... contents ... --ref` in any agent prompt
- [x] Only 2 files changed, minimal diff (17 lines added to each)

Generated with [Claude Code](https://claude.com/claude-code)