### PR TITLE
Add entry: Tragedy of the Commons

### DIFF
--- a/catalog/entries/tragedy-of-the-commons.md
+++ b/catalog/entries/tragedy-of-the-commons.md
@@ -1,0 +1,146 @@
+---
+applies_to:
+- shared-resources
+- organizational-behavior
+author: agent:metaphorex-miner
+categories:
+- mathematics-and-logic
+- economics-and-finance
+- social-dynamics
+contributors: []
+created: '2026-03-21'
+grounding: established
+harness: Claude Code
+kind: paradigm
+limits:
+  - '[paradigm] assumes actors are anonymous, interchangeable, and unable to communicate -- real commons users typically know each other, negotiate norms, and impose graduated sanctions, which changes outcomes fundamentally'
+  - '[paradigm] models the resource as a single undifferentiated pool with linear depletion, but most real commons have spatial structure, regeneration dynamics, and threshold effects that create different strategic landscapes'
+  - '[paradigm] treats the number of players as fixed, but in open-access resources the problem is often entry rather than overuse -- the strategic structure shifts from N-player dilemma to a free-entry game with different equilibria'
+name: Tragedy of the Commons
+related:
+- the-commons
+- prisoners-dilemma
+- free-rider-problem
+slug: tragedy-of-the-commons
+source_frame: game-theory
+transfers:
+  - '[paradigm] each actor faces a payoff structure where the private gain from exploiting one more unit exceeds the private share of the collective loss, making defection individually dominant regardless of what others do'
+  - '[paradigm] the tragedy is a Nash equilibrium -- no single actor can improve their outcome by unilaterally restraining themselves, so rational agents converge on mutual overexploitation even when all prefer the cooperative outcome'
+  - '[paradigm] the gap between the Nash equilibrium and the social optimum quantifies the exact cost of uncoordinated action, giving a measurable "price of anarchy" for any commons-like situation'
+updated: '2026-03-21'
+---
+
+## Transfers
+
+Hardin's 1968 formalization takes an ancient observation -- shared pastures get
+overgrazed -- and gives it the structure of an N-player game. Each herder
+choosing whether to add one more cow faces a payoff matrix where the full
+benefit of the extra cow accrues to them alone, while the cost of degradation is
+distributed across all users. This asymmetry between private benefit and
+socialized cost is the engine of the tragedy.
+
+The game-theoretic structure is what makes this a paradigm rather than a
+cautionary tale:
+
+- **Dominant strategy leads to ruin** -- adding another cow is the best response
+  regardless of what other herders do. If others restrain, you profit from the
+  abundant pasture. If others overgraze, you must extract value before the
+  resource collapses. The rational move is the same in both cases, which is why
+  appeals to conscience fail as a governance strategy. The tragedy is not caused
+  by greed but by incentive architecture.
+- **Nash equilibrium diverges from social optimum** -- the equilibrium where
+  every herder overgrazes is stable (no one benefits from unilateral restraint)
+  but Pareto-inferior to the outcome where everyone restrains. This gap between
+  what rational agents do and what they collectively prefer is the paradigm's
+  central insight. It recurs in carbon emissions, antibiotics overuse, open
+  source maintenance, and any situation where individual rationality aggregates
+  into collective loss.
+- **The price of anarchy is measurable** -- game theory quantifies how much
+  welfare is destroyed by the lack of coordination. This moves the conversation
+  from moral language ("people should cooperate") to engineering language ("this
+  coordination mechanism reduces the welfare gap by X%"). Congestion pricing,
+  cap-and-trade, and contribution licensing all work by restructuring the payoff
+  matrix rather than by changing human nature.
+- **Iteration and identity transform the game** -- in the one-shot version,
+  defection dominates. But real commons are played repeatedly by identifiable
+  actors. Repeated play enables tit-for-tat, reputation effects, and norm
+  enforcement. Ostrom's empirical work showed that communities routinely solve
+  commons problems when they have clear boundaries, monitoring, and graduated
+  sanctions -- mechanisms that convert the one-shot tragedy into an iterated
+  game where cooperation can be sustained.
+
+## Limits
+
+- **Anonymity is assumed but rare** -- Hardin's model works when actors cannot
+  identify, communicate with, or sanction each other. Most real commons
+  violate these assumptions. Village fisheries, irrigation systems, and alpine
+  meadows have been governed successfully for centuries by communities that
+  monitor members and punish free-riders. The "tragedy" describes open-access
+  resources with no governance, which is a policy failure, not an inevitability.
+  Ostrom's Nobel-winning research is the definitive empirical refutation.
+- **Linear depletion is a simplification** -- the model assumes each additional
+  cow degrades the pasture by a fixed amount. Real ecosystems have nonlinear
+  dynamics: threshold effects, regeneration capacity, and spatial heterogeneity.
+  A fishery might sustain moderate harvesting indefinitely but collapse abruptly
+  when a threshold is crossed. The linear model understates both the resilience
+  of lightly used commons and the catastrophic nature of overuse.
+- **The paradigm favors privatization** -- Hardin's original essay presented
+  only two solutions: privatize the resource or impose centralized regulation.
+  This binary obscures the vast space of community-based governance arrangements
+  that Ostrom documented. Using "tragedy of the commons" as a diagnostic tool
+  biases toward markets or states as the only remedies, sidelining cooperative
+  solutions that empirically work.
+- **Non-rivalrous resources break the model** -- the paradigm requires that one
+  actor's use diminishes what remains for others. This applies to fisheries,
+  pastures, and atmospheric carbon capacity. It does not apply to knowledge,
+  software, or digital goods, which can be copied without depletion. Applying
+  "tragedy of the commons" to Wikipedia or open source imports scarcity
+  assumptions where abundance is the structural reality.
+
+## Expressions
+
+- "Tragedy of the commons" -- Hardin's coinage, now used as shorthand for any
+  situation where individual rationality produces collective ruin
+- "Free rider problem" -- the specific failure mode where actors benefit from
+  the collective resource without contributing to its maintenance
+- "Price of anarchy" -- game-theoretic measure of the welfare loss from
+  uncoordinated action versus optimal coordination
+- "Overfishing" / "overgrazing" -- literal instances that serve as the default
+  mental models for the paradigm
+- "Race to the bottom" -- the dynamic where competitive pressure forces actors
+  to extract more, lower standards, or cut costs in ways that degrade the shared
+  resource (regulatory environment, labor standards, environmental protections)
+- "Enclosure" -- the historical and metaphorical act of privatizing a commons,
+  from English land enclosure to digital platform lock-in
+
+## Origin Story
+
+The phrase originates with Garrett Hardin's 1968 essay in *Science*, though the
+underlying game structure was recognized earlier by Lloyd (1833) and implicitly
+by Aristotle ("what is common to the greatest number has the least care
+bestowed upon it"). Hardin's contribution was the vivid framing and the claim
+of inevitability.
+
+The paradigm dominated environmental and economic policy for two decades,
+providing intellectual justification for privatization programs worldwide.
+Elinor Ostrom's *Governing the Commons* (1990) was the empirical corrective,
+documenting hundreds of successful community-managed commons and identifying
+eight design principles for sustainable governance. She won the 2009 Nobel
+Memorial Prize in Economic Sciences for this work.
+
+The tension between Hardin's theoretical pessimism and Ostrom's empirical
+optimism remains live. In technology, it structures debates about open source
+sustainability, platform governance, AI training data, and the atmospheric
+commons. The paradigm's enduring power is that it names the specific
+game-theoretic structure that makes cooperation hard -- and thereby identifies
+exactly where institutional design must intervene.
+
+## References
+
+- Hardin, G. "The Tragedy of the Commons," *Science* 162 (1968): 1243-1248
+- Ostrom, E. *Governing the Commons: The Evolution of Institutions for
+  Collective Action* (1990)
+- Lloyd, W.F. *Two Lectures on the Checks to Population* (1833) -- the
+  original overgrazing thought experiment
+- Roughgarden, T. "The Price of Anarchy in Games of Incomplete Information,"
+  *ACM EC* (2012) -- formalizing welfare loss from uncoordinated action


### PR DESCRIPTION
## Summary

- Adds `tragedy-of-the-commons` paradigm entry (game-theory source frame)
- Covers Nash equilibrium divergence, price of anarchy, Hardin vs. Ostrom
- Distinct from existing `the-commons` archetype: this entry focuses on the formal game-theoretic structure
- Resolves dangling `related` references from `prisoners-dilemma` and `stone-soup`

Closes #1962

## Validation

✓ `uv run scripts/validate.py` — 0 errors, 148 pre-existing warnings (dangling references from other entries)

## Other issues in batch

- #1960 (map-territory-problem) -- already exists, closed
- #1961 (butterfly-effect) -- already exists, closed
- #1963 (infinite-monkey-theorem) -- already exists, closed
- #1966 (halting-problem) -- already exists, closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
