### PR TITLE
Fix kaizen #1432: Add worktree branch guard to miner agent

### DIFF
--- a/.claude/agents/miner.md
+++ b/.claude/agents/miner.md
@@ -201,6 +201,22 @@ When writing entries, prioritize:
 
 Avoid restating what any educated reader already knows about the metaphor.
 
+**Git Safety (worktree guard):**
+
+Nested worktrees can cause commits on unintended branches. At the start of
+every run, perform these two checks:
+
+1. **Verify repo root.** Run `git rev-parse --show-toplevel` and confirm the
+   output matches the expected repository root. If it does not, abort
+   immediately with a clear error — do not proceed with any git operations.
+2. **Verify branch before committing.** Before every `git commit` or
+   `gh pr create`, run `git branch --show-current` and confirm it matches the
+   branch you created for this task. If the branch name is wrong, abort with a
+   clear error — do not commit to the wrong branch.
+
+If either check fails, stop work and report the mismatch in a comment on the
+source issue. Do not attempt to fix the worktree state yourself.
+
 **Git Workflow:**
 
 - Create a branch: `mine/<project-name>/<slug>`


### PR DESCRIPTION
## Summary

- Fixes #1432 -- nested worktrees cause branch confusion for miner agents
- Added a **Git Safety (worktree guard)** section to `.claude/agents/miner.md`
- The section requires miners to verify `git rev-parse --show-toplevel` matches the expected repo root at run start, and `git branch --show-current` matches the intended branch before every commit or PR creation
- If either check fails, the miner aborts and reports the mismatch on the source issue

## What was broken

When miners run inside nested worktrees (e.g., `.claude/worktrees/agent-*`), `git checkout` and `git commit` can silently operate on the wrong working tree, causing commits on unintended branches.

## What the fix does

Adds two mandatory pre-flight checks to the miner's instructions:
1. Repo root verification at the start of every run
2. Branch name verification before every commit or PR creation

Both checks are fail-safe: mismatch means abort, not attempt to self-correct.

## Test plan

- [ ] Verify the new section renders correctly in the agent file
- [ ] Confirm no other files were changed (minimal diff)

Generated with [Claude Code](https://claude.com/claude-code)