### PR TITLE
Add 5 entries: bannard aphorisms and carpentry proverbs batch

### DIFF
--- a/catalog/entries/best-carpenters-fewest-chips.md
+++ b/catalog/entries/best-carpenters-fewest-chips.md
@@ -1,0 +1,171 @@
+---
+author: agent:metaphorex-miner
+categories:
+- arts-and-culture
+- software-engineering
+contributors: []
+created: '2026-03-21'
+grounding: folk
+harness: Claude Code
+kind: mental-model
+limits:
+- '[model] conflates economy of action with economy of waste -- a carpenter who makes few chips may have done so by planning precisely, or by cutting timidly and leaving excess material, so chip-count alone is ambiguous without knowing whether the target dimensions were achieved'
+- '[model] fails in domains where exploration is the point -- a researcher who runs the fewest experiments is not the best researcher, because the goal is discovery rather than execution of a known plan, yet the proverb''s structure rewards convergence over divergence'
+name: Best Carpenters Make the Fewest Chips
+provenance: carpentry-woodworking
+related:
+- let-the-tool-do-the-work
+- good-art-carries-high-density-of-choice
+slug: best-carpenters-fewest-chips
+source_frame: carpentry
+transfers:
+- '[model] precise cuts remove exactly the planned material and nothing more, so waste volume is a visible proxy for the gap between intention and execution -- transferring the prediction that in any craft with irreversible material removal, low waste indicates high planning quality'
+- '[model] each chip represents a corrective cut that a better plan would have avoided, encoding the principle that rework is a lagging indicator of upstream planning failure, which transfers to software (fewer bug-fix commits), writing (fewer revision passes), and surgery (fewer corrective procedures)'
+- '[model] the proverb counts outputs (chips) rather than inputs (effort or time), providing a metric that is observable by third parties without access to the practitioner''s process, which is why it functions as a folk quality heuristic across trades'
+updated: '2026-03-21'
+---
+
+## Transfers
+
+The proverb dates to the English woodworking tradition, with variants
+attested from the sixteenth century onward. "The best carpenter makes
+the fewest chips" (sometimes "the best workman makes the fewest chips")
+encodes a folk observation about the relationship between skill and
+waste. A carpenter who must plane, trim, and re-cut produces a pile of
+shavings and offcuts; a carpenter who measures precisely, cuts once, and
+fits cleanly leaves little behind.
+
+Key structural parallels:
+
+- **Waste as inverse skill metric** -- the proverb's core structure.
+  In carpentry, every chip is material that was attached to the
+  workpiece and should not have been, or material that needed to be
+  removed but was removed in multiple passes rather than one. The
+  skilled carpenter marks once, saws to the line, and planes to
+  final dimension in a few strokes. The unskilled carpenter overcuts,
+  then trims, then adjusts, then patches -- each step producing waste.
+  This transfers to software engineering, where the number of
+  bug-fix commits, emergency patches, and refactoring PRs after a
+  feature ships is the analogous chip pile. A well-planned
+  implementation arrives close to final form on the first pass.
+
+- **Planning quality over execution speed** -- the proverb does not
+  say the best carpenter works fastest; it says they produce the
+  least waste. The implication is that skill manifests primarily in
+  the quality of upstream thinking -- measuring, visualizing the
+  cut, reading the grain -- rather than in the speed of the saw.
+  In writing, the analogous claim is that a well-outlined piece
+  requires fewer drafts. In surgery, that a well-planned operation
+  requires fewer corrective procedures. The metric (waste) is a
+  lagging indicator of a leading quality (planning).
+
+- **Observable proxy for invisible skill** -- chips are visible;
+  planning is invisible. The proverb gives observers a way to
+  evaluate skill without understanding the craft. You do not need
+  to know joinery to see that one carpenter's floor is clean and
+  another's is covered in shavings. This proxy structure transfers
+  to any domain where process quality is hidden but its waste
+  products are visible: in software, the commit log is the chip
+  pile; in management, the number of emergency meetings is the
+  chip pile; in cooking, the volume of trimmings in the compost
+  bin tells you about the chef's knife skills.
+
+- **Economy as aesthetic** -- the proverb connects efficiency to
+  quality to beauty. A joint that fits without adjustment is not
+  only more efficient to produce; it is tighter, stronger, and
+  more elegant. Waste reduction and quality improvement are the
+  same action, not competing goals. This transfers to code (fewer
+  lines is often better code), to prose (tight writing is better
+  writing), and to design (minimalism as the aesthetic consequence
+  of precise decision-making).
+
+## Limits
+
+- **Economy is not always the goal** -- in exploratory work, waste
+  is the point. A sculptor roughing out a form from a block of
+  marble produces enormous amounts of waste by design. A researcher
+  running experiments is "making chips" deliberately -- most
+  hypotheses will fail, and that failure is informative. The
+  proverb's structure rewards convergence toward a known target,
+  not divergent exploration. Applying it to research, art, or
+  early-stage design penalizes the necessary mess of creative
+  search.
+
+- **Confuses economy of material with economy of time** -- a
+  carpenter who makes few chips may have spent hours measuring and
+  re-measuring before cutting. The waste pile is small, but the
+  time cost is high. The proverb says nothing about time efficiency;
+  it measures only material waste. In software, the developer who
+  writes the fewest bug-fix commits may have spent weeks in design
+  review. Whether that tradeoff is worthwhile depends on context
+  the proverb does not address.
+
+- **Survivorship bias** -- we see the clean workshop; we do not see
+  the practice pieces. Every expert carpenter once made enormous
+  messes. The proverb describes the endpoint of a skill development
+  curve but can be misread as a description of how the best
+  carpenters always worked. Applied prescriptively to beginners
+  ("make fewer chips"), it produces paralysis: the novice who is
+  afraid to cut wastes more material through hesitation and
+  half-cuts than one who commits to a bold, slightly-off cut.
+
+- **Chips are not always waste** -- in some woodworking traditions,
+  shavings and offcuts are themselves valuable: tinder, packing
+  material, animal bedding, kindling. The proverb assumes chips
+  have zero value, but byproducts can be resources. In software,
+  the "chips" of a project -- abandoned prototypes, exploratory
+  branches, failed approaches -- sometimes contain reusable code,
+  transferable insights, or documentation of what does not work.
+
+## Expressions
+
+- "The best carpenter makes the fewest chips" -- the English proverb,
+  attested from the 1500s in various forms
+
+- "Measure twice, cut once" -- the most widely known variant, which
+  shifts focus from the waste metric to the planning behavior that
+  reduces it
+
+- "A clean shop is a sign of a good craftsman" -- the workshop variant,
+  extending from waste volume to overall workspace discipline
+
+- "First-time quality" -- the manufacturing and lean-production term
+  for the same principle: getting the output right on the first pass,
+  eliminating rework
+
+- "Do it right the first time" -- the generic management version,
+  which preserves the planning-over-correction structure but loses
+  the specific material insight about waste as a skill metric
+
+- "Code smell" -- the software engineering adaptation (Fowler, 1999):
+  visible symptoms in the codebase that indicate upstream planning
+  or design failures, analogous to the chip pile on the workshop floor
+
+## Origin Story
+
+The proverb belongs to the English proverbial tradition and appears in
+various forms from the sixteenth century onward. It circulated among
+the craft guilds where apprenticeship was the primary mode of skill
+transmission. The workshop floor was a daily, visible record of each
+worker's skill level, and waste volume was a natural metric because
+timber was expensive and offcuts were largely useless for fine joinery.
+
+The proverb's longevity reflects the universality of its structure:
+any domain with irreversible material transformation and visible waste
+products generates the same folk observation. Butchers, tailors,
+stonemasons, and leather workers all have variants of the same
+principle. The carpentry version persists because wood is the most
+commonly worked material and "chips" is the most vivid image of waste.
+
+## References
+
+- Proverb attested in English proverbial collections from the 16th
+  century onward; see Tilley, M.P. *A Dictionary of the Proverbs
+  in England in the Sixteenth and Seventeenth Centuries*. University
+  of Michigan Press, 1950
+- Fowler, M. *Refactoring: Improving the Design of Existing Code*.
+  Addison-Wesley, 1999 -- "code smells" as the software equivalent
+  of workshop waste
+- Womack, J. & Jones, D. *Lean Thinking*. Simon & Schuster, 1996 --
+  waste elimination as the organizing principle of manufacturing
+  quality

