### PR TITLE
Add entry: Stone Soup

### DIFF
--- a/catalog/entries/stone-soup.md
+++ b/catalog/entries/stone-soup.md
@@ -1,0 +1,185 @@
+---
+applies_to:
+- collaborative-work
+author: agent:metaphorex-miner
+categories:
+- organizational-behavior
+- economics-and-finance
+contributors: []
+created: '2026-03-20'
+grounding: folk
+harness: Claude Code
+kind: metaphor
+limits:
+  - '[source] The traveler''s stone is a deliberate ruse -- he knows the soup needs real ingredients -- so importing the pattern into collaboration risks normalizing deception as a legitimate coordination mechanism'
+  - '[source] The villagers contribute voluntarily only because social pressure and curiosity operate in a small, face-to-face community; the pattern does not transfer to anonymous or large-scale contexts where free-riding has no social cost'
+  - '[source] The tale ends when the soup is eaten, obscuring the question of ongoing maintenance -- one pot of soup is an event, not an institution, and the metaphor says nothing about sustaining contributions over time'
+name: Stone Soup
+related:
+- barn-raising
+- tragedy-of-the-commons
+slug: stone-soup
+source_frame: folklore
+transfers:
+  - '[source] A worthless seed contribution (a stone) placed in a communal pot catalyzes genuine contributions from bystanders, mapping onto how a minimal viable artifact can unlock collective investment that no one would have initiated alone'
+  - '[source] Each villager adds only what they can spare -- a carrot, an onion -- and receives a share of the whole, mapping the structure of pooled marginal contributions producing a result no single contributor could achieve'
+  - '[source] The traveler is an outsider who provides the coordination frame, not the substance, mapping onto the role of a facilitator or platform that contributes structure rather than content'
+updated: '2026-03-20'
+---
+
+## Transfers
+
+In the European folk tale, a hungry traveler arrives in a village where
+no one will share food. He fills a pot with water, drops in a stone, and
+announces he is making "stone soup." Curious villagers gather. The
+traveler tastes the broth and says it is good but would be even better
+with a little garnish -- perhaps a carrot? One villager fetches a carrot.
+Then an onion. Then meat. By the end, the village has produced a rich
+communal soup from ingredients that "nobody had."
+
+The structural insight is not about trickery but about coordination
+failure and how to break it. The villagers had the ingredients all along.
+What they lacked was a coordination mechanism -- a reason to contribute
+when no one else was contributing. The stone (worthless in itself)
+functions as a focal point that makes the first contribution legible and
+safe.
+
+Key structural parallels:
+
+- **The seed contribution lowers activation energy** -- the traveler does
+  not ask for food. He starts cooking. The stone in the pot is a minimal
+  viable artifact that makes the project real and visible. Contributing a
+  carrot to an existing pot of soup is psychologically easier than being
+  the first person to offer food to a stranger. In open-source software,
+  the equivalent is publishing a working prototype: it is easier to submit
+  a patch to existing code than to start a project from nothing. The seed
+  contribution reframes the social situation from "will you give me
+  something?" to "will you improve something that already exists?"
+
+- **Marginal contributions aggregate into a collective good** -- no single
+  villager provides the whole meal. Each gives what they can spare -- a
+  carrot here, a potato there. The resulting soup exceeds what any
+  individual could have produced. This maps onto crowdfunding, barn
+  raising, Wikipedia editing, and any context where many small
+  contributions combine into something none of the contributors could
+  build alone. The key structural feature is that each contribution is
+  individually painless but collectively transformative.
+
+- **The facilitator contributes structure, not substance** -- the
+  traveler's actual contribution is negligible (a stone). His real value
+  is providing the coordination frame: the pot, the fire, the public
+  ritual of cooking, and the social fiction that something valuable is
+  already underway. This maps onto platform founders, community organizers,
+  and open-source maintainers whose primary contribution is creating a
+  structure into which others can contribute, not producing the content
+  themselves.
+
+- **Social visibility drives participation** -- the cooking happens in
+  public. Each villager sees others contributing, which normalizes and
+  escalates participation. This is the mechanism behind fundraising
+  thermometers, GitHub contribution graphs, and Kickstarter progress bars:
+  making existing contributions visible to potential contributors lowers
+  the perceived risk of contributing.
+
+- **The deception is productive** -- the traveler's claim that a stone
+  makes soup is a lie. But the lie serves as a coordination device that
+  produces a genuine collective good. The folk tale sits comfortably with
+  this ambiguity: the trickster is celebrated, not condemned. This maps
+  onto "fake it till you make it" strategies, vaporware demos that attract
+  real investment, and MVPs that promise more than they deliver in order to
+  generate the contributions that will eventually fulfill the promise.
+
+## Limits
+
+- **The trickster problem** -- the traveler knows the stone is worthless.
+  He manipulates the villagers into contributing by creating a false
+  pretext. When the metaphor is applied approvingly to collaboration, it
+  implicitly endorses deception as a legitimate coordination tool. This
+  sits uneasily with contexts that depend on trust: open-source projects
+  whose founders oversell capabilities to attract contributors risk
+  burning goodwill when the deception becomes apparent. The folk tale
+  works because it ends at the feast; real collaborations continue past
+  the first meal.
+
+- **Face-to-face social pressure does not scale** -- the tale depends on
+  a small village where everyone can see what everyone else is doing.
+  Villagers contribute partly because their neighbors are watching. This
+  mechanism breaks down in large-scale, anonymous contexts. Wikipedia
+  works not because of stone-soup dynamics but because of institutional
+  structure (editorial policies, admin hierarchies, bots). The metaphor
+  flatters projects that succeed through governance by attributing their
+  success to spontaneous generosity.
+
+- **One meal is not a system** -- stone soup is an event, not an
+  institution. The tale says nothing about whether the villagers will
+  cook together tomorrow, or whether the traveler's departure will
+  collapse the cooperation. Many real-world collaboration challenges are
+  not about catalyzing the first contribution but about sustaining
+  contributions over time. Kickstarter campaigns fund a product; they do
+  not fund its maintenance. The metaphor is silent on the hardest part of
+  collective action: keeping it going.
+
+- **The metaphor obscures power asymmetry** -- the traveler captures a
+  disproportionate share of the value (a full meal for a stone) while the
+  villagers each sacrifice real resources. Applied to platforms, this maps
+  onto the dynamic where platform founders capture the value of user
+  contributions. Calling this "stone soup" romanticizes extraction as
+  facilitation.
+
+- **It assumes surplus exists** -- the tale only works because the
+  villagers actually have spare ingredients. If they were truly destitute,
+  no amount of clever coordination would produce soup. The metaphor can
+  mislead in contexts of genuine scarcity, suggesting that the problem is
+  always coordination rather than resources.
+
+## Expressions
+
+- "Stone soup project" -- a project bootstrapped by a minimal seed that
+  attracts community contributions, common in open-source discourse
+- "Bringing a stone to the pot" -- contributing something nominally but
+  expecting others to do the real work; used critically
+- "Who brought the stone?" -- questioning who is the facilitator vs. who
+  is doing the real work, often in organizational retrospectives
+- "Stone soup" as a name for collaborative cooking events, potlucks, and
+  community meals -- the tale has been re-literalized
+- "All it needed was a stone" -- optimistic framing for the power of a
+  minimal viable prototype to catalyze collective effort
+
+## Origin Story
+
+The tale exists in dozens of European variants: "Stone Soup" (English,
+French), "Nail Soup" (Swedish -- *Soppsten*), "Axe Soup" (Czech,
+Russian), "Button Soup" (various). Marcia Brown's 1947 Caldecott-winning
+picture book *Stone Soup* popularized the French version in American
+children's literature, with three soldiers rather than a lone traveler.
+The Aarne-Thompson tale type is AT 1548 ("The Soup-Stone").
+
+The tale belongs to a broader family of trickster narratives where a
+clever outsider uses social engineering to extract resources from a
+reluctant community. Unlike most trickster tales, Stone Soup is unusual
+in that the trick produces a genuine collective benefit -- the soup is
+real, and everyone eats. This structural feature is what makes it
+productive as a metaphor for collaboration rather than mere con artistry.
+
+The metaphor entered technology discourse through open-source culture.
+Eric Raymond's *The Cathedral and the Bazaar* (1999) does not use the
+phrase, but the dynamic he describes -- Linus Torvalds posting a minimal
+kernel that attracted thousands of contributors -- is structurally
+identical. The term "stone soup" appears in software engineering blogs
+and community management guides from the mid-2000s onward to describe
+the strategy of publishing a minimal working artifact to attract
+contributions.
+
+## References
+
+- Brown, M. *Stone Soup* (1947) -- the canonical English-language
+  children's version
+- Aarne, A. and Thompson, S. *The Types of the Folktale* (1961) --
+  classifies the tale as AT 1548
+- Raymond, E. *The Cathedral and the Bazaar* (1999) -- describes the
+  structural dynamic without using the term
+- Benkler, Y. *The Wealth of Networks* (2006) -- theorizes commons-based
+  peer production, the economic structure Stone Soup illustrates
+- Ostrom, E. *Governing the Commons* (1990) -- the institutional
+  conditions under which collective resource management succeeds,
+  addressing limits the folk tale ignores

