### PR TITLE
Fix kaizen #1449: require candidate details in prospector manifest

### DIFF
--- a/.claude/agents/prospector.md
+++ b/.claude/agents/prospector.md
@@ -166,9 +166,10 @@ Schema Mapping, Gotchas.
       "kind": "conceptual-metaphor",
       "source_frame": "economics",
       "target_frame": "time-and-temporality",
+      "applies_to": ["time-management"],
       "categories": ["cognitive-linguistics"],
       "source": "archive|llm",
-      "description": "Brief description of what makes this interesting"
+      "description": "Maps economic concepts (spending, saving, wasting) onto time, shaping how people treat time as a limited resource to be budgeted."
     }
   ]
 }
@@ -177,6 +178,28 @@ Schema Mapping, Gotchas.
 Each candidate's `source` field must be `"archive"` (from scraping script)
 or `"llm"` (gap-fill from LLM knowledge). The Surveyor will scrutinize
 `"llm"` entries more heavily.
+
+**Candidate Detail Requirements (CRITICAL):**
+
+Every candidate in the manifest MUST include substantive values for these
+fields. The Miner should NOT need to research from scratch what the mapping
+is about. Bare slugs with no details are unacceptable.
+
+Required for every candidate:
+- `kind` — the suggested entry kind (metaphor, pattern, archetype, paradigm,
+  mental-model). Do not leave blank or use a placeholder.
+- `applies_to` — one or more target domains where this concept is applied.
+  Be specific: "software-architecture" not just "engineering".
+- `description` — 1-2 sentences describing the conceptual mapping or core
+  insight. This is the Miner's starting point; make it count.
+
+Required when `kind` is `metaphor`:
+- `source_frame` — the source domain the metaphor draws from. Must be a
+  specific frame, not a vague category.
+
+If you cannot determine a field with reasonable confidence, write your best
+guess and append "(tentative)" so the Surveyor and Miner know to verify it.
+A tentative value is always better than no value.
 
 **Run Comment:**
 
@@ -196,6 +219,8 @@ current commit hash.
   stdout. They should be idempotent and produce the same output on each run.
 - Archive-scraping scripts are REQUIRED when a structured source exists
 - Manifest entries should be specific — "argument-is-war" not "chapter 3"
+- Manifest candidates missing `kind`, `applies_to`, or `description` will
+  be rejected by the Surveyor. Fill in every field for every candidate.
 - Err on the side of more candidates; the Miner and Assayer will filter
 - For archive-type projects: the candidate list should be EXHAUSTIVE relative
   to the archive. Missing known entries is worse than including marginal ones.


### PR DESCRIPTION
Closes #1449

## Summary

- Sub-issues created from prospector manifests lacked candidate details (kind, source_frame, applies_to, description), forcing miners to research from scratch instead of extracting from provided material.
- The prospector prompt's manifest schema example had a placeholder description and no `applies_to` field, and there was no explicit requirement that these fields be substantive.

## Changes

- Added `applies_to` field to the manifest JSON example in `.claude/agents/prospector.md`
- Replaced the placeholder description with a real 1-2 sentence mapping description
- Added a new **Candidate Detail Requirements (CRITICAL)** section mandating:
  - `kind` on every candidate
  - `applies_to` on every candidate
  - `description` (1-2 sentences) on every candidate
  - `source_frame` when kind is `metaphor`
  - "(tentative)" annotation when confidence is low
- Added a quality standard bullet: candidates missing required fields will be rejected

## Test plan

- [x] Verified the prompt file parses correctly (valid YAML frontmatter, valid JSON example)
- [x] No scripts were changed, so no validation run needed
- [ ] Verify next prospector run produces manifests with all required fields populated

Generated with [Claude Code](https://claude.com/claude-code)