### PR TITLE
Fix kaizen #1924: validate manifest kind values before PR creation

### DIFF
--- a/.claude/agents/prospector.md
+++ b/.claude/agents/prospector.md
@@ -170,11 +170,20 @@ If the token is NOT set, use default auth (no prefix needed).
    applies_to, categories
 8. **Run the scraping script** to produce structured output, then write
    the manifest at `playbooks/<project-name>/manifest.json`
-9. Write the playbook at `playbooks/<project-name>/playbook.md` — include
+9. **Validate the manifest before proceeding.** Run:
+   ```bash
+   uv run scripts/validate_manifest.py playbooks/<project-name>/manifest.json
+   ```
+   This checks that every candidate's `kind` is one of the allowed schema
+   values (`metaphor`, `pattern`, `archetype`, `paradigm`, `mental-model`),
+   names are title case (not ALL-CAPS), `source` is `archive` or `llm`, and
+   `source_frame` differs from `target_frame`. Fix any errors before
+   continuing. Do NOT open a PR with a failing manifest.
+10. Write the playbook at `playbooks/<project-name>/playbook.md` — include
    the archive URLs and methodology in the Access Method section
-10. Open a PR with: playbook + scripts + manifest
-11. Add the `in-progress` label to the parent issue to claim it
-12. Post a run summary comment on the parent issue
+11. Open a PR with: playbook + scripts + manifest
+12. Add the `in-progress` label to the parent issue to claim it
+13. Post a run summary comment on the parent issue
 
 **Playbook Format:**
 