--- a/catalog/frames/folklore.md
+++ b/catalog/frames/folklore.md
@@ -1,0 +1,29 @@
+---
+created: '2026-03-20'
+name: Folklore
+related:
+- mythology
+- narrative
+- social-behavior
+roles:
+- trickster
+- fool
+- villager
+- moral
+- ruse
+- transformation
+- communal-lesson
+slug: folklore
+updated: '2026-03-20'
+---
+
+Folk tales, fables, and oral narratives passed down through communities
+to encode practical wisdom, social norms, and cautionary lessons. Unlike
+mythology, folklore does not deal with sacred origins or divine beings;
+its characters are ordinary people, talking animals, or clever tricksters
+navigating everyday social situations. As a source domain, folklore
+provides compact narrative structures whose morals have become proverbial
+-- the boy who cried wolf, the emperor's new clothes, stone soup. The
+structural patterns are portable because the tales were already designed
+to teach transferable lessons about cooperation, deception, trust, and
+collective action.


### PR DESCRIPTION
## Summary

- Adds **Stone Soup** (`catalog/entries/stone-soup.md`) — a metaphor entry mapping the European folk tale onto coordination-bootstrapping and collective contribution dynamics
- Creates **folklore** source frame (`catalog/frames/folklore.md`) — distinguishes folk tales from sacred mythology as a source domain
- Kind: `metaphor` (source domain still recognized by most speakers)
- Source frame: `folklore` (new)
- Applies to: `collaborative-work`

## Key analytical contributions

- Identifies the **trickster problem**: the metaphor implicitly endorses deception as a coordination tool, which sits uneasily with trust-dependent contexts like open-source
- Names the **one meal vs. institution** limit: stone soup is an event, not a system, and the metaphor is silent on sustaining contributions over time
- Identifies the **power asymmetry**: the facilitator captures disproportionate value (a full meal for a stone), mapping onto platform dynamics

## Validation

`uv run scripts/validate.py validate` passes with zero errors. All warnings are pre-existing dangling references.

Closes #2295

---
Generated with [Claude Code](https://claude.com/claude-code)