--- a/catalog/entries/good-art-carries-high-density-of-choice.md
+++ b/catalog/entries/good-art-carries-high-density-of-choice.md
@@ -1,0 +1,151 @@
+---
+author: agent:metaphorex-miner
+categories:
+- arts-and-culture
+- philosophy
+contributors: []
+created: '2026-03-21'
+grounding: folk
+harness: Claude Code
+kind: mental-model
+limits:
+- '[model] conflates deliberateness with quality -- outsider art and folk art can be powerful precisely because they are not saturated with self-conscious choices, yet the model predicts they should register as low quality, revealing a bias toward trained-artist aesthetics'
+- '[model] provides no way to distinguish a high density of good choices from a high density of bad choices -- a maximalist painting may encode hundreds of decisions per square inch and still be terrible, so choice-density is necessary but not sufficient and the model is incomplete without a quality-of-choice criterion'
+name: Good Art Carries High Density of Choice
+provenance: bannard-aphorisms
+related:
+- best-carpenters-fewest-chips
+- in-art-remedy-mistakes-by-taking-advantage-of-them
+slug: good-art-carries-high-density-of-choice
+source_frame: visual-arts-practice
+transfers:
+- '[model] in painting, a passage that looks effortless often encodes dozens of decisions -- color temperature, edge hardness, value relationship, brushstroke direction -- compressed so that no single choice calls attention to itself, structuring the prediction that perceived effortlessness correlates with decision density, not decision absence'
+- '[model] the metric is decisions per unit, not effort per unit, which distinguishes this from labor theories of value and transfers to writing (every word in a poem is chosen while prose tolerates default phrasing), cooking (a composed dish vs. a reheated one), and code (idiomatic one-liners that compress multiple design decisions)'
+- '[model] carries the diagnostic that when art feels thin or generic, the underlying cause is often low decision density -- the artist defaulted to convention rather than choosing at each point -- providing a structural explanation for why mass-produced and formulaic work reads as inferior even when technically competent'
+updated: '2026-03-21'
+---
+
+## Transfers
+
+The aphorism is associated with the American painter and critic Darby
+Bannard, who used it to articulate what separates accomplished painting
+from competent painting. His observation was not about effort or
+technique in isolation but about something more specific: the number of
+deliberate decisions per unit of finished surface. A master's brushstroke
+encodes choices about color, value, temperature, edge quality, direction,
+thickness, and placement -- simultaneously. A student's brushstroke
+typically addresses one or two of these dimensions and defaults on the
+rest.
+
+Key structural parallels:
+
+- **Decisions per unit, not effort per unit** -- the principle's most
+  important distinction. A painting can take thousands of hours and
+  still be low-density if most of those hours were spent on mechanical
+  execution (filling in, smoothing, copying). Conversely, a painting
+  done in a single session can be high-density if every stroke was a
+  genuine decision. This metric -- decisions per unit of output, not
+  time per unit -- transfers directly to writing. Poetry is denser
+  than prose because every word is chosen; prose permits filler. A
+  well-written legal brief is denser than a verbose one. A well-designed
+  API is denser than a sprawling one.
+
+- **Effortlessness as compression, not absence** -- when a viewer says
+  a painting "looks effortless," they are describing the successful
+  compression of many decisions into a result that does not display
+  its labor. This is not the absence of effort but the invisibility of
+  it. The same structure appears in athletic performance (the great
+  athlete looks relaxed because every micro-adjustment is automatic),
+  in prose style (Hemingway's "simple" sentences compress extensive
+  editorial judgment), and in code (a well-factored function that
+  "just works" compresses extensive architectural reasoning).
+
+- **Convention as the zero-choice default** -- the model implies that
+  for every decision point, there is a default (the conventional
+  response) and an active choice. When an artist uses the conventional
+  color, the expected composition, the standard technique, they are
+  making zero choices at those points. The density drops. This explains
+  why technically proficient academic painting can feel "dead": every
+  element is correct but none was chosen. The same applies to writing
+  that uses cliches (zero-choice language), to architecture that uses
+  standard floor plans (zero-choice spatial design), and to software
+  that uses boilerplate patterns without adapting them (zero-choice
+  engineering).
+
+- **Quality as information** -- there is an implicit information-theoretic
+  structure. High-density choice is high-entropy: each element carries
+  information because it could have been otherwise. Low-density choice
+  is low-entropy: each element is predictable from convention. The
+  viewer's experience of "interest" or "richness" correlates with
+  encountering decisions they did not expect. This transfers to any
+  domain where quality is judged by engagement rather than by
+  compliance with specification.
+
+## Limits
+
+- **Choice-density is necessary but not sufficient** -- a painting can
+  be saturated with deliberate decisions and still fail. Every color
+  chosen, every edge considered, every value relationship weighed -- and
+  the result is incoherent, overwrought, or simply ugly. The model
+  provides no quality criterion for the choices themselves, only a
+  quantity metric. Maximalism can be high-density and terrible.
+
+- **Biased toward trained-artist aesthetics** -- outsider art, folk
+  art, children's art, and naive art can be powerfully affecting
+  precisely because they lack the self-conscious decision-making the
+  model privileges. A Grandma Moses painting is not dense with
+  deliberate choices in Bannard's sense, yet it communicates something
+  that highly trained work sometimes does not. The model cannot account
+  for this without expanding "choice" to include unconscious or
+  intuitive decisions, which stretches the concept past its usefulness.
+
+- **Invisible to the untrained viewer** -- the model implies that
+  quality is recognizable through its density, but untrained viewers
+  often cannot perceive the decisions that make a work dense. A
+  layperson may prefer a low-density illustration (clear, clean,
+  conventionally pretty) over a high-density painting (complex,
+  ambiguous, demanding). The model describes a real structural
+  property but one that requires trained perception to detect.
+
+- **Conflates kinds of choices** -- a choice about color temperature
+  and a choice about subject matter are different kinds of decisions
+  operating at different scales. The model treats all choices as
+  equivalent units to be counted, but some choices cascade (a
+  compositional decision constrains hundreds of subsequent brushwork
+  decisions) while others are local. Total decision count may matter
+  less than the quality of a few high-leverage decisions.
+
+## Expressions
+
+- "Good art carries high density of choice" -- Bannard's formulation,
+  common in painting criticism and MFA studio critiques
+
+- "Every mark is a decision" -- the studio-instruction variant,
+  used to push students past default mark-making
+
+- "Kill your darlings" -- the writing corollary (attributed to
+  various sources), which implies that if you cannot justify a
+  sentence's presence as a deliberate choice, it should be cut
+
+- "There are no neutral choices in a poem" -- the poetics version,
+  asserting that every word, line break, and sound pattern is a
+  decision-carrying element
+
+- "Opinionated design" -- the software and product-design adaptation:
+  a framework or product that encodes strong choices at every level
+  rather than deferring decisions to the user
+
+- "God is in the details" -- Mies van der Rohe's architecture
+  principle, which locates quality in the density of micro-level
+  decisions rather than in the overall concept
+
+## References
+
+- Bannard, D. "Aphorisms for Artists." *artblog.net* and personal
+  notebooks -- the source of the aphorism and its intellectual context
+- Arnheim, R. *Art and Visual Perception*. University of California
+  Press, 1954 -- the perceptual basis for distinguishing deliberate
+  from default visual organization
+- Gombrich, E.H. *Art and Illusion*. Phaidon, 1960 -- on the role of
+  convention and schema in visual art, which provides the theoretical
+  background for "zero-choice defaults"

