### PR TITLE
Re-prospect: Hauser & Reich Notes on Directing (#1232)

### DIFF
--- a/playbooks/hauser-reich-directing/manifest.json
+++ b/playbooks/hauser-reich-directing/manifest.json
@@ -1,0 +1,175 @@
+{
+  "project": "hauser-reich-directing",
+  "project_issue": 1232,
+  "source_type": "archive",
+  "archive_urls": [
+    "https://www.goodreads.com/work/quotes/246935-notes-on-directing",
+    "https://www.leadershipnow.com/leadershop/9780802717085.html",
+    "https://fluidself.org/books/art/impro",
+    "https://jamesclear.com/book-summaries/impro",
+    "https://taylorpearson.me/bookreview/impro-johnstone-notes/",
+    "https://blas.com/impro/",
+    "https://dramatics.org/understanding-viewpoints/",
+    "https://www.studiobinder.com/blog/walter-murch-rule-of-six/",
+    "https://nofilmschool.com/2016/11/6-rules-good-cutting-according-oscar-winning-editor-walter-murch"
+  ],
+  "candidates": [
+    {
+      "slug": "director-as-obstetrician",
+      "name": "Director as Obstetrician",
+      "kind": "metaphor",
+      "source_frame": "medicine",
+      "target_frame": "theatrical-directing",
+      "categories": ["creative-leadership"],
+      "source": "archive",
+      "archive_url": "https://www.goodreads.com/work/quotes/246935-notes-on-directing",
+      "description": "The director is not the parent of the play but the obstetrician -- present at its birth for clinical reasons, whose job is first to do no harm. Reframes creative leadership as stewardship rather than authorship."
+    },
+    {
+      "slug": "every-scene-is-a-chase-scene",
+      "name": "Every Scene Is a Chase Scene",
+      "kind": "metaphor",
+      "source_frame": "pursuit-and-escape",
+      "target_frame": "theatrical-directing",
+      "categories": ["creative-leadership"],
+      "source": "llm",
+      "description": "Character A wants something from Character B who does not want to give it. Recasts all dramatic (and human) interaction as want-driven negotiation, transferring to sales, management, teaching, and design."
+    },
+    {
+      "slug": "give-actions-not-emotions",
+      "name": "Give Actions Not Emotions",
+      "kind": "mental-model",
+      "source_frame": "theatrical-directing",
+      "target_frame": "feedback-and-communication",
+      "categories": ["creative-leadership"],
+      "source": "llm",
+      "description": "Do not tell the actor what to feel; give them something to do. Transfers to management (specify behaviors not attitudes), teaching (assign tasks not mindsets), and design (affordances not intentions)."
+    },
+    {
+      "slug": "talk-to-the-character-not-the-actor",
+      "name": "Talk to the Character Not the Actor",
+      "kind": "mental-model",
+      "source_frame": "theatrical-directing",
+      "target_frame": "feedback-and-communication",
+      "categories": ["creative-leadership"],
+      "source": "llm",
+      "description": "Address feedback to the role, not the person. Preserves psychological safety by separating identity from performance. Transfers to code review (critique the code not the coder) and management."
+    },
+    {
+      "slug": "you-cannot-create-results-only-conditions",
+      "name": "You Cannot Create Results Only Conditions",
+      "kind": "mental-model",
+      "source_frame": "theatrical-directing",
+      "target_frame": "leadership-and-management",
+      "categories": ["creative-leadership", "systems-thinking"],
+      "source": "llm",
+      "description": "The director sets conditions for discovery rather than prescribing outcomes. Transfers to management, teaching, parenting, and system design -- anywhere indirect control outperforms direct command."
+    },
+    {
+      "slug": "casting-is-ninety-percent",
+      "name": "Casting Is Ninety Percent",
+      "kind": "mental-model",
+      "source_frame": "theatrical-directing",
+      "target_frame": "leadership-and-management",
+      "categories": ["creative-leadership"],
+      "source": "archive",
+      "archive_url": "https://www.leadershipnow.com/leadershop/9780802717085.html",
+      "description": "Sixty to ninety percent of directing is casting. Once you have the right people, much of the work is done. Transfers directly to hiring as the dominant leadership decision."
+    },
+    {
+      "slug": "character-is-conduct",
+      "name": "Character Is Conduct",
+      "kind": "mental-model",
+      "source_frame": "theatrical-directing",
+      "target_frame": "judgment-and-evaluation",
+      "categories": ["creative-leadership"],
+      "source": "archive",
+      "archive_url": "https://www.goodreads.com/work/quotes/246935-notes-on-directing",
+      "description": "We know people primarily by what they do, not what they or others say about them. Aristotle's insight applied to directing: judge character by action. Transfers to hiring, performance evaluation, and trust-building."
+    },
+    {
+      "slug": "just-tell-the-story",
+      "name": "Just Tell the Story",
+      "kind": "mental-model",
+      "source_frame": "theatrical-directing",
+      "target_frame": "communication",
+      "categories": ["creative-leadership"],
+      "source": "llm",
+      "description": "Tell the story as believably and excitingly as possible. Whatever does not tell the story should be subject to a very fishy examination. A ruthless editing principle that transfers to writing, presenting, and product design."
+    },
+    {
+      "slug": "rehearsal-is-not-performance",
+      "name": "Rehearsal Is Not Performance",
+      "kind": "metaphor",
+      "source_frame": "theatrical-directing",
+      "target_frame": "learning-and-development",
+      "categories": ["creative-leadership"],
+      "source": "llm",
+      "description": "Rehearsal requires a different psychology than performance -- a safe space for experimentation, failure, and discovery. Transfers to prototyping, staging environments, practice sessions, and psychological safety."
+    },
+    {
+      "slug": "status-transactions",
+      "name": "Status Transactions",
+      "kind": "metaphor",
+      "source_frame": "economics",
+      "target_frame": "social-dynamics",
+      "categories": ["improvisation", "social-dynamics"],
+      "source": "archive",
+      "archive_url": "https://fluidself.org/books/art/impro",
+      "description": "Johnstone's insight that every human interaction is a status transaction -- status as something you do, not something you are. Every movement and inflection implies a status level. Transfers to negotiation, management, and social design."
+    },
+    {
+      "slug": "offers-and-blocks",
+      "name": "Offers and Blocks",
+      "kind": "metaphor",
+      "source_frame": "improvisation",
+      "target_frame": "collaboration",
+      "categories": ["improvisation", "creative-leadership"],
+      "source": "archive",
+      "archive_url": "https://fluidself.org/books/art/impro",
+      "description": "An offer is any action a partner can accept or reject. Blocking is aggression that prevents scene development. Acceptance allows scenes to generate themselves. Transfers to brainstorming, collaboration, and innovation culture."
+    },
+    {
+      "slug": "the-magic-if",
+      "name": "The Magic If",
+      "kind": "mental-model",
+      "source_frame": "theatrical-directing",
+      "target_frame": "imagination-and-creativity",
+      "categories": ["acting-technique"],
+      "source": "archive",
+      "archive_url": "https://www.backstage.com/magazine/article/the-definitive-guide-to-the-stanislavsky-acting-technique-65716/",
+      "description": "Stanislavski's technique: 'What would I do IF I were in these circumstances?' Converts intellectual analysis into embodied imagination. Transfers to empathy exercises, scenario planning, design thinking, and user-centered design."
+    },
+    {
+      "slug": "the-rule-of-six",
+      "name": "The Rule of Six",
+      "kind": "mental-model",
+      "source_frame": "film-editing",
+      "target_frame": "decision-making",
+      "categories": ["creative-leadership"],
+      "source": "archive",
+      "archive_url": "https://nofilmschool.com/2016/11/6-rules-good-cutting-according-oscar-winning-editor-walter-murch",
+      "description": "Murch's six ranked criteria for an ideal cut: emotion (51%), story, rhythm, eye-trace, planarity, spatial continuity. The hierarchy is the insight -- emotion outweighs everything else combined. Transfers to any prioritized decision framework."
+    },
+    {
+      "slug": "the-duty-is-to-the-text",
+      "name": "The Duty Is to the Text",
+      "kind": "mental-model",
+      "source_frame": "theatrical-directing",
+      "target_frame": "creative-process",
+      "categories": ["creative-leadership"],
+      "source": "llm",
+      "description": "The director serves the play, not their own vision. Reframes creative ego as subordinate to the problem being solved. Transfers to engineering (serve the user not your architecture), consulting (serve the client not your methodology)."
+    },
+    {
+      "slug": "the-ensemble",
+      "name": "The Ensemble",
+      "kind": "mental-model",
+      "source_frame": "theatrical-directing",
+      "target_frame": "team-dynamics",
+      "categories": ["creative-leadership"],
+      "source": "llm",
+      "description": "Team coherence over individual brilliance. The ensemble produces emergent work no individual could achieve alone. Transfers to sports teams, engineering teams, and any collaborative creative endeavor."
+    }
+  ]
+}

--- a/playbooks/hauser-reich-directing/playbook.md
+++ b/playbooks/hauser-reich-directing/playbook.md
@@ -1,0 +1,181 @@
+---
+project_issue: 1232
+repo: metaphorex/metaphorex
+source_type: book
+status: draft
+---
+
+# Playbook: Hauser & Reich's Notes on Directing
+
+## Source Description
+
+**Frank Hauser & Russell Reich, *Notes on Directing: 130 Lessons in
+Leadership from the Director's Chair*** (2003, self-published; 2008,
+RCR Creative Press; 2011, Walker & Company). 130 numbered aphorisms
+with commentary covering script interpretation, the director's role,
+casting, rehearsal, actor communication, staging, and comedy technique.
+
+Supplementary sources from the original issue:
+- **Keith Johnstone, *Impro: Improvisation and the Theatre*** (1979) --
+  status transactions, offers/blocks, spontaneity
+- **Anne Bogart, *A Director Prepares*** (2001) / **Bogart & Landau,
+  *The Viewpoints Book*** (2005) -- nine physical + five vocal Viewpoints
+- **Walter Murch, *In the Blink of an Eye*** (1995/2001) -- Rule of Six
+  editing criteria
+- **Konstantin Stanislavski, *An Actor Prepares*** (1936) -- the Magic If,
+  given circumstances, emotion memory
+
+The issue's selectivity guidance: import only lessons encoding reasoning
+about leadership, creativity, or collaboration that transfers beyond
+theater. Purely technical staging notes do not qualify.
+
+## Access Method
+
+### Primary Source: No Open Archive
+
+The primary text (*Notes on Directing*) is a copyrighted book. There is
+**no freely accessible structured digital archive** of the 130 lessons:
+
+- **Archive.org**: Two copies exist but are borrow-only (1-hour checkout):
+  - https://archive.org/details/notesondirecting0000haus
+  - https://archive.org/details/notesondirecting00haus
+- **Google Books**: Preview only, no full text:
+  - https://books.google.com/books/about/Notes_on_Directing.html?id=SsvnQQAACAAJ
+- **Bookey.app**: Chapter summary exists but returned 403 on fetch:
+  - https://www.bookey.app/book/notes-on-directing
+
+**Publicly accessible fragments** (used for archive-sourced candidates):
+- Goodreads quotes page (3 quotes visible): https://www.goodreads.com/work/quotes/246935-notes-on-directing
+- LeadershipNow product page (chapter headings + casting insight): https://www.leadershipnow.com/leadershop/9780802717085.html
+
+### Supplementary Sources: Structured Web Summaries
+
+These sources have extensive, freely-accessible structured summaries
+online that the scraping script targets:
+
+| Source | Archive URL | What it provides |
+|--------|-------------|-----------------|
+| Johnstone *Impro* | https://fluidself.org/books/art/impro | Status, offers/blocks, spontaneity concepts |
+| Johnstone *Impro* | https://jamesclear.com/book-summaries/impro | Core principles summary |
+| Johnstone *Impro* | https://taylorpearson.me/bookreview/impro-johnstone-notes/ | Teaching methodology, mask work |
+| Johnstone *Impro* | https://blas.com/impro/ | Detailed concept breakdown |
+| Bogart Viewpoints | https://dramatics.org/understanding-viewpoints/ | 9 physical + 5 vocal viewpoint definitions |
+| Murch Rule of Six | https://nofilmschool.com/2016/11/6-rules-good-cutting-according-oscar-winning-editor-walter-murch | Six criteria with percentages |
+| Murch Rule of Six | https://www.studiobinder.com/blog/walter-murch-rule-of-six/ | Detailed analysis |
+| Stanislavski system | https://www.backstage.com/magazine/article/the-definitive-guide-to-the-stanislavsky-acting-technique-65716/ | Magic If, given circumstances, emotion memory |
+
+### Scraping Script
+
+`playbooks/hauser-reich-directing/scripts/scrape_sources.py` fetches from
+Goodreads quotes, fluidself.org Impro summary, and Dramatics.org Viewpoints.
+Run with: `uv run playbooks/hauser-reich-directing/scripts/scrape_sources.py`
+
+The script produces JSON to stdout. It is idempotent and produces
+consistent output across runs (modulo page content changes).
+
+## Extraction Strategy
+
+### Candidate Selection Criteria
+
+From the 130 Hauser/Reich lessons, select only those that:
+1. Encode a **structural mapping** from theater to another domain
+   (leadership, feedback, hiring, system design, learning)
+2. Have a **named or nameable** aphorism (not just general advice)
+3. Are **not purely technical** stage-directing instructions
+
+From supplementary sources, select concepts that:
+1. Have become **cross-domain vocabulary** (status transactions,
+   offers/blocks, the Magic If)
+2. Encode a **transferable reasoning pattern** (Rule of Six priority
+   hierarchy, ensemble dynamics)
+
+### Source Attribution
+
+Each candidate is marked with its source provenance:
+- `"archive"` -- verifiable from a publicly accessible web page (URL cited)
+- `"llm"` -- from LLM knowledge of the book, not independently verifiable
+  from a free online source
+
+**7 of 15 candidates are archive-sourced; 8 are LLM-sourced.**
+
+The LLM-sourced candidates come from the copyrighted primary text. They are
+well-known directing aphorisms widely cited in theater education, but no
+free structured archive enumerates them. The Surveyor should verify these
+against the book if a copy is available.
+
+### Deduplication
+
+- `yes-and` was removed: already claimed by comedy-writers-glossary project
+  (issue #1885)
+- `status-is-up` exists in the catalog (provenance: lakoff-johnson-mwlb) as
+  the cognitive-linguistics metaphor. Our `status-transactions` is the
+  Johnstone improvisation concept -- distinct entry, different source frame
+  (economics vs spatial-orientation), different emphasis (social technique
+  vs linguistic metaphor).
+
+## Schema Mapping
+
+| Manifest field | Entry frontmatter | Notes |
+|---------------|-------------------|-------|
+| `slug` | `slug` | kebab-case, matches filename |
+| `name` | `name` | Human-readable title |
+| `kind` | `kind` | `metaphor` or `mental-model` only |
+| `source_frame` | `source_frame` | Required for metaphor kind |
+| `target_frame` | `applies_to[0]` | Maps to applies_to array |
+| `categories` | `categories` | Array of category slugs |
+| -- | `provenance` | Set to `hauser-reich-directing` |
+| -- | `author` | Set to `agent:metaphorex-miner` |
+| -- | `grounding` | Default `folk` for most; `established` for Stanislavski/Murch |
+
+### Kind Assignment Rationale
+
+All candidates use either `metaphor` or `mental-model`:
+- **metaphor**: Candidates with a clear source-target structural mapping
+  (director-as-obstetrician, every-scene-is-a-chase, status-transactions,
+  offers-and-blocks, rehearsal-is-not-performance)
+- **mental-model**: Candidates that are decision heuristics or reasoning
+  frameworks without a strict metaphorical source domain (give-actions-not-
+  emotions, casting-is-ninety-percent, rule-of-six, just-tell-the-story)
+
+The rejected `cross-field-mapping` kind does not exist in the schema.
+Valid kinds are: `metaphor`, `pattern`, `archetype`, `paradigm`, `mental-model`.
+
+### Frames Needed
+
+New frames to create alongside entries:
+- `theatrical-directing` -- director's craft, staging, rehearsal process
+- `improvisation` -- improv theater technique, spontaneity, scene work
+- `film-editing` -- cutting, montage, editorial decision-making
+- `feedback-and-communication` -- giving feedback, communication patterns
+- `pursuit-and-escape` -- chase, pursuit, evasion dynamics
+
+Existing frames that apply:
+- `economics` (for status-transactions source frame)
+- `leadership-and-management`, `collaboration`, `decision-making`,
+  `social-dynamics`, `learning-and-development` (various target frames)
+
+## Gotchas
+
+1. **No archive for primary source.** The 8 LLM-sourced candidates cannot
+   be independently verified from free web resources. The Surveyor should
+   verify against a physical or borrowed copy of the book.
+
+2. **Candidate count is below the 130-lesson total.** The issue's
+   selectivity guidance explicitly calls for filtering to ~10-18 lessons
+   with cross-domain transfer. We have 15 candidates, within that range.
+   This is NOT an exhaustive enumeration of the 130 lessons.
+
+3. **`status-transactions` vs `status-is-up`.** These are distinct entries:
+   Johnstone's improvisational concept (status as social behavior) vs.
+   Lakoff/Johnson's cognitive metaphor (status mapped to vertical
+   orientation). The Miner should cross-reference in `related:` fields.
+
+4. **`yes-and` excluded.** Already claimed by comedy-writers-glossary
+   project (issue #1885). If the Surveyor wants it here instead, move
+   the sub-issue.
+
+5. **Viewpoints not included as candidates.** Bogart's nine Viewpoints
+   (spatial relationship, kinesthetic response, shape, gesture, repetition,
+   architecture, tempo, duration, topography) are interesting but are
+   performance-technique vocabulary, not metaphors or mental models with
+   cross-domain transfer. Could be reconsidered if the Surveyor disagrees.

--- a/playbooks/hauser-reich-directing/scripts/scrape_sources.py
+++ b/playbooks/hauser-reich-directing/scripts/scrape_sources.py
@@ -1,0 +1,142 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["requests", "beautifulsoup4"]
+# ///
+"""Scrape publicly accessible structured sources for theatrical directing concepts.
+
+Primary source (Hauser & Reich, Notes on Directing) is a copyrighted book
+with no open-access digital archive. The archive.org copies are borrow-only.
+This script scrapes the SUPPLEMENTARY structured sources that are publicly
+accessible, producing a partial candidate list. LLM gap-fill is required
+for the primary source candidates.
+
+Scraped sources:
+  1. Goodreads quotes page for Notes on Directing (public quotes)
+  2. Fluidself.org Impro summary (Johnstone concepts)
+  3. Dramatics.org Viewpoints article (Bogart/Overlie concepts)
+
+Output: JSON to stdout with extracted concepts keyed by source.
+"""
+
+import json
+import re
+import sys
+import time
+
+import requests
+from bs4 import BeautifulSoup
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Metaphorex research bot; +https://github.com/metaphorex/metaphorex)"
+}
+
+
+def scrape_goodreads_quotes() -> list[dict]:
+    """Scrape publicly visible quotes from Notes on Directing on Goodreads."""
+    url = "https://www.goodreads.com/work/quotes/246935-notes-on-directing"
+    quotes = []
+    try:
+        resp = requests.get(url, headers=HEADERS, timeout=15)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, "html.parser")
+        # Goodreads quote text is in <div class="quoteText">
+        for qt in soup.select(".quoteText"):
+            text = qt.get_text(strip=True)
+            # Clean up attribution
+            text = re.sub(r"\s*---?\s*Frank Hauser.*$", "", text)
+            text = re.sub(r"\s*---?\s*Russell Reich.*$", "", text)
+            if text and len(text) > 20:
+                quotes.append({"text": text.strip(), "source_url": url})
+    except Exception as e:
+        print(f"Warning: Goodreads scrape failed: {e}", file=sys.stderr)
+    return quotes
+
+
+def scrape_fluidself_impro() -> list[dict]:
+    """Scrape structured Impro concepts from fluidself.org book notes."""
+    url = "https://fluidself.org/books/art/impro"
+    concepts = []
+    try:
+        resp = requests.get(url, headers=HEADERS, timeout=15)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, "html.parser")
+        # Extract section headings and bullet points
+        article = soup.select_one("article") or soup.select_one(".post-content") or soup
+        current_section = "general"
+        for el in article.find_all(["h2", "h3", "li", "p", "strong"]):
+            if el.name in ("h2", "h3"):
+                current_section = el.get_text(strip=True).lower()
+            elif el.name == "li":
+                text = el.get_text(strip=True)
+                if len(text) > 15:
+                    concepts.append({
+                        "section": current_section,
+                        "text": text,
+                        "source_url": url,
+                    })
+    except Exception as e:
+        print(f"Warning: Fluidself scrape failed: {e}", file=sys.stderr)
+    return concepts
+
+
+def scrape_dramatics_viewpoints() -> list[dict]:
+    """Scrape Viewpoints definitions from Dramatics Magazine."""
+    url = "https://dramatics.org/understanding-viewpoints/"
+    viewpoints = []
+    try:
+        resp = requests.get(url, headers=HEADERS, timeout=15)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, "html.parser")
+        # Look for viewpoint definitions in the article body
+        article = soup.select_one("article") or soup.select_one(".entry-content") or soup
+        for el in article.find_all(["p", "li", "h2", "h3", "strong"]):
+            text = el.get_text(strip=True)
+            # Look for viewpoint names (typically bold or in headers)
+            if any(vp in text.lower() for vp in [
+                "spatial relationship", "kinesthetic response", "shape",
+                "gesture", "repetition", "architecture", "tempo",
+                "duration", "topography", "pitch", "dynamic", "timbre",
+                "silence", "acceleration",
+            ]):
+                viewpoints.append({
+                    "text": text,
+                    "source_url": url,
+                })
+    except Exception as e:
+        print(f"Warning: Dramatics scrape failed: {e}", file=sys.stderr)
+    return viewpoints
+
+
+def main():
+    results = {
+        "scraped_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "sources": {
+            "goodreads_quotes": {
+                "url": "https://www.goodreads.com/work/quotes/246935-notes-on-directing",
+                "description": "Publicly visible quotes from Notes on Directing",
+                "data": scrape_goodreads_quotes(),
+            },
+            "fluidself_impro": {
+                "url": "https://fluidself.org/books/art/impro",
+                "description": "Structured Impro concepts from fluidself.org",
+                "data": scrape_fluidself_impro(),
+            },
+            "dramatics_viewpoints": {
+                "url": "https://dramatics.org/understanding-viewpoints/",
+                "description": "Viewpoints definitions from Dramatics Magazine",
+                "data": scrape_dramatics_viewpoints(),
+            },
+        },
+        "notes": [
+            "Primary source (Hauser & Reich Notes on Directing) is copyrighted.",
+            "Archive.org copies are borrow-only, not freely scrapable.",
+            "This script covers supplementary structured sources only.",
+            "Primary source candidates require LLM gap-fill.",
+        ],
+    }
+    json.dump(results, sys.stdout, indent=2)
+    print(file=sys.stdout)  # trailing newline
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Re-prospecting of import project #1232 after Surveyor rejection of PR #1706
- Addresses all 6 rejection points: invalid kind values, missing scraping script, access-restricted archive, dishonest source attribution, yes-and duplicate
- 15 candidates: 7 archive-sourced (with citation URLs), 8 LLM-sourced (honestly marked)
- Scraping script targets Goodreads quotes, fluidself.org (Impro), Dramatics.org (Viewpoints)
- All kind values are now `metaphor` or `mental-model` (no `cross-field-mapping`)
- `yes-and` removed (claimed by comedy-writers-glossary #1885)

## Changes from PR #1706

| Issue | Fix |
|-------|-----|
| 100% LLM-sourced | 7/15 now archive-sourced with URLs |
| No scraping script | `scripts/scrape_sources.py` added |
| archive.org borrow-only | Documented; used Goodreads, LeadershipNow, structured summaries instead |
| `source_type: "archive"` on all candidates | Honest `"archive"` vs `"llm"` per candidate |
| Invalid `cross-field-mapping` kind | All candidates use `metaphor` or `mental-model` |
| `yes-and` duplicate | Removed |

## Candidates (15)

| Slug | Kind | Source | Source Frame |
|------|------|--------|-------------|
| director-as-obstetrician | metaphor | archive | medicine |
| every-scene-is-a-chase-scene | metaphor | llm | pursuit-and-escape |
| give-actions-not-emotions | mental-model | llm | theatrical-directing |
| talk-to-the-character-not-the-actor | mental-model | llm | theatrical-directing |
| you-cannot-create-results-only-conditions | mental-model | llm | theatrical-directing |
| casting-is-ninety-percent | mental-model | archive | theatrical-directing |
| character-is-conduct | mental-model | archive | theatrical-directing |
| just-tell-the-story | mental-model | llm | theatrical-directing |
| rehearsal-is-not-performance | metaphor | llm | theatrical-directing |
| status-transactions | metaphor | archive | economics |
| offers-and-blocks | metaphor | archive | improvisation |
| the-magic-if | mental-model | archive | theatrical-directing |
| the-rule-of-six | mental-model | archive | film-editing |
| the-duty-is-to-the-text | mental-model | llm | theatrical-directing |
| the-ensemble | mental-model | llm | theatrical-directing |

## Test plan

- [x] `uv run scripts/validate.py validate` passes (zero errors)
- [x] Scraping script runs: `uv run playbooks/hauser-reich-directing/scripts/scrape_sources.py`
- [ ] Surveyor reviews manifest for completeness and accuracy
- [ ] Surveyor verifies LLM-sourced candidates against book if copy available

Generated with [Claude Code](https://claude.com/claude-code)