### PR TITLE
kaizen: validate manifest category slugs against catalog (#2300)

### DIFF
--- a/.claude/agents/prospector.md
+++ b/.claude/agents/prospector.md
@@ -136,11 +136,15 @@ shell — exports don't persist). If no crew config exists, skip prefixes.
    applies_to, categories
 8. **Run the scraping script** to produce structured output, then write
    the manifest at `playbooks/<project-name>/manifest.json`
-9. Write the playbook at `playbooks/<project-name>/playbook.md` — include
+9. **Verify every category slug in the manifest exists as a file in
+   `catalog/categories/`.** List the directory and cross-check each slug.
+   If a slug has no matching `.md` file, fix the manifest before proceeding.
+   Run `uv run scripts/validate.py validate-manifests` to confirm zero errors.
+10. Write the playbook at `playbooks/<project-name>/playbook.md` — include
    the archive URLs and methodology in the Access Method section
-10. Open a PR with: playbook + scripts + manifest
-11. Add the `in-progress` label to the parent issue to claim it
-12. Post a run summary comment on the parent issue
+11. Open a PR with: playbook + scripts + manifest
+12. Add the `in-progress` label to the parent issue to claim it
+13. Post a run summary comment on the parent issue
 
 **Playbook Format:**
 

--- a/playbooks/lakoff-johnson-mwlb/manifest.json
+++ b/playbooks/lakoff-johnson-mwlb/manifest.json
@@ -15,7 +15,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "embodied-experience",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Euphoric_States_Are_Up.html",
@@ -31,7 +31,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Control_Is_Up.html",
@@ -47,7 +47,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Rational_Is_Up.html",
@@ -63,7 +63,7 @@
       "source_frame": "containers",
       "target_frame": "vision",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "The_Visual_Field_Is_A_Container.html",
@@ -79,7 +79,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "vision",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "The_Visual_Field_Is_A_Bounded_Region.html",
@@ -95,7 +95,7 @@
       "source_frame": "manufacturing",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "The_Mind_Is_A_Machine.html",
@@ -111,7 +111,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Mind,_Or_Mental_Self_Is_A_Brittle_Object.html",
@@ -127,7 +127,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "The_Conduit_Metaphor.html",
@@ -144,7 +144,7 @@
       "source_frame": "social-roles",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Ideas_Are_People.html",
@@ -160,7 +160,7 @@
       "source_frame": "vision",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Ideas_Are_Light_Sources.html",
@@ -176,7 +176,7 @@
       "source_frame": "economics",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Ideas_Are_Resources.html",
@@ -192,7 +192,7 @@
       "source_frame": "social-behavior",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Ideas_Are_Fashions.html",
@@ -208,7 +208,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Ideas_Are_Objects.html",
@@ -226,7 +226,7 @@
       "source_frame": "journeys",
       "target_frame": "journeys",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Longterm_Purposeful_Activity_Is_A_Journey.html",
@@ -242,7 +242,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Causation_Is_Control_Over_Relative_Location.html",
@@ -258,7 +258,7 @@
       "source_frame": "economics",
       "target_frame": "time-and-temporality",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Time_Is_A_Resource.html",
@@ -275,7 +275,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "time-and-temporality",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Time_Is_Something_Moving_Toward_You.html",
@@ -291,7 +291,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "time-and-temporality",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Time_Is_A_Landscape_We_Move_Through.html",
@@ -307,7 +307,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "love-and-relationships",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Love_Is_Madness.html",
@@ -324,7 +324,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "love-and-relationships",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Love_Is_A_Unity_(of_Two_Complementary_Parts).html",
@@ -340,7 +340,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "embodied-experience",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Emotional_Stability_Is_Balance.html",
@@ -356,7 +356,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "embodied-experience",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Emotions_Are_Entities_Within_A_Person.html",
@@ -372,7 +372,7 @@
       "source_frame": "journeys",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "States_Are_Locations.html",
@@ -389,7 +389,7 @@
       "source_frame": "journeys",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Existence_Is_A_Location_(here).html",
@@ -405,7 +405,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "embodied-experience",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Action_Is_Motion.html",
@@ -422,7 +422,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "embodied-experience",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Change_Is_Motion.html",
@@ -439,7 +439,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "vision",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Seeing_Is_Touching,_Eyes_Are_Limbs.html",
@@ -455,7 +455,7 @@
       "source_frame": "horticulture",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "People_Are_Plants.html",
@@ -471,7 +471,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "embodied-experience",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Difficulties_Are_Containers.html",
@@ -487,7 +487,7 @@
       "source_frame": "journeys",
       "target_frame": "embodied-experience",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Longterm_Purposeful_Change_Is_A_Journey.html",
@@ -504,7 +504,7 @@
       "source_frame": "war",
       "target_frame": "love-and-relationships",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Competition_Is_War.html",
@@ -521,7 +521,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "love-and-relationships",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Desires_Are_Forces_Between_The_Desired_And_The_Desirer.html",
@@ -538,7 +538,7 @@
       "source_frame": "manufacturing",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "People_Are_Machines.html",
@@ -554,7 +554,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Obligations_Are_Forces.html",
@@ -570,7 +570,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Properties_Are_Possessions.html",
@@ -586,7 +586,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "archive",
       "archive_file": "Psychological_Forces_Are_Physical_Forces..html",
@@ -602,7 +602,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "embodied-experience",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -618,7 +618,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "embodied-experience",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -635,7 +635,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "embodied-experience",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -651,7 +651,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "social-roles",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -667,7 +667,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "embodied-experience",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -683,7 +683,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "social-behavior",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -700,7 +700,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "time-and-temporality",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -716,7 +716,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -732,7 +732,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "time-and-temporality",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -748,7 +748,7 @@
       "source_frame": "containers",
       "target_frame": "economics",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -765,7 +765,7 @@
       "source_frame": "manufacturing",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -781,7 +781,7 @@
       "source_frame": "manufacturing",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -797,7 +797,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -813,7 +813,7 @@
       "source_frame": "economics",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -829,7 +829,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -845,7 +845,7 @@
       "source_frame": "collaborative-work",
       "target_frame": "love-and-relationships",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -862,7 +862,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "love-and-relationships",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -878,7 +878,7 @@
       "source_frame": "competition",
       "target_frame": "journeys",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -894,7 +894,7 @@
       "source_frame": "containers",
       "target_frame": "journeys",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -910,7 +910,7 @@
       "source_frame": "economics",
       "target_frame": "economics",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -926,7 +926,7 @@
       "source_frame": "containers",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -943,7 +943,7 @@
       "source_frame": "journeys",
       "target_frame": "argumentation",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -959,7 +959,7 @@
       "source_frame": "architecture-and-building",
       "target_frame": "argumentation",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -977,7 +977,7 @@
       "source_frame": "embodied-experience",
       "target_frame": "journeys",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -994,7 +994,7 @@
       "source_frame": "containers",
       "target_frame": "embodied-experience",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -1010,7 +1010,7 @@
       "source_frame": "social-roles",
       "target_frame": "manufacturing",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,
@@ -1026,7 +1026,7 @@
       "source_frame": "intellectual-inquiry",
       "target_frame": "intellectual-inquiry",
       "categories": [
-        "cognitive-linguistics"
+        "linguistics"
       ],
       "source": "llm",
       "archive_file": null,

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -7,9 +7,10 @@
 """Metaphorex content validator and extractor.
 
 Usage:
-    uv run scripts/validate.py validate          # validate all content
+    uv run scripts/validate.py validate              # validate all content
     uv run scripts/validate.py validate catalog/entries/ # validate specific dir
-    uv run scripts/validate.py extract            # emit JSON to stdout
+    uv run scripts/validate.py validate-manifests     # validate playbook manifests
+    uv run scripts/validate.py extract                # emit JSON to stdout
 """
 
 from __future__ import annotations
@@ -27,6 +28,7 @@ ENTRIES_DIR = CATALOG_DIR / "entries"
 FRAMES_DIR = CATALOG_DIR / "frames"
 CATEGORIES_DIR = CATALOG_DIR / "categories"
 WORKS_DIR = CATALOG_DIR / "works"
+PLAYBOOKS_DIR = ROOT / "playbooks"
 
 VALID_KINDS = {
     "metaphor",
@@ -304,6 +306,44 @@ def validate(target: str | None = None) -> tuple[list[str], list[str]]:
     return errors, warnings
 
 
+def category_slugs_from_files() -> set[str]:
+    """Collect category slugs from filenames in catalog/categories/."""
+    slugs = set()
+    if CATEGORIES_DIR.exists():
+        for f in CATEGORIES_DIR.glob("*.md"):
+            slugs.add(f.stem)
+    return slugs
+
+
+def validate_manifests() -> tuple[list[str], list[str]]:
+    """Validate playbook manifest.json files against catalog categories."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    cat_slugs = category_slugs_from_files()
+
+    if not PLAYBOOKS_DIR.exists():
+        return errors, warnings
+
+    for manifest_path in sorted(PLAYBOOKS_DIR.glob("*/manifest.json")):
+        prefix = str(manifest_path.relative_to(ROOT))
+        try:
+            data = json.loads(manifest_path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            errors.append(f"{prefix}: failed to parse manifest: {exc}")
+            continue
+
+        for candidate in data.get("candidates", []):
+            slug = candidate.get("slug", "<unknown>")
+            for cat in candidate.get("categories", []):
+                if cat not in cat_slugs:
+                    errors.append(
+                        f"{prefix}: candidate '{slug}' references "
+                        f"unknown category '{cat}'"
+                    )
+
+    return errors, warnings
+
+
 def extract() -> list[dict]:
     results = []
     for f in sorted(ENTRIES_DIR.glob("*.md")):
@@ -317,7 +357,7 @@ def extract() -> list[dict]:
 
 
 def main() -> None:
-    if len(sys.argv) < 2 or sys.argv[1] not in ("validate", "extract"):
+    if len(sys.argv) < 2 or sys.argv[1] not in ("validate", "validate-manifests", "extract"):
         print(__doc__.strip())
         sys.exit(1)
 
@@ -338,6 +378,22 @@ def main() -> None:
             sys.exit(1)
         else:
             print("All content valid.")
+            sys.exit(0)
+
+    elif command == "validate-manifests":
+        errors, warnings = validate_manifests()
+        if warnings:
+            print(f"{len(warnings)} warning(s):\n")
+            for w in warnings:
+                print(f"  ~ {w}")
+            print()
+        if errors:
+            print(f"{len(errors)} manifest error(s):\n")
+            for e in errors:
+                print(f"  - {e}")
+            sys.exit(1)
+        else:
+            print("All manifests valid.")
             sys.exit(0)
 
     elif command == "extract":


### PR DESCRIPTION
## Summary

Closes #2300

- **`scripts/validate.py`**: Added `validate-manifests` subcommand that loads each `playbooks/*/manifest.json`, extracts `categories` arrays from candidates, and cross-references them against filenames in `catalog/categories/`. Reports any slug that doesn't match an existing `.md` file.
- **`.claude/agents/prospector.md`**: Added explicit step 9 in the Prospector process: verify every category slug in the manifest exists as a file in `catalog/categories/` and run `validate-manifests` before proceeding.
- **`playbooks/lakoff-johnson-mwlb/manifest.json`**: Fixed 63 instances of non-existent category `cognitive-linguistics` to the correct slug `linguistics` (which matches the actual file `catalog/categories/linguistics.md`).

## What was broken

Manifests could reference category slugs that don't exist in the catalog (e.g., `cognitive-linguistics` instead of `linguistics`). No validation caught this at PR creation time, so bad data propagated downstream to miners.

## Test plan

- [x] `uv run scripts/validate.py validate` passes (no regressions)
- [x] `uv run scripts/validate.py validate-manifests` passes clean after manifest fix
- [x] New subcommand correctly detects invalid category slugs when present

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>