@@ -201,18 +210,23 @@ Schema Mapping, Gotchas.
   "candidates": [
     {
       "slug": "time-is-money",
-      "name": "TIME IS MONEY",
-      "kind": "conceptual-metaphor",
+      "name": "Time Is Money",
+      "kind": "metaphor",
       "source_frame": "economics",
       "target_frame": "time-and-temporality",
       "applies_to": ["time-management"],
       "categories": ["cognitive-linguistics"],
-      "source": "archive|llm",
+      "source": "archive",
       "description": "Maps economic concepts (spending, saving, wasting) onto time, shaping how people treat time as a limited resource to be budgeted."
     }
   ]
 }
 ```
+
+**Allowed `kind` values:** `metaphor`, `pattern`, `archetype`, `paradigm`,
+`mental-model`. No other values are accepted. Common mistakes: `conceptual-metaphor`
+(use `metaphor`), `dead-metaphor` (use `metaphor`), `cross-field-mapping`
+(use `metaphor` or `pattern`).
 
 Each candidate's `source` field must be `"archive"` (from scraping script)
 or `"llm"` (gap-fill from LLM knowledge). The Surveyor will scrutinize

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -1,0 +1,136 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Manifest validator for Prospector-generated manifest.json files.
+
+Usage:
+    uv run scripts/validate_manifest.py playbooks/my-project/manifest.json
+    uv run scripts/validate_manifest.py playbooks/*/manifest.json
+
+Validates each candidate entry against Metaphorex schema rules:
+- kind is one of: metaphor, pattern, archetype, paradigm, mental-model
+- name is title case (not ALL-CAPS, not all-lowercase)
+- source_frame != target_frame (same-domain anti-pattern)
+- source is one of: archive, llm
+- Required fields present: slug, name, kind, source
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+VALID_KINDS = {
+    "metaphor",
+    "pattern",
+    "archetype",
+    "paradigm",
+    "mental-model",
+}
+
+REJECTED_KINDS = {"conceptual-metaphor", "dead-metaphor", "cross-field-mapping"}
+
+VALID_SOURCES = {"archive", "llm"}
+
+REQUIRED_CANDIDATE_FIELDS = {"slug", "name", "kind", "source"}
+
+
+def validate_manifest(path: Path) -> list[str]:
+    """Validate a manifest.json file. Returns a list of error strings."""
+    errors: list[str] = []
+
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        return [f"{path}: invalid JSON: {e}"]
+
+    if not isinstance(data, dict):
+        return [f"{path}: top-level value must be an object"]
+
+    candidates = data.get("candidates", [])
+    if not isinstance(candidates, list):
+        return [f"{path}: 'candidates' must be an array"]
+
+    for i, c in enumerate(candidates):
+        prefix = f"{path}: candidate[{i}] ({c.get('slug', '???')})"
+
+        # Required fields
+        for field in REQUIRED_CANDIDATE_FIELDS:
+            if field not in c:
+                errors.append(f"{prefix}: missing required field '{field}'")
+
+        # kind validation
+        kind = c.get("kind")
+        if kind is not None:
+            if kind in REJECTED_KINDS:
+                errors.append(
+                    f"{prefix}: kind '{kind}' is not valid. "
+                    f"Did you mean 'metaphor'? "
+                    f"Allowed: {', '.join(sorted(VALID_KINDS))}"
+                )
+            elif kind not in VALID_KINDS:
+                errors.append(
+                    f"{prefix}: kind '{kind}' is not valid. "
+                    f"Allowed: {', '.join(sorted(VALID_KINDS))}"
+                )
+
+        # name validation: not ALL-CAPS
+        name = c.get("name")
+        if isinstance(name, str) and len(name) > 1:
+            alpha_chars = [ch for ch in name if ch.isalpha()]
+            if alpha_chars and all(ch.isupper() for ch in alpha_chars):
+                errors.append(
+                    f"{prefix}: name '{name}' is ALL-CAPS. "
+                    f"Use title case (e.g. 'Argument Is War')."
+                )
+
+        # source_frame != target_frame
+        sf = c.get("source_frame")
+        tf = c.get("target_frame")
+        if sf and tf and sf == tf:
+            errors.append(
+                f"{prefix}: source_frame and target_frame are identical ('{sf}'). "
+                f"A mapping must cross domains."
+            )
+
+        # source validation
+        source = c.get("source")
+        if source is not None and source not in VALID_SOURCES:
+            errors.append(
+                f"{prefix}: source '{source}' is not valid. "
+                f"Allowed: {', '.join(sorted(VALID_SOURCES))}"
+            )
+
+    return errors
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: uv run scripts/validate_manifest.py <manifest.json> [...]", file=sys.stderr)
+        return 1
+
+    all_errors: list[str] = []
+    files_checked = 0
+
+    for arg in sys.argv[1:]:
+        path = Path(arg)
+        if not path.exists():
+            all_errors.append(f"{path}: file not found")
+            continue
+        files_checked += 1
+        all_errors.extend(validate_manifest(path))
+
+    if all_errors:
+        for err in all_errors:
+            print(f"ERROR: {err}", file=sys.stderr)
+        print(f"\n{len(all_errors)} error(s) in {files_checked} manifest(s).", file=sys.stderr)
+        return 1
+
+    print(f"{files_checked} manifest(s) validated, 0 errors.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds `scripts/validate_manifest.py` that checks manifest candidates for:
  - `kind` is one of the 5 allowed schema values (metaphor, pattern, archetype, paradigm, mental-model)
  - `name` is not ALL-CAPS (must be title case)
  - `source_frame` != `target_frame` (same-domain anti-pattern)
  - `source` is one of: archive, llm
  - Required fields present: slug, name, kind, source
- Adds step 9 to the Prospector process (`.claude/agents/prospector.md`) requiring manifest validation before PR creation
- Fixes the example manifest in the prompt which itself used invalid values (`conceptual-metaphor` kind, `TIME IS MONEY` ALL-CAPS name, `archive|llm` source) that agents were copying
- Adds explicit "Allowed kind values" documentation block with common mistakes and corrections

## What was broken

The Prospector agent had no validation gate between manifest generation and PR creation. Invalid `kind` values like `conceptual-metaphor` (not in the schema) and ALL-CAPS names went undetected until Surveyor review. Worse, the example manifest in the agent prompt itself contained these invalid values, actively teaching the agent to produce bad output.

## Test plan

- [x] `uv run scripts/validate_manifest.py playbooks/*/manifest.json` catches invalid kind, ALL-CAPS name, same-domain mapping in existing manifests (confirming the bug existed)
- [x] `uv run scripts/validate.py validate` still passes (no regressions)

Closes #1924