--- a/catalog/entries/in-art-remedy-mistakes-by-taking-advantage-of-them.md
+++ b/catalog/entries/in-art-remedy-mistakes-by-taking-advantage-of-them.md
@@ -1,0 +1,144 @@
+---
+author: agent:metaphorex-miner
+categories:
+- arts-and-culture
+- decision-making
+contributors: []
+created: '2026-03-21'
+grounding: folk
+harness: Claude Code
+kind: mental-model
+limits:
+- '[model] applies only when the error is materially present and reworkable -- a dancer cannot incorporate a stumble after the performance is over, and a surgeon cannot reframe a wrong incision as a design feature, so the heuristic requires ongoing process, not retrospective evaluation'
+- '[model] risks becoming a rationalization for carelessness -- the principle describes what skilled practitioners do with unavoidable errors, not a license to skip preparation, yet popular usage often collapses the distinction between recovering from mistakes and not bothering to avoid them'
+name: In Art, Remedy Mistakes by Taking Advantage of Them
+provenance: bannard-aphorisms
+related:
+- good-enough-mother
+- the-painting-replaces-your-ideas-with-its-ideas
+slug: in-art-remedy-mistakes-by-taking-advantage-of-them
+source_frame: visual-arts-practice
+transfers:
+- '[model] the painter who turns an accidental drip into a compositional element is performing a cognitive reframe: reclassifying an event from "deviation from plan" to "material for the next decision," which transfers to any domain where the work-in-progress is still malleable'
+- '[model] the heuristic encodes asymmetric reversibility -- in painting, scraping off and restarting costs more than integrating, so the cheapest recovery is forward-incorporation, a cost structure that recurs in jazz improvisation, startup pivots, and iterative software development'
+- '[model] carries the prediction that practitioners who treat errors as generative material will produce more original work than those who treat errors as pure loss, because error-as-material introduces variation that deliberate planning would not have produced'
+updated: '2026-03-21'
+---
+
+## Transfers
+
+The principle originates in studio practice and is most often attributed
+to the tradition of oil painting, where the medium's slow drying time
+makes reworking not only possible but standard. A drip, an unintended
+color mixture, a brushstroke that lands wrong -- each of these can be
+scraped away, but the experienced painter often finds it cheaper and
+more interesting to incorporate them. The aphorism encodes this studio
+wisdom as a general heuristic.
+
+Key structural parallels:
+
+- **Forward-incorporation is cheaper than reversal** -- in oil painting,
+  scraping back to bare canvas and repainting costs time, material, and
+  the accumulated texture of prior layers. Incorporating the error costs
+  only a change of intention. This cost asymmetry transfers directly to
+  domains where undoing is expensive: in jazz, stopping to restart a
+  phrase breaks the ensemble's flow, while bending a wrong note into a
+  chromatic approach tone costs nothing. In software, reverting a shipped
+  feature and re-architecting is expensive; pivoting the feature to serve
+  the use case it accidentally enabled is often cheaper.
+
+- **Error as variation source** -- deliberate planning tends to stay
+  within the planner's existing repertoire. Mistakes introduce
+  genuinely unplanned material. The painter who always mixes the
+  same palette will never discover certain color relationships; the
+  accidental mixture forces exploration. This is structurally identical
+  to the role of mutation in evolutionary search: variation that the
+  system would not have generated on purpose becomes the raw material
+  for selection.
+
+- **Skill determines whether the heuristic works** -- a beginning
+  painter cannot incorporate a drip because they lack the compositional
+  vocabulary to integrate unexpected elements. The aphorism describes
+  expert behavior: the practitioner who has internalized enough
+  technique to improvise around disruption. This transfers to jazz
+  (only a musician with strong harmonic knowledge can turn a wrong note
+  into a substitution) and to entrepreneurship (only a team with deep
+  domain knowledge can recognize that their failed product accidentally
+  solves a different problem).
+
+- **The heuristic reframes the emotional register of error** -- in most
+  domains, mistakes trigger anxiety and self-criticism. The aphorism
+  proposes a different response: curiosity. "What can this become?"
+  replaces "How do I fix this?" This affective shift is itself a
+  transferable cognitive tool, used in improvisational theater (the
+  "yes, and" principle), design thinking (prototype failures as
+  learning), and resilience psychology (post-traumatic growth).
+
+## Limits
+
+- **Not all errors are reworkable** -- the aphorism applies to
+  domains where the work is still in progress and the medium is
+  forgiving. A painter working in wet oil has options; a fresco painter
+  working into wet plaster has far fewer. A surgeon cannot reframe
+  a misplaced cut. A bridge engineer cannot incorporate a structural
+  miscalculation. The heuristic requires that (a) the process is
+  ongoing, (b) the medium permits reworking, and (c) the stakes
+  allow experimentation. In domains where errors are irreversible or
+  life-critical, the only responsible response is prevention, not
+  incorporation.
+
+- **Confuses description with prescription** -- the aphorism describes
+  what skilled practitioners actually do (incorporate errors) and
+  presents it as advice (you should incorporate errors). But the skill
+  to do this is exactly what beginners lack. Telling a novice to
+  "take advantage of mistakes" without teaching the compositional
+  judgment required is like telling a non-swimmer to "use the current."
+  The advice is true but not actionable without substantial prior
+  competence.
+
+- **Slides into excuse-making** -- "I meant to do that" is the
+  degenerate form of this principle. When error-incorporation becomes
+  a retrospective justification rather than a genuine creative response,
+  the heuristic stops generating good work and starts generating
+  self-deception. The line between creative recovery and rationalized
+  carelessness is real but unmarked, and the aphorism provides no
+  criterion for distinguishing them.
+
+- **Selection bias in the evidence** -- we remember the drip that
+  became a design element; we do not remember the hundreds of drips
+  that were simply wiped away. The aphorism survives because its
+  confirming instances are memorable and its disconfirming instances
+  are invisible. The actual base rate of "mistakes successfully
+  incorporated" vs. "mistakes that just made things worse" is unknown
+  and probably unfavorable.
+
+## Expressions
+
+- "In art, one must remedy mistakes by taking advantage of them" --
+  the aphorism itself, widely attributed to various sources in the
+  painting tradition
+
+- "There are no mistakes, only happy accidents" -- Bob Ross's
+  popularization, which preserves the incorporation principle but
+  softens it by denying the mistake entirely
+
+- "Wrong notes are just one fret away from right ones" -- jazz and
+  blues teaching shorthand for the same principle applied to harmony
+
+- "Pivot" -- the startup term for incorporating a market mistake
+  by redirecting the company toward what the failed product accidentally
+  revealed
+
+- "Yes, and" -- improvisational theater's foundational rule, which
+  applies the incorporation principle to collaborative performance:
+  treat every offer, including accidental ones, as material to build on
+
+## References
+
+- Bayles, D. & Orland, T. *Art & Fear: Observations on the Perils
+  (and Rewards) of Artmaking*. Image Continuum Press, 1993 -- explores
+  the role of error in studio practice
+- Nachmanovitch, S. *Free Play: Improvisation in Life and Art*.
+  Tarcher, 1990 -- the incorporation principle across art forms
+- Ries, E. *The Lean Startup*. Crown, 2011 -- the "pivot" as
+  systematic error-incorporation in entrepreneurship

