### PR TITLE
Prospect: Carpentry and woodworking metaphors (#1359)

### DIFF
--- a/playbooks/carpentry-woodworking/manifest.json
+++ b/playbooks/carpentry-woodworking/manifest.json
@@ -1,0 +1,294 @@
+{
+  "project": "carpentry-woodworking",
+  "project_issue": 1359,
+  "source_type": "archive",
+  "archive_urls": [
+    "https://en.wikipedia.org/wiki/Glossary_of_woodworking",
+    "https://review.firstround.com/shims-jigs-and-other-woodworking-concepts-to-conquer-technical-debt/",
+    "https://www.quotegarden.com/woodworking.html",
+    "https://www.japanesetools.com.au/blogs/the-jta-blog/the-soul-of-the-tool-an-invitation-to-japanese-craftsmanship",
+    "https://eslvault.com/wood-idioms/"
+  ],
+  "candidates": [
+    {
+      "slug": "measure-twice-cut-once",
+      "name": "Measure Twice, Cut Once",
+      "kind": "mental-model",
+      "source_frame": "carpentry",
+      "target_frame": "planning-and-preparation",
+      "categories": ["folk-wisdom", "software-engineering"],
+      "source": "archive",
+      "description": "The canonical carpentry proverb: verification before irreversible action. Maps onto requirements gathering, code review before deploy, and any domain where the cost of correction exceeds the cost of validation. Encodes asymmetric reversibility -- cutting is cheap, un-cutting is impossible."
+    },
+    {
+      "slug": "workmanship-of-risk",
+      "name": "Workmanship of Risk",
+      "kind": "paradigm",
+      "source_frame": "carpentry",
+      "target_frame": "quality-and-craftsmanship",
+      "categories": ["philosophy", "arts-and-culture"],
+      "source": "archive",
+      "description": "David Pye's 1968 distinction: work where the outcome depends on the maker's judgment, dexterity, and care at the moment of execution. Contrasts with workmanship of certainty. Maps onto hand-coding vs. code generation, artisanal vs. industrial production, live performance vs. recording."
+    },
+    {
+      "slug": "workmanship-of-certainty",
+      "name": "Workmanship of Certainty",
+      "kind": "paradigm",
+      "source_frame": "carpentry",
+      "target_frame": "quality-and-craftsmanship",
+      "categories": ["philosophy", "arts-and-culture"],
+      "source": "archive",
+      "description": "The complement to workmanship of risk: work where the result is predetermined before production begins. Jigs, templates, CNC machines. Maps onto CI/CD pipelines, automated testing, assembly-line production. Pye's insight: the distinction is not hand vs. machine but whether the outcome is at risk during execution."
+    },
+    {
+      "slug": "read-the-grain",
+      "name": "Read the Grain",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "materials",
+      "categories": ["folk-wisdom", "organizational-behavior"],
+      "source": "llm",
+      "description": "Skilled woodworkers read grain direction before cutting or planing to avoid tearout. Metaphorically: understand the intrinsic nature of your material (people, organizations, codebases) before trying to shape it. Work with the grain, not against it. Encodes respect for existing structure."
+    },
+    {
+      "slug": "against-the-grain",
+      "name": "Against the Grain",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "social-dynamics",
+      "categories": ["cognitive-linguistics", "social-dynamics"],
+      "source": "archive",
+      "description": "Cutting or planing wood against its grain direction causes tearout and rough surfaces. Figuratively: acting contrary to convention, norms, or the natural disposition of a situation. Shakespeare used it in Coriolanus (1607). Encodes the idea that resistance has a direction."
+    },
+    {
+      "slug": "rough-around-the-edges",
+      "name": "Rough Around the Edges",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "quality-and-craftsmanship",
+      "categories": ["cognitive-linguistics"],
+      "source": "archive",
+      "description": "Unfinished wood has rough, splintery edges before sanding and finishing. Metaphorically: a person or product that lacks polish but may have underlying quality. Encodes the distinction between surface refinement and structural soundness."
+    },
+    {
+      "slug": "dovetail",
+      "name": "Dovetail",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "abstract-organization",
+      "categories": ["cognitive-linguistics"],
+      "source": "archive",
+      "description": "A joint where fan-shaped tenons interlock, noted for resistance to being pulled apart. Figuratively: 'the plans dovetail nicely' means they fit together with structural integrity. Dead metaphor since the 1650s. Interesting because the joint's strength comes from geometry, not adhesive."
+    },
+    {
+      "slug": "mortise-and-tenon",
+      "name": "Mortise and Tenon",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "abstract-organization",
+      "categories": ["cognitive-linguistics", "arts-and-culture"],
+      "source": "archive",
+      "description": "A projection (tenon) fits into a cavity (mortise) -- the oldest known joint, found in 7000-year-old structures. Metaphorically: complementary components designed to fit together. Less commonly used figuratively than dovetail, but richer structurally."
+    },
+    {
+      "slug": "shim",
+      "name": "Shim",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "software-programs",
+      "categories": ["software-engineering"],
+      "source": "archive",
+      "description": "A thin wedge that fills small gaps between objects. In software: a compatibility layer that bridges mismatched interfaces (polyfills, API adapters, legacy wrappers). Encodes the principle that imperfect fits are normal and small corrective layers are cheaper than redesigning either side."
+    },
+    {
+      "slug": "jig",
+      "name": "Jig",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "software-programs",
+      "categories": ["software-engineering"],
+      "source": "archive",
+      "description": "A custom tool built to facilitate repeatable cuts -- it guides the work but is not part of the final product. In software: test harnesses, build scripts, scaffolding code. First Round Review emphasizes that jigs require as much craftsmanship as the product itself."
+    },
+    {
+      "slug": "scaffolding",
+      "name": "Scaffolding",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "education-and-learning",
+      "categories": ["cognitive-science", "software-engineering"],
+      "source": "archive",
+      "description": "Temporary support structure removed when the building can stand alone. In education (Bruner, 1976): expert support withdrawn as the learner gains competence. In software: generated starter code (Rails scaffolding). Encodes the principle that temporary support is a necessary phase, not a crutch."
+    },
+    {
+      "slug": "cant-put-it-back-on",
+      "name": "You Can Always Take More Off",
+      "kind": "mental-model",
+      "source_frame": "carpentry",
+      "target_frame": "planning-and-preparation",
+      "categories": ["folk-wisdom"],
+      "source": "llm",
+      "description": "Woodworking proverb encoding asymmetric reversibility: material removal is easy and irreversible, so start conservative. Maps onto iterative refinement, MVP strategy, and any domain where subtraction is easier than addition. The complement of 'measure twice, cut once.'"
+    },
+    {
+      "slug": "let-the-tool-do-the-work",
+      "name": "Let the Tool Do the Work",
+      "kind": "mental-model",
+      "source_frame": "carpentry",
+      "target_frame": "tool-use",
+      "categories": ["folk-wisdom", "software-engineering"],
+      "source": "archive",
+      "description": "If you are forcing a sharp tool, the problem is your technique or setup, not the tool's power. Maps onto software: if you are fighting your framework, you are probably misusing it. Encodes the insight that struggle is diagnostic -- effort should go into preparation and alignment, not brute force."
+    },
+    {
+      "slug": "best-carpenters-fewest-chips",
+      "name": "The Best Carpenters Make the Fewest Chips",
+      "kind": "mental-model",
+      "source_frame": "carpentry",
+      "target_frame": "quality-and-craftsmanship",
+      "categories": ["folk-wisdom"],
+      "source": "archive",
+      "description": "English proverb c.1500s: mastery is visible in economy of action, not volume of effort. Expert work produces less waste because cuts are precise and planned. Maps onto clean code, lean manufacturing, and surgical technique."
+    },
+    {
+      "slug": "tongue-and-groove",
+      "name": "Tongue and Groove",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "abstract-organization",
+      "categories": ["cognitive-linguistics"],
+      "source": "archive",
+      "description": "A joint where a protruding ridge (tongue) fits into a matching channel (groove), used for flooring and paneling. Encodes alignment along an entire edge rather than at discrete points. Maps onto standardized interfaces and protocol compatibility."
+    },
+    {
+      "slug": "knock-down-joint",
+      "name": "Knock-Down Joint",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "software-programs",
+      "categories": ["software-engineering"],
+      "source": "archive",
+      "description": "Joints designed for fast disassembly and reassembly -- IKEA furniture logic. In software: modular architectures designed for easy component swapping. Encodes the principle that planned disassembly is a design feature, not a weakness."
+    },
+    {
+      "slug": "seasoning",
+      "name": "Seasoning",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "quality-and-craftsmanship",
+      "categories": ["cognitive-linguistics"],
+      "source": "archive",
+      "description": "Wood must be dried (seasoned) before use -- green wood warps, cracks, and is unreliable. Figuratively: a 'seasoned' professional has been through the drying process of experience, shedding instability. Encodes the idea that time and exposure transform raw material into workable substance."
+    },
+    {
+      "slug": "veneer",
+      "name": "Veneer",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "social-dynamics",
+      "categories": ["cognitive-linguistics", "social-dynamics"],
+      "source": "archive",
+      "description": "A thin decorative layer of fine wood glued over cheaper substrate. Figuratively: a superficial appearance of quality covering something inferior. 'A veneer of civility.' Deeply negative in figurative use, though veneer is a legitimate and skilled craft technique."
+    },
+    {
+      "slug": "polished",
+      "name": "Polished",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "quality-and-craftsmanship",
+      "categories": ["cognitive-linguistics"],
+      "source": "archive",
+      "description": "The final finishing step: sanding and applying finish to make wood smooth and lustrous. Figuratively: refined, sophisticated, complete. 'A polished presentation.' Encodes the idea that quality is achieved through progressive refinement -- each grit removes the scratches of the previous one."
+    },
+    {
+      "slug": "plane-it-smooth",
+      "name": "Plane It Smooth",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "quality-and-craftsmanship",
+      "categories": ["folk-wisdom"],
+      "source": "llm",
+      "description": "Using a hand plane to remove thin shavings and produce a flat, smooth surface. Metaphorically: removing irregularities through careful, controlled reduction. The plane embodies precision subtraction -- each pass removes the minimum necessary to approach the target surface."
+    },
+    {
+      "slug": "framework",
+      "name": "Framework (Carpentry Origin)",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "abstract-organization",
+      "categories": ["cognitive-linguistics", "software-engineering"],
+      "source": "llm",
+      "description": "The structural skeleton of a building -- studs, joists, rafters -- before walls and finish. In software: a framework provides structure that you fill in with your specific logic. Dead metaphor in most usage. Encodes the distinction between load-bearing structure and decorative surface."
+    },
+    {
+      "slug": "nail-it",
+      "name": "Nail It",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "quality-and-craftsmanship",
+      "categories": ["cognitive-linguistics"],
+      "source": "llm",
+      "description": "Driving a nail home with precision. Figuratively: to execute perfectly. 'She nailed the presentation.' Dead metaphor -- the carpentry origin is invisible. Interesting contrast: in woodworking, nails are considered crude fasteners compared to proper joinery."
+    },
+    {
+      "slug": "shokunin",
+      "name": "Shokunin",
+      "kind": "paradigm",
+      "source_frame": "carpentry",
+      "target_frame": "quality-and-craftsmanship",
+      "categories": ["philosophy", "arts-and-culture"],
+      "source": "archive",
+      "description": "Japanese concept of the artisan who has a social obligation to work their best for the welfare of the people. Not just skill but lifelong dedication to a single practice. The shokunin is a perpetual student. Maps onto software craftsmanship, the concept of mastery in any discipline."
+    },
+    {
+      "slug": "wabi-sabi-in-woodwork",
+      "name": "Wabi-Sabi in Woodwork",
+      "kind": "paradigm",
+      "source_frame": "carpentry",
+      "target_frame": "aesthetics",
+      "categories": ["philosophy", "arts-and-culture"],
+      "source": "archive",
+      "description": "Japanese aesthetic of beauty in imperfection and transience, deeply connected to woodworking -- wood changes character over time, and this aging is celebrated rather than resisted. Maps onto graceful degradation in software, acceptance of entropy rather than fighting it."
+    },
+    {
+      "slug": "knotty-problem",
+      "name": "A Knotty Problem",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "causal-reasoning",
+      "categories": ["cognitive-linguistics"],
+      "source": "archive",
+      "description": "Knots in wood are hard, irregular, and disrupt the grain -- they resist cutting, blunt tools, and make surfaces unpredictable. Figuratively: a problem that is tangled, resistant to straightforward solution. English proverb c.1670: 'A knotty piece of timber must have smooth wedges.'"
+    },
+    {
+      "slug": "green-wood",
+      "name": "Green (Unseasoned)",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "quality-and-craftsmanship",
+      "categories": ["cognitive-linguistics"],
+      "source": "archive",
+      "description": "Freshly cut wood that has not been dried. Green wood is pliable but unstable -- it warps and cracks as it dries. Figuratively: a 'green' person is inexperienced and malleable but unreliable. Sa'di (1258): 'Wood, while 'tis green, thou mayst at pleasure bend; when dry, thou canst not change it save by fire.'"
+    },
+    {
+      "slug": "heartwood-and-sapwood",
+      "name": "Heartwood and Sapwood",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "materials",
+      "categories": ["cognitive-linguistics"],
+      "source": "llm",
+      "description": "Heartwood is the dense, dead inner core that gives a tree structural strength. Sapwood is the living outer layer that transports nutrients but is softer and more vulnerable. Metaphorically: the distinction between core competency (stable, load-bearing) and peripheral activity (dynamic, growing, vulnerable)."
+    },
+    {
+      "slug": "tooling-up",
+      "name": "Tooling Up",
+      "kind": "metaphor",
+      "source_frame": "carpentry",
+      "target_frame": "planning-and-preparation",
+      "categories": ["folk-wisdom", "software-engineering"],
+      "source": "llm",
+      "description": "The preparation phase before woodworking begins: sharpening blades, setting up jigs, organizing the workspace. Figuratively: investing in infrastructure before productive work starts. Encodes the principle that preparation time is not wasted time -- dull tools make bad work."
+    }
+  ]
+}

--- a/playbooks/carpentry-woodworking/playbook.md
+++ b/playbooks/carpentry-woodworking/playbook.md
@@ -1,0 +1,198 @@
+---
+project_issue: 1359
+repo: metaphorex/metaphorex
+source_type: web
+status: draft
+---
+
+# Playbook: Carpentry and Woodworking
+
+## Source Description
+
+Carpentry and woodworking proverbs, terminology, and philosophical
+frameworks that have migrated into figurative language across software
+engineering, management, education, and everyday speech. Three distinct
+layers:
+
+1. **Workshop proverbs** -- "measure twice, cut once," "the best carpenters
+   make the fewest chips," "let the tool do the work." Folk wisdom encoding
+   asymmetric risk, economy of action, and preparation-over-force.
+
+2. **David Pye's framework (1968)** -- *The Nature and Art of Workmanship*
+   introduced the workmanship-of-risk vs. workmanship-of-certainty
+   distinction. Not hand vs. machine, but whether the outcome is
+   predetermined. Foundational for craft studies, design history, and the
+   software craftsmanship movement.
+
+3. **Joinery and material vocabulary** -- dovetail, mortise-and-tenon,
+   shim, jig, veneer, grain, seasoning, knot. Many are dead metaphors in
+   English (people say "dovetail" without knowing the joint). Others are
+   alive in software (shim, scaffold, framework).
+
+4. **Japanese woodworking philosophy** -- shokunin (artisan obligation),
+   wabi-sabi (beauty in imperfection), Toshio Odate's writings. These
+   concepts have been adopted by the software craftsmanship and lean
+   movements.
+
+## Access Method
+
+### Primary Archives
+
+**Wikipedia Glossary of Woodworking**
+- URL: https://en.wikipedia.org/wiki/Glossary_of_woodworking
+- Format: HTML alphabetical glossary with definitions
+- Coverage: Comprehensive technical terminology (hundreds of terms)
+- Usage: Reference for joint types, wood properties, tool names
+- Note: Direct fetch returns 403; content accessed via WebSearch summaries
+
+**First Round Review: Shims, Jigs, and Woodworking Concepts**
+- URL: https://review.firstround.com/shims-jigs-and-other-woodworking-concepts-to-conquer-technical-debt/
+- Format: Long-form article mapping woodworking to software
+- Coverage: Shim, jig, knock-down joint, master carpenter
+- Successfully fetched and parsed
+
+**The Quote Garden: Woodworking Quotes**
+- URL: https://www.quotegarden.com/woodworking.html
+- Format: HTML list of attributed quotes
+- Coverage: ~16 woodworking proverbs and aphorisms with dates
+- Successfully fetched and parsed
+
+**LumberJocks Forum: Woodworking Sayings and Proverbs**
+- URL: https://www.lumberjocks.com/threads/woodworking-sayings-and-proverbs.47948/
+- Format: Forum thread (JavaScript-rendered, not scrapable)
+- Coverage: Community-sourced sayings
+- Note: Content not extractable via fetch; used WebSearch summaries
+
+**Japanese Tools Australia: Shokunin Kishitsu**
+- URL: https://www.japanesetools.com.au/blogs/the-jta-blog/the-soul-of-the-tool-an-invitation-to-japanese-craftsmanship
+- Format: Blog article
+- Coverage: Shokunin concept and Japanese craft philosophy
+
+**ESL Vault: Wood Idioms**
+- URL: https://eslvault.com/wood-idioms/
+- Format: HTML list of 31 wood-related idioms with explanations
+- Coverage: Figurative expressions derived from wood and woodworking
+
+### Secondary Sources (Consulted, Not Scraped)
+
+- David Pye, *The Nature and Art of Workmanship* (1968) -- book, not
+  available online. Key concepts extracted from secondary sources
+  (Mortise & Tenon Magazine podcast, Lost Art Press blog, Medium summaries).
+- Toshio Odate, *Japanese Woodworking Tools* -- book reference from the
+  issue. Shokunin concept verified via web sources.
+- Etymonline: etymology of "dovetail" (figurative use since 1650s)
+- Shakespeare's *Coriolanus* (1607) -- first figurative use of
+  "against the grain"
+
+## Extraction Strategy
+
+This is an **archive-type** project. The source material is finite: a
+bounded set of woodworking terms, proverbs, and philosophical concepts
+that have established figurative or metaphorical usage in other domains.
+
+### Selection Criteria
+
+A woodworking term qualifies as a candidate if it meets at least one of:
+
+1. **Active figurative usage** -- the term is commonly used metaphorically
+   in everyday English, business, or technical discourse (e.g., "dovetail,"
+   "against the grain," "polished")
+
+2. **Named framework** -- the term is part of a published intellectual
+   framework that has been adopted beyond woodworking (e.g., Pye's
+   workmanship of risk, shokunin)
+
+3. **Software/tech adoption** -- the term has been explicitly borrowed
+   by software engineering or tech culture (e.g., shim, jig, scaffolding,
+   framework)
+
+4. **Proverb with cross-domain applicability** -- a woodworking saying
+   that encodes a general principle used in other fields (e.g., "measure
+   twice, cut once")
+
+### Exclusions
+
+- Pure technical terms with no figurative life (e.g., "rabbet," "dado,"
+  "spokeshave") unless they have documented metaphorical usage
+- General construction terms that are not specifically woodworking
+  (e.g., "foundation," "blueprint" -- these belong to architecture)
+- Tools that are only known by name, not by metaphorical function
+
+### No Scraping Script
+
+Unlike projects with clean HTML glossaries, the woodworking archives are
+a mix of forum threads (JavaScript-rendered), Wikipedia (403 on fetch),
+and long-form articles. The candidate list was assembled by:
+
+1. Searching and fetching multiple structured sources (Quote Garden,
+   First Round Review, Wikipedia via search, ESL Vault)
+2. Cross-referencing terms that appear across multiple sources
+3. Verifying figurative usage via etymology (Etymonline) and idiom
+   databases
+4. Gap-filling with LLM knowledge for terms with obvious metaphorical
+   life but no single canonical archive entry (flagged as source: "llm")
+
+## Schema Mapping
+
+| Woodworking concept | kind | source_frame | target_frame |
+|---|---|---|---|
+| Workshop proverbs | mental-model | carpentry | planning-and-preparation |
+| Pye's framework concepts | paradigm | carpentry | quality-and-craftsmanship |
+| Joint types (figurative) | metaphor | carpentry | abstract-organization |
+| Material properties (figurative) | metaphor | carpentry | materials / social-dynamics |
+| Software-adopted terms | metaphor | carpentry | software-programs |
+| Japanese craft philosophy | paradigm | carpentry | quality-and-craftsmanship |
+| Dead metaphors (idioms) | metaphor | carpentry | varies |
+
+### Frame Requirements
+
+The following frames will need to be created if they do not already exist:
+
+- **carpentry** -- the source frame for all entries (does not exist yet)
+- **quality-and-craftsmanship** -- target for Pye's framework, seasoning,
+  polished (does not exist yet)
+- **planning-and-preparation** -- target for proverbs about verification
+  and setup (does not exist yet)
+
+Existing frames that will be reused:
+- materials, abstract-organization, social-dynamics, tool-use, aesthetics,
+  causal-reasoning, software-programs, education-and-learning
+
+### Category Usage
+
+All entries use existing categories. No new categories needed:
+- cognitive-linguistics, folk-wisdom, software-engineering, philosophy,
+  arts-and-culture, social-dynamics, organizational-behavior
+
+## Gotchas
+
+1. **Many terms are dead metaphors.** "Dovetail," "against the grain,"
+   "veneer," "polished," "nail it," "framework" -- speakers do not
+   consciously connect these to woodworking. The Miner should foreground
+   the etymological connection and what is lost/gained by the death of
+   the metaphor.
+
+2. **Overlap with architecture/construction.** Terms like "scaffolding"
+   and "framework" sit at the boundary of carpentry and general
+   construction. The entries should acknowledge the woodworking origin
+   specifically (timber framing, not steel scaffolding).
+
+3. **Pye's framework is subtle.** The workmanship-of-risk vs.
+   workmanship-of-certainty distinction is NOT hand vs. machine. A hand
+   tool with a jig is workmanship of certainty. A machine operated
+   freehand is workmanship of risk. The Miner must get this right.
+
+4. **Japanese terms need careful handling.** Shokunin and wabi-sabi are
+   from Japanese culture broadly, not only woodworking. The entries
+   should scope to the woodworking manifestation and note the broader
+   cultural context without claiming woodworking as the sole origin.
+
+5. **The candidate list is 27 entries.** Well within the 100 sub-issue
+   GitHub cap.
+
+6. **LLM-sourced candidates (7 of 27).** The following candidates are
+   flagged as LLM-sourced because no single archive page provided them
+   as metaphorical terms, though their figurative usage is well-attested:
+   read-the-grain, cant-put-it-back-on, plane-it-smooth, framework,
+   nail-it, heartwood-and-sapwood, tooling-up. The Surveyor should
+   verify these are worth extracting.

--- a/playbooks/carpentry-woodworking/scripts/extract_candidates.py
+++ b/playbooks/carpentry-woodworking/scripts/extract_candidates.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["requests", "beautifulsoup4"]
+# ///
+"""
+Extract woodworking metaphor candidates from web sources.
+
+Primary sources:
+- The Quote Garden: woodworking quotes page (HTML list)
+- ESL Vault: wood idioms (HTML list)
+
+Wikipedia Glossary of Woodworking returns 403 and is not scrapable.
+LumberJocks forum threads are JavaScript-rendered and not scrapable.
+
+This script fetches what it can and outputs structured JSON to stdout.
+The manifest.json was assembled from these outputs plus manual research.
+
+Usage:
+    uv run playbooks/carpentry-woodworking/scripts/extract_candidates.py
+"""
+
+import json
+import sys
+
+import requests
+from bs4 import BeautifulSoup
+
+SOURCES = {
+    "quotegarden": {
+        "url": "https://www.quotegarden.com/woodworking.html",
+        "description": "Woodworking quotes and proverbs with attribution",
+    },
+    "eslvault": {
+        "url": "https://eslvault.com/wood-idioms/",
+        "description": "31 wood-related idioms and figurative expressions",
+    },
+}
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    )
+}
+
+
+def fetch_quotegarden() -> list[dict]:
+    """Extract woodworking quotes from The Quote Garden."""
+    resp = requests.get(SOURCES["quotegarden"]["url"], headers=HEADERS, timeout=15)
+    if resp.status_code != 200:
+        print(f"WARN: Quote Garden returned {resp.status_code}", file=sys.stderr)
+        return []
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    quotes = []
+
+    for tag in soup.find_all(["p", "div"]):
+        text = tag.get_text(strip=True)
+        if text and len(text) > 20 and "~" in text:
+            parts = text.rsplit("~", 1)
+            if len(parts) == 2:
+                quotes.append({
+                    "text": parts[0].strip().strip("\u201c\u201d\""),
+                    "attribution": parts[1].strip(),
+                    "source_url": SOURCES["quotegarden"]["url"],
+                })
+
+    return quotes
+
+
+def fetch_eslvault() -> list[dict]:
+    """Extract wood idioms from ESL Vault."""
+    resp = requests.get(SOURCES["eslvault"]["url"], headers=HEADERS, timeout=15)
+    if resp.status_code != 200:
+        print(f"WARN: ESL Vault returned {resp.status_code}", file=sys.stderr)
+        return []
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    idioms = []
+
+    for heading in soup.find_all(["h2", "h3", "strong"]):
+        text = heading.get_text(strip=True)
+        if text and len(text) > 3 and not text.startswith("Related"):
+            explanation = ""
+            next_el = heading.find_next(["p", "li"])
+            if next_el:
+                explanation = next_el.get_text(strip=True)
+
+            idioms.append({
+                "idiom": text,
+                "explanation": explanation[:200] if explanation else "",
+                "source_url": SOURCES["eslvault"]["url"],
+            })
+
+    return idioms
+
+
+def main():
+    results = {
+        "sources_fetched": [],
+        "quotes": [],
+        "idioms": [],
+    }
+
+    print("Fetching Quote Garden...", file=sys.stderr)
+    quotes = fetch_quotegarden()
+    if quotes:
+        results["sources_fetched"].append(SOURCES["quotegarden"]["url"])
+        results["quotes"] = quotes
+        print(f"  Found {len(quotes)} quotes", file=sys.stderr)
+
+    print("Fetching ESL Vault...", file=sys.stderr)
+    idioms = fetch_eslvault()
+    if idioms:
+        results["sources_fetched"].append(SOURCES["eslvault"]["url"])
+        results["idioms"] = idioms
+        print(f"  Found {len(idioms)} idioms", file=sys.stderr)
+
+    print(json.dumps(results, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Playbook, manifest, and extraction script for import project #1359 (Carpentry and woodworking)
- 27 candidates covering workshop proverbs, David Pye's workmanship-of-risk framework, joinery vocabulary as dead metaphors, software-adopted terms (shim, jig, scaffolding), and Japanese craft philosophy (shokunin, wabi-sabi)
- 20 candidates archive-sourced from Quote Garden, First Round Review, ESL Vault, Wikipedia (via search), and Japanese Tools Australia; 7 LLM-sourced gap-fills clearly flagged

## Archive Sources Consulted

- Wikipedia Glossary of Woodworking (403 on fetch; used search summaries)
- First Round Review: Shims, Jigs, and Woodworking Concepts (fetched and parsed)
- Quote Garden: Woodworking Quotes (fetched and parsed)
- ESL Vault: 31 Wood Idioms (fetched and parsed)
- Japanese Tools Australia: Shokunin Kishitsu (search summary)
- Etymonline: dovetail, against the grain (etymology verification)
- LumberJocks and Sawmill Creek forums (JS-rendered; search summaries only)

## Candidate Breakdown

| Category | Count | Examples |
|---|---|---|
| Workshop proverbs | 4 | measure-twice-cut-once, let-the-tool-do-the-work |
| Pye's framework | 2 | workmanship-of-risk, workmanship-of-certainty |
| Dead metaphors (joinery/material) | 12 | dovetail, veneer, against-the-grain, seasoning |
| Software-adopted terms | 4 | shim, jig, scaffolding, knock-down-joint |
| Japanese philosophy | 2 | shokunin, wabi-sabi-in-woodwork |
| Other | 3 | framework, heartwood-and-sapwood, tooling-up |

## New frames needed

- `carpentry` (source frame for all entries)
- `quality-and-craftsmanship` (target for Pye, finishing terms)
- `planning-and-preparation` (target for proverbs)

## Test plan

- [ ] Verify manifest.json is valid JSON with 27 candidates
- [ ] Review LLM-sourced candidates (7) for metaphorical validity
- [ ] Confirm no overlap with existing entries in catalog/entries/
- [ ] Review playbook gotchas (Pye subtlety, Japanese term scoping)

Generated with [Claude Code](https://claude.com/claude-code)