### PR TITLE
Add entry: Banach-Tarski Paradox

### DIFF
--- a/catalog/entries/banach-tarski-paradox.md
+++ b/catalog/entries/banach-tarski-paradox.md
@@ -1,0 +1,177 @@
+---
+slug: banach-tarski-paradox
+name: Banach-Tarski Paradox
+kind: mental-model
+source_frame: set-theory
+categories:
+  - mathematics-and-logic
+  - philosophy
+author: agent:metaphorex-miner
+contributors: []
+related:
+  - hilberts-hotel
+  - zenos-paradox
+  - russells-paradox
+provenance: mathematical-folklore
+created: '2026-03-21'
+updated: '2026-03-21'
+grounding: proven
+harness: Claude Code
+transfers:
+  - '[model] demonstrates that decomposing a whole into parts and reassembling them can yield more than the original, exposing the hidden dependence of conservation laws on measurability -- the pieces are so irregular that "volume" is undefined for them, so no volume is created or destroyed'
+  - '[model] shows that individually valid transformations (rigid rotations and translations applied to well-defined sets) can compose into a globally impossible-seeming outcome, diagnosing the class of errors where each step passes audit but the aggregate violates a constraint no single step was checked against'
+  - '[model] imports the distinction between constructive and non-constructive existence: the paradoxical decomposition requires the Axiom of Choice to select pieces that cannot be explicitly described, teaching that some proofs guarantee existence without providing any recipe for realization'
+limits:
+  - '[model] breaks when applied to physical matter, because the "pieces" in the theorem are not physical objects -- they are non-measurable sets with no volume, area, or boundary, and no physical cutting process can produce them; invoking Banach-Tarski to question conservation of mass is a category error'
+  - '[model] misleads by suggesting that axiom systems routinely produce absurdities, when the result is better understood as revealing that our intuition about volume is an extra assumption (Lebesgue measurability) not guaranteed by the basic axioms of set theory -- the paradox is precise, not pathological'
+  - '[model] obscures the role of dimensionality: the result holds in three or more dimensions but fails in one and two dimensions, meaning the "valid steps, impossible outcome" intuition does not generalize to all decomposition problems -- the geometry matters, not just the logic'
+---
+
+## Transfers
+
+In 1924, Stefan Banach and Alfred Tarski proved that a solid ball in
+three-dimensional space can be decomposed into a finite number of disjoint
+subsets, which can then be reassembled -- using only rotations and
+translations -- into two solid balls, each identical to the original. No
+stretching, no gaps, no overlaps. The result is a theorem, not a conjecture:
+it follows rigorously from the Zermelo-Fraenkel axioms of set theory plus the
+Axiom of Choice.
+
+The "paradox" is that volume appears to double. It does not, because the
+pieces involved are non-measurable sets -- collections so pathologically
+irregular that the concept of volume does not apply to them. The theorem does
+not violate conservation; it reveals that conservation depends on an
+assumption (measurability) that the axioms do not guarantee.
+
+Key structural parallels:
+
+- **Valid local steps, impossible global outcome** -- each step of the
+  decomposition and reassembly is a legitimate rigid motion applied to a
+  well-defined set. No individual step is wrong. Yet the composite result
+  violates a constraint (conservation of volume) that seems inviolable. This
+  is the model's primary cognitive contribution: it names a failure mode where
+  every component passes inspection but the system-level invariant is broken.
+  In software, this maps onto race conditions, composition bugs, and emergent
+  security vulnerabilities where each module is correct in isolation. In
+  finance, it maps onto regulatory arbitrage where each transaction is legal
+  but the portfolio-level position circumvents the regulation's intent.
+
+- **The hidden role of unmeasurable components** -- the trick works only
+  because the pieces are non-measurable. They are mathematical objects with no
+  physical analogue: you cannot cut them, see them, or compute their volume.
+  The model teaches that some operations succeed only by introducing entities
+  that resist inspection. In organizational restructuring, analogous moves
+  create "pieces" -- shell entities, shadow IT systems, off-balance-sheet
+  vehicles -- whose properties cannot be measured by existing instruments. The
+  Banach-Tarski pattern diagnoses situations where the unmeasurability of the
+  intermediate components is not a side effect but the mechanism.
+
+- **Axiom dependence** -- the theorem requires the Axiom of Choice, which
+  asserts the existence of certain selection functions without constructing
+  them. Without Choice, the decomposition cannot be performed. The model
+  teaches sensitivity to foundational assumptions: the "impossible" result
+  follows logically from axioms that most mathematicians accept. If you want
+  to reject the conclusion, you must reject an axiom, and that rejection has
+  consequences elsewhere. In policy, this maps onto situations where an
+  undesirable outcome is the logical consequence of accepted principles, and
+  the real debate is about which principle to revise.
+
+- **Dimensionality as a hidden constraint** -- the paradox holds in three
+  or more dimensions but not in one or two. This is because the free group
+  of rotations in three dimensions has properties that lower-dimensional
+  rotation groups lack. The model teaches that structural properties of a
+  space can enable or prevent pathological compositions, a lesson that
+  transfers to system design: adding dimensions of freedom (permissions,
+  configuration options, integration points) can cross a threshold that
+  enables composition failures impossible in simpler systems.
+
+## Limits
+
+- **No physical realization exists** -- the non-measurable pieces required
+  by the theorem cannot be produced by any physical process. They have no
+  boundary, no surface, no volume. Invoking Banach-Tarski to argue that
+  physical duplication is possible, or that conservation of mass is suspect,
+  is a category error. The theorem operates in the domain of pure set theory,
+  where "piece" means something no physical knife can cut. The model is
+  valuable for reasoning about abstract systems (axiom sets, legal frameworks,
+  software compositions) and misleading for reasoning about physical ones.
+
+- **The paradox is precise, not absurd** -- the theorem is often presented
+  as evidence that mathematics produces nonsense. It does not. It produces a
+  precise result that reveals the gap between our geometric intuition (all
+  subsets of space have volume) and the actual axioms (they do not). The model
+  should be used to identify hidden assumptions in formal systems, not to
+  argue that formal systems are unreliable. Treating Banach-Tarski as "math
+  gone wrong" misses its actual lesson, which is "your intuitions about
+  conservation include an assumption you did not notice."
+
+- **The Axiom of Choice is not optional for most mathematics** -- rejecting
+  Choice to avoid Banach-Tarski is like refusing to drive because cars can
+  crash. Choice is used throughout functional analysis, topology, and algebra.
+  The model should not be taken to imply that the Axiom of Choice is
+  suspicious or that mathematics would be better without it. The appropriate
+  lesson is that powerful axioms have powerful consequences, some of which
+  conflict with intuition.
+
+- **"Doubling" is not the interesting part** -- popular accounts focus on
+  "you can turn one ball into two!" as though the theorem were a magic trick.
+  The mathematically significant content is the existence of non-measurable
+  sets and the role of the Axiom of Choice in producing them. Using
+  Banach-Tarski primarily as a metaphor for duplication or getting something
+  for nothing misses the structural insight and reduces the model to a
+  parlor trick.
+
+## Expressions
+
+- "That's Banach-Tarski" -- describing a situation where individually valid
+  operations compose into an outcome that seems to violate a system
+  invariant
+- "The pieces are non-measurable" -- diagnosing that an operation works
+  only because the intermediate components resist inspection or accounting
+- "You're relying on the Axiom of Choice" -- pointing out that a conclusion
+  depends on an assumption so foundational that it is usually invisible, and
+  questioning whether that assumption should be accepted
+- "One ball becomes two" -- the popular shorthand, often used humorously to
+  describe accounting tricks, stock splits, or organizational duplication
+- "Banach-Tarski is an anagram of Banach-Tarski Banach-Tarski" -- the
+  mathematician's joke, which compresses the theorem's content into a
+  self-referential punchline
+
+## Origin Story
+
+Stefan Banach and Alfred Tarski published "Sur la decomposition des
+ensembles de points en parties respectivement congruentes" in
+*Fundamenta Mathematicae* in 1924. The result was a strengthening of
+an earlier theorem by Felix Hausdorff (1914), who had shown that a
+sphere's surface could be decomposed and reassembled into a larger
+surface, minus countably many points. Banach and Tarski eliminated the
+missing points, producing a clean duplication of the solid ball.
+
+The theorem was initially regarded as a curiosity or a reductio ad
+absurdum of the Axiom of Choice. Over the following decades, as
+mathematicians came to accept Choice as indispensable, the paradox
+was reinterpreted: not as evidence against Choice, but as evidence
+that measurability is a non-trivial property that must be explicitly
+imposed. This reinterpretation -- from "absurd consequence" to
+"revelatory theorem" -- is itself instructive. It shows how a
+community's framing of a result changes as the foundational
+commitments shift.
+
+The theorem entered popular mathematical culture through Martin
+Gardner's columns and has since become a standard example in set
+theory courses, philosophy of mathematics, and popular science
+writing. Its metaphorical use -- for situations where valid steps
+produce impossible outcomes -- is most common in mathematics, logic,
+and theoretical computer science.
+
+## References
+
+- Banach, S. and Tarski, A. "Sur la decomposition des ensembles de
+  points en parties respectivement congruentes," *Fundamenta
+  Mathematicae* 6 (1924): 244-277
+- Wagon, S. *The Banach-Tarski Paradox* (Cambridge, 1985) -- the
+  standard monograph, accessible to advanced undergraduates
+- Hausdorff, F. "Bemerkung uber den Inhalt von Punktmengen,"
+  *Mathematische Annalen* 75 (1914): 428-433 -- the precursor result
+- Wapner, L. *The Pea and the Sun: A Mathematical Paradox* (2005) --
+  popular account for general audiences


### PR DESCRIPTION
## Summary

- Adds `banach-tarski-paradox` entry (kind: mental-model, source_frame: set-theory)
- The other 4 issues in this mathematical-folklore batch (#1943, #1944, #1945, #1947) already had entries on main and were closed as duplicates

Closes #1946

## Validation

```
uv run scripts/validate.py validate
```

✓ All checks pass (zero errors, 148 pre-existing dangling-reference warnings)
✓ Slug matches filename
✓ Author format correct (agent:metaphorex-miner)
✓ Kind valid (mental-model)
✓ Harness field present
✓ All required body sections present and non-empty
✓ Source frame set-theory exists
✓ Enrichment fields valid: 3 transfers (min 2), 3 limits (min 2)
✓ All propositions use correct [model] prefix
✓ No empty strings or duplicates in transfers/limits

Generated with [Claude Code](https://claude.com/claude-code)