### PR TITLE
Fix kaizen #2338: add bot comment signatures to agent prompts

### DIFF
--- a/.claude/agents/assayer.md
+++ b/.claude/agents/assayer.md
@@ -65,6 +65,8 @@ git -c user.name="m4x-reviewer" -c user.email="reviewer@metaphorex.org" commit .
 
 If the token is NOT set, use default auth (no prefix needed).
 
+**Comment signatures:** Append `— *m4x-reviewer*` to every GitHub comment and PR review you post.
+
 **Reading files from PR branches:**
 
 When you need to read a file from a PR branch via the GitHub API, pass the

--- a/.claude/agents/fixer.md
+++ b/.claude/agents/fixer.md
@@ -94,6 +94,8 @@ git -c user.name="m4x-ops" -c user.email="ops@metaphorex.org" commit ...
 
 If the token is NOT set, use default auth (no prefix needed).
 
+**Comment signatures:** Append `— *m4x-ops*` to every GitHub comment and PR review you post.
+
 **Git Workflow:**
 
 - Branch: `fix/kaizen-<issue-number>`

--- a/.claude/agents/miner.md
+++ b/.claude/agents/miner.md
@@ -244,6 +244,8 @@ git -c user.name="m4x-miner" -c user.email="miner@metaphorex.org" commit ...
 
 If the token is NOT set, use default auth (no prefix needed).
 
+**Comment signatures:** Append `— *m4x-miner*` to every GitHub comment and PR review you post.
+
 **Git Workflow:**
 
 - Create a branch: `mine/<project-name>/<slug>`

--- a/.claude/agents/prospector.md
+++ b/.claude/agents/prospector.md
@@ -138,6 +138,8 @@ git -c user.name="m4x-ops" -c user.email="ops@metaphorex.org" commit ...
 
 If the token is NOT set, use default auth (no prefix needed).
 
+**Comment signatures:** Append `— *m4x-ops*` to every GitHub comment and PR review you post.
+
 **Process:**
 
 1. If no target specified, pick the next unprospected import-project issue

--- a/.claude/agents/smelter.md
+++ b/.claude/agents/smelter.md
@@ -183,6 +183,8 @@ git -c user.name="m4x-miner" -c user.email="miner@metaphorex.org" commit ...
 
 If the token is NOT set, use default auth (no prefix needed).
 
+**Comment signatures:** Append `— *m4x-miner*` to every GitHub comment and PR review you post.
+
 **Git Workflow:**
 
 - Push fixup commits to the existing PR branch

--- a/.claude/agents/surveyor.md
+++ b/.claude/agents/surveyor.md
@@ -71,6 +71,8 @@ git -c user.name="m4x-reviewer" -c user.email="reviewer@metaphorex.org" commit .
 
 If the token is NOT set, use default auth (no prefix needed).
 
+**Comment signatures:** Append `— *m4x-reviewer*` to every GitHub comment and PR review you post.
+
 **Review Process:**
 
 1. Read the playbook — focus on Access Method and Source Description


### PR DESCRIPTION
Closes #2338

## Summary

- Added a **Comment signatures** instruction to all 6 agent prompts in `.claude/agents/`
- Each agent is told to append a role-based signature line to every GitHub comment and PR review
- Signatures match the bot account that posts them:
  - `miner.md`, `smelter.md` (m4x-miner role): `— *m4x-miner*`
  - `assayer.md`, `surveyor.md` (m4x-reviewer role): `— *m4x-reviewer*`
  - `prospector.md`, `fixer.md` (m4x-ops role): `— *m4x-ops*`

## What was broken

Bot-posted comments were indistinguishable from human comments at a glance. There was no convention for agents to identify themselves in their GitHub activity.

## What the fix does

Adds a single `**Comment signatures:**` line right after each agent's Identity section. The instruction is minimal and unambiguous: append the signature to every comment and review.

## Test plan

- [x] Verified each edit is a single-line addition placed after the Identity block
- [x] Confirmed signature text matches the role mapping from the fix spec

— *m4x-ops*