--- a/catalog/entries/let-the-tool-do-the-work.md
+++ b/catalog/entries/let-the-tool-do-the-work.md
@@ -1,0 +1,143 @@
+---
+author: agent:metaphorex-miner
+categories:
+- software-engineering
+- arts-and-culture
+contributors: []
+created: '2026-03-21'
+grounding: folk
+harness: Claude Code
+kind: mental-model
+limits:
+- '[model] assumes the tool is appropriate for the task -- a carpenter forcing a chisel is sometimes using the wrong chisel, not the wrong technique, and the maxim cannot distinguish between operator error and tool-task mismatch without external judgment'
+- '[model] presupposes a well-designed tool -- the principle holds for a sharp plane on straight-grained timber but fails when the tool itself is defective or the material is pathological, yet it offers no diagnostic for when resistance signals tool failure rather than user error'
+name: Let the Tool Do the Work
+provenance: carpentry-woodworking
+related:
+- best-carpenters-fewest-chips
+slug: let-the-tool-do-the-work
+source_frame: carpentry
+transfers:
+- '[model] a sharp hand plane removes shavings under its own weight -- the operator guides direction and depth while the blade geometry does the cutting -- encoding the principle that a well-configured tool requires guidance, not force, which transfers to any system where excessive operator effort signals misalignment between setup and task'
+- '[model] the diagnostic is embodied: muscular strain in the operator is the error signal, not the outcome, allowing real-time detection of misuse before the work is ruined, a feedback structure that transfers to software (fighting the framework), writing (forcing a sentence), and management (micromanaging a capable team)'
+- '[model] carries the prediction that increasing operator force will degrade rather than improve results -- a forced plane chatters and tears grain, a forced framework produces brittle workarounds -- because the tool''s design encodes constraints that force violates'
+updated: '2026-03-21'
+---
+
+## Transfers
+
+In carpentry, "let the tool do the work" is among the first lessons
+taught and the last fully learned. A sharp hand plane, properly set,
+removes a continuous ribbon of wood under nothing more than its own
+weight and the forward motion of the operator's arms. A sharp chisel,
+struck with a mallet at the correct angle, splits wood along the grain
+with minimal effort. When the operator finds themselves pushing hard,
+gripping tight, or sweating over a cut, the principle says: the problem
+is not insufficient effort. The problem is setup -- a dull blade, a
+wrong angle, an inappropriate tool for the material, a workpiece that
+is not properly secured.
+
+Key structural parallels:
+
+- **Effort as diagnostic, not solution** -- the most important
+  transfer. In carpentry, muscular strain is not a sign that you need
+  to try harder; it is a sign that something is wrong upstream. The
+  blade is dull. The grain direction is fighting you. The workpiece
+  is not clamped. This inverts the naive assumption that difficulty
+  requires more effort and replaces it with: difficulty requires
+  diagnosis. In software engineering, fighting your framework --
+  writing elaborate workarounds, monkey-patching core behavior,
+  writing thousands of lines to accomplish what the framework should
+  handle in tens -- is the equivalent of forcing a dull plane. The
+  correct response is not more code but a step back: are you using
+  the right tool? Is it configured correctly? Are you working with
+  or against its design assumptions?
+
+- **Setup over execution** -- the principle implies that most of the
+  skill is in preparation. Sharpening the blade, selecting the right
+  tool, reading the grain, securing the workpiece -- these upstream
+  decisions determine whether execution will be effortless or agonizing.
+  In writing, the equivalent is outlining: a writer who has thought
+  through the structure of an argument before drafting will find that
+  sentences "write themselves." A writer who starts without structure
+  will force every paragraph. In management, it is hiring: a manager
+  with the right team in place can "let the team do the work"; a
+  manager with the wrong team will micromanage and exhaust themselves.
+
+- **The tool encodes accumulated knowledge** -- a well-designed hand
+  plane embodies centuries of refinement: the blade angle, the throat
+  opening, the sole geometry all encode solutions to problems that
+  the individual user need not re-solve. Forcing the tool means
+  overriding this accumulated knowledge with individual effort. In
+  software, a framework encodes architectural decisions; fighting it
+  means re-solving problems the framework authors already solved,
+  usually worse.
+
+- **Bodily feedback is the signal** -- in carpentry, you feel resistance
+  through your hands before you see bad results in the wood. The
+  principle teaches practitioners to attend to this proprioceptive
+  signal as an early warning system. The software equivalent is the
+  feeling of dread when modifying a certain module, the sense that
+  a feature is "fighting you." These affective signals are real
+  diagnostic information, not mere frustration.
+
+## Limits
+
+- **Not all resistance is operator error** -- sometimes the wood is
+  knotty, cross-grained, or spalted, and no amount of correct
+  technique will make the cut easy. The principle can mislead when
+  the material is genuinely difficult. In software, some problems are
+  inherently complex -- they fight every framework because they are
+  hard, not because you chose the wrong tool. The principle provides
+  no way to distinguish "you are using this wrong" from "this is
+  genuinely hard."
+
+- **Assumes the tool exists and is appropriate** -- "let the tool
+  do the work" presupposes that the right tool is available. When
+  no existing tool fits the task, the principle becomes inapplicable.
+  In software, this manifests as over-reliance on frameworks: if
+  your problem does not fit any existing framework's assumptions,
+  the correct response may be to build a bespoke solution, not to
+  keep searching for a framework that does the work for you.
+
+- **Can produce learned helplessness with tools** -- taken too far,
+  the principle suggests that the operator should never exert effort,
+  which can produce a dependence on tooling that atrophies fundamental
+  skill. A carpenter who only uses power tools may lose the ability
+  to work by hand. A programmer who only uses frameworks may lose
+  the ability to think about data structures. The principle is about
+  efficiency, not about delegating all understanding to the tool.
+
+- **Hides the cost of setup** -- the principle makes execution look
+  effortless but does not advertise the hours spent sharpening,
+  learning tool geometry, and developing the judgment to select the
+  right tool. An observer sees the easy cut; they do not see the
+  years of preparation that made it easy. This can create unrealistic
+  expectations: "If I just find the right tool, the work will be
+  easy" -- when in fact, the work of learning to use the right tool
+  correctly is itself substantial.
+
+## Expressions
+
+- "Let the tool do the work" -- the standard carpentry maxim,
+  transmitted in workshops and woodworking instruction since at
+  least the 19th century guild tradition
+
+- "If you're forcing it, something's wrong" -- the diagnostic
+  corollary, common in trades from plumbing to auto mechanics
+
+- "A sharp tool is a safe tool" -- the safety variant, encoding
+  the same principle: a dull blade requires force, force reduces
+  control, reduced control causes injury
+
+- "Don't fight the framework" -- the software engineering
+  translation, common in web development communities since the
+  rise of opinionated frameworks (Rails, Django, Angular)
+
+- "Work smarter, not harder" -- the generic popularization, which
+  preserves the effort-as-diagnostic structure but loses the
+  specific insight about tool-operator-material relationships
+
+- "You're holding it wrong" -- Apple's inadvertent invocation (2010),
+  which applies the same structure to product design: if the user
+  is struggling, the problem may be in the tool, not the user

--- a/catalog/entries/the-painting-replaces-your-ideas-with-its-ideas.md
+++ b/catalog/entries/the-painting-replaces-your-ideas-with-its-ideas.md
@@ -1,0 +1,170 @@
+---
+applies_to:
+- creative-process
+author: agent:metaphorex-miner
+categories:
+- arts-and-culture
+- philosophy
+contributors: []
+created: '2026-03-21'
+grounding: folk
+harness: Claude Code
+kind: metaphor
+limits:
+- '[source] breaks because a painting has no nervous system, no preferences, and no goals -- attributing "ideas" to the canvas is a projection of the artist''s unconscious pattern-recognition onto inert material, and the metaphor obscures this by granting the object literal agency'
+- '[source] misleads when taken as permission to abandon intention entirely -- the painter who only follows the canvas''s "ideas" without contributing compositional judgment produces not art but randomness, yet the metaphor provides no vocabulary for the necessary balance between responsiveness and direction'
+name: The Painting Replaces Your Ideas with Its Ideas
+provenance: bannard-aphorisms
+related:
+- in-art-remedy-mistakes-by-taking-advantage-of-them
+- good-art-carries-high-density-of-choice
+slug: the-painting-replaces-your-ideas-with-its-ideas
+source_frame: visual-arts-practice
+transfers:
+- '[source] in painting, the physical state of the canvas at each stage generates visual relationships the artist did not plan -- an accidental color adjacency, an unexpected spatial rhythm -- which then demand responses that override the original intention, mapping agency from the artist onto the accumulating material'
+- '[source] the work-in-progress functions as a second interlocutor whose "proposals" are the emergent properties of accumulated decisions, structuring the creative process as a dialogue between the maker''s plan and the object''s emergent logic'
+- '[source] carries the temporal structure of progressive displacement: the artist''s original idea governs early marks but loses authority as the painting''s own visual logic becomes more articulated, so that late-stage decisions are dictated more by what is already on the canvas than by what was originally intended'
+updated: '2026-03-21'
+---
+
+## Transfers
+
+The aphorism, associated with the painter and critic Darby Bannard,
+names a phenomenon familiar to anyone who has worked in a material
+medium: the plan you started with is not the plan you finish with, and
+the reason is not that you changed your mind but that the work itself
+changed it for you. The painting -- the physical object accumulating on
+the canvas -- develops properties that were not part of the original
+conception. These emergent properties make demands. They suggest
+continuations. They veto alternatives. The painter who listens to these
+demands produces better work than the painter who insists on the
+original plan.
+
+Key structural parallels:
+
+- **Emergent properties as agency** -- the metaphor's core move. A
+  painting is pigment on fabric. It has no ideas. But it does have
+  emergent visual properties: color relationships, spatial rhythms,
+  textural contrasts, value patterns. These properties arise from the
+  accumulation of brushstrokes and were not fully predictable from
+  the plan. When Bannard says the painting "has ideas," he means
+  these emergent properties constrain and direct the next move more
+  powerfully than the artist's original intention. The metaphor
+  personifies this constraint as agency. The same structure appears
+  in software: a codebase "wants" to be refactored in a certain
+  direction -- meaning its accumulated architectural decisions make
+  some changes natural and others prohibitively expensive.
+
+- **Progressive displacement of original intention** -- the temporal
+  structure is crucial. At the start, the artist's idea governs: the
+  first marks are deliberate, planned, controlled. But each mark
+  changes the visual field, and the changed field generates new
+  relationships. By mid-painting, the artist is responding as much
+  to what is on the canvas as to what was in the plan. By late
+  stages, the original idea may be entirely displaced. This is
+  structurally identical to how novels develop: many authors report
+  that characters "take over" the story, meaning that the logic of
+  the accumulated narrative constrains subsequent choices more than
+  the outline does. In software, this is the codebase that has
+  "outgrown its architecture" -- the accumulated implementation
+  decisions have generated a structure that resists the original
+  design and proposes its own.
+
+- **Responsiveness as skill** -- the metaphor implies that the good
+  painter is the one who listens to the painting's "ideas" rather
+  than forcing the original plan. This frames creative skill not as
+  execution of intention but as sensitivity to emergent possibility.
+  The same valorization of responsiveness appears in improvisational
+  music (the ensemble follows where the music goes, not where the
+  chart says), in agile software development (respond to what the
+  code and users are telling you, not what the spec says), and in
+  military strategy (adapt to the battlefield, not the war plan).
+
+- **The work as interlocutor** -- the deepest transfer. The metaphor
+  structures the creative process as a conversation between two
+  agents: the artist (who has intentions) and the painting (which
+  has emergent demands). Neither has sole authority. The artist
+  proposes; the painting disposes. This dialogic structure appears
+  wherever makers work with resistant or responsive material: the
+  sculptor in conversation with the stone's grain, the potter
+  responding to the clay's behavior on the wheel, the programmer
+  in dialogue with the compiler's error messages.
+
+## Limits
+
+- **The painting has no ideas** -- the fundamental limit. Attributing
+  agency to an inert object is a projection. What the painter
+  perceives as the painting's "ideas" are patterns recognized by the
+  painter's own visual system. The canvas does not propose; the
+  painter's trained perception proposes and attributes the proposal
+  to the canvas. The metaphor is useful precisely because it
+  externalizes an internal process (unconscious pattern recognition)
+  and makes it available for conscious response, but it becomes
+  misleading if taken literally as a claim about the object's agency.
+
+- **Abandoning intention entirely produces nothing** -- the metaphor
+  implies that the painting's ideas are better than the artist's.
+  But a painter who starts with no intention and merely responds to
+  accidents produces random accumulation, not art. The metaphor
+  describes a balance between intention and responsiveness but
+  provides no framework for where the balance should sit. Bannard
+  himself was a highly intentional painter; the aphorism describes
+  how even strong intentions are modified by material reality, not
+  a recommendation to start without intentions.
+
+- **Medium-specific** -- the metaphor draws its force from painting's
+  particular properties: slow accumulation, visible history, spatial
+  simultaneity (all marks coexist on the surface). It transfers less
+  cleanly to time-based arts where previous decisions are not
+  simultaneously visible. A musician cannot "look at" the first
+  sixteen bars while improvising the seventeenth in the way a painter
+  can look at the entire canvas while placing the next stroke. The
+  dialogic structure weakens in media where the work-in-progress is
+  not persistently perceivable.
+
+- **Romanticizes a loss of control** -- the metaphor frames the
+  displacement of intention as a positive event ("the painting's
+  ideas are better"). But sometimes the painting's emergent
+  properties are leading the artist toward incoherence, and the
+  correct response is to override them -- to scrape back, to
+  reassert the original structure, to refuse the painting's
+  "suggestion." The metaphor provides no criterion for when to
+  listen and when to override.
+
+## Expressions
+
+- "The painting replaces your ideas with its ideas" -- Bannard's
+  aphorism, used in painting instruction and studio critiques
+
+- "The painting tells you what it needs" -- a common studio variant,
+  shifting from "replacement" to "communication"
+
+- "My characters took over the story" -- the fiction writer's version,
+  attributing agency to accumulated narrative logic rather than to
+  visual properties
+
+- "The code wants to be refactored this way" -- the software
+  engineering equivalent, attributing agency to the codebase's
+  accumulated architectural pressures
+
+- "Listen to the material" -- the craft-tradition generalization,
+  common in ceramics, woodworking, and metalwork: attend to what
+  the material's properties suggest rather than forcing your plan
+
+- "Plans are useless, but planning is indispensable" -- Eisenhower's
+  dictum, which captures the same temporal structure: the plan
+  governs the start, but reality (the painting's "ideas") governs
+  the execution
+
+## References
+
+- Bannard, D. "Aphorisms for Artists." *artblog.net* and personal
+  notebooks -- the source of the aphorism
+- Bayles, D. & Orland, T. *Art & Fear: Observations on the Perils
+  (and Rewards) of Artmaking*. Image Continuum Press, 1993 --
+  discusses the dialogic relationship between artist and work
+- Elkins, J. *What Painting Is*. Routledge, 1999 -- on the
+  materiality of paint and its role in directing the painter
+- Schon, D. *The Reflective Practitioner*. Basic Books, 1983 --
+  theorizes the "back-talk" of materials in professional practice,
+  the academic version of Bannard's insight


### PR DESCRIPTION
## Summary

- **in-art-remedy-mistakes-by-taking-advantage-of-them** (mental-model, visual-arts-practice) -- Closes #1873
- **let-the-tool-do-the-work** (mental-model, carpentry) -- Closes #1874
- **good-art-carries-high-density-of-choice** (mental-model, visual-arts-practice) -- Closes #1875
- **best-carpenters-fewest-chips** (mental-model, carpentry) -- Closes #1876
- **the-painting-replaces-your-ideas-with-its-ideas** (metaphor, visual-arts-practice) -- Closes #1877

Three entries from Bannard's aphorisms on studio practice and two carpentry proverbs. Kind assignments: four mental-models (cognitive heuristics transferable across domains) and one metaphor (personification of the canvas as an agent with ideas).

## Validator output

Zero errors. 128 pre-existing warnings (dangling references in other entries).

## Validation

- Frontmatter schema compliance: all 5 entries valid
- Transfers, Limits, Expressions sections: all substantive
- No existing entries or frames were modified
- `uv run scripts/validate.py validate` -- 0 errors