### PR TITLE
Fix kaizen #1683: add duplicate section and deprecated heading checks

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -49,6 +49,13 @@ REJECTED_KINDS = {"conceptual-metaphor", "dead-metaphor", "cross-field-mapping"}
 
 REQUIRED_MAPPING_SECTIONS = {"Transfers", "Limits", "Expressions"}
 
+# Legacy headings that should be replaced with canonical names
+DEPRECATED_HEADINGS = {
+    "Where It Breaks": "Limits",
+    "What It Brings": "Transfers",
+    "What It Enables": "Expressions",
+}
+
 
 def slugs_in(directory: Path) -> set[str]:
     """Collect all slugs from frontmatter in a directory."""
@@ -194,6 +201,24 @@ def validate_entry(path: Path, frame_slugs: set[str], category_slugs: set[str],
             errors.append(f"{prefix}: missing required section '## {section}'")
         elif not sections[section]:
             errors.append(f"{prefix}: section '## {section}' is empty")
+
+    # Duplicate section check — parse_sections silently overwrites duplicates,
+    # so count headings directly from the raw markdown body
+    heading_counts: dict[str, int] = {}
+    for line in post.content.split("\n"):
+        m = re.match(r"^## (.+)$", line)
+        if m:
+            h = m.group(1).strip()
+            heading_counts[h] = heading_counts.get(h, 0) + 1
+    for section in REQUIRED_MAPPING_SECTIONS:
+        count = heading_counts.get(section, 0)
+        if count > 1:
+            errors.append(f"{prefix}: duplicate section '## {section}' appears {count} times")
+
+    # Deprecated heading check
+    for heading, replacement in DEPRECATED_HEADINGS.items():
+        if heading in heading_counts:
+            errors.append(f"{prefix}: deprecated section '## {heading}' — use '## {replacement}'")
 
 
 def validate_frame(path: Path, frame_slugs: set[str], errors: list[str], warnings: list[str]) -> None:


### PR DESCRIPTION
## Summary

Fixes #1683

- **Duplicate section check**: After parsing body sections, the validator now counts raw `## ` headings in the markdown body and errors if any required heading (`## Transfers`, `## Limits`, `## Expressions`) appears more than once. Previously, `parse_sections()` used a dict so duplicates were silently overwritten.

- **Deprecated heading check**: The validator now errors on legacy headings (`## Where It Breaks`, `## What It Brings`, `## What It Enables`) and suggests the canonical replacement (`## Limits`, `## Transfers`, `## Expressions`).

## What was broken

`parse_sections()` returns a `dict[str, str]`, so if an entry had `## Expressions` twice, the second overwrote the first with no error. Legacy headings like `## Where It Breaks` were never flagged -- entries using them would only get a "missing required section" error for `## Limits` without explaining why.

## What changed

Added a `DEPRECATED_HEADINGS` mapping constant and two new check blocks in `validate_entry()` (after the existing required-sections check):
1. Count all `## ` headings in raw content; error if any required section appears more than once.
2. Error if any deprecated heading is present, with a message naming the canonical replacement.

## Test plan

- [x] `uv run scripts/validate.py validate` runs successfully (exits 1 due to pre-existing content issues now correctly caught -- 183 new errors across entries with legacy headings and duplicate sections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)