### PR TITLE
Enrich: structural tags batch 1 (50 entries)

### DIFF
--- a/catalog/entries/a-bad-system-beats-a-good-person.md
+++ b/catalog/entries/a-bad-system-beats-a-good-person.md
@@ -7,6 +7,16 @@ categories:
 contributors: []
 created: '2026-03-18'
 grounding: established
+embodied_patterns:
+  - container
+  - force
+  - part-whole
+relation_types:
+  - cause
+  - contain
+  - prevent
+structure: hierarchy
+abstraction_level: generic
 kind: mental-model
 name: A Bad System Beats a Good Person
 provenance: tps-deming

--- a/catalog/entries/a-chance-to-cut-is-a-chance-to-cure.md
+++ b/catalog/entries/a-chance-to-cut-is-a-chance-to-cure.md
@@ -19,6 +19,16 @@ provenance: scheins-surgical-aphorisms
 created: '2026-03-20'
 updated: '2026-03-20'
 grounding: folk
+embodied_patterns:
+  - force
+  - blockage
+  - removal
+relation_types:
+  - transform
+  - enable
+  - cause
+structure: transformation
+abstraction_level: specific
 harness: Claude Code
 transfers:
   - '[source] Surgical access to a pathology is a precondition that may not recur -- the abdomen is already open, the patient is already under anesthesia -- importing the structure where the opportunity to intervene has its own costs and rarity that make the marginal cost of acting now far lower than acting later'

--- a/catalog/entries/a-force-is-a-moving-object.md
+++ b/catalog/entries/a-force-is-a-moving-object.md
@@ -31,6 +31,16 @@ transfers:
 - '[source] gives forces a temporal arrival structure -- a force was not here, then approached, then made impact -- making abstract causation tractable through the narrative of collision'
 - '[source] allows agents to propel forces (''she hurled accusations'', ''they launched an attack''), extending the metaphor into causation where exerting force is throwing something at a target'
 updated: '2026-03-14'
+embodied_patterns:
+  - force
+  - path
+  - blockage
+relation_types:
+  - cause
+  - transform
+  - translate
+structure: transformation
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/a-hard-row-to-hoe.md
+++ b/catalog/entries/a-hard-row-to-hoe.md
@@ -3,6 +3,16 @@ slug: a-hard-row-to-hoe
 name: A Hard Row to Hoe
 kind: metaphor
 dead: true
+embodied_patterns:
+  - path
+  - force
+  - blockage
+relation_types:
+  - cause
+  - prevent
+  - accumulate
+structure: pipeline
+abstraction_level: generic
 source_frame: agriculture
 applies_to:
 - difficulty

--- a/catalog/entries/a-la-minute.md
+++ b/catalog/entries/a-la-minute.md
@@ -15,6 +15,16 @@ related:
   - dying-on-the-pass
   - prep
 dead: false
+embodied_patterns:
+  - flow
+  - container
+  - iteration
+relation_types:
+  - transform
+  - enable
+  - select
+structure: pipeline
+abstraction_level: specific
 created: '2026-03-19'
 updated: '2026-03-19'
 grounding: folk

--- a/catalog/entries/a-place-to-wait.md
+++ b/catalog/entries/a-place-to-wait.md
@@ -24,6 +24,16 @@ transfers:
 - '[source] demands that waiting spaces communicate status -- queue position, estimated time, progress indication -- importing the architectural principle that the wait should not be opaque'
 - '[source] treats the waiting place as a liminal transition zone between two states (outside/inside, requesting/receiving), framing buffer states as architectural thresholds rather than defects'
 updated: '2026-03-14'
+embodied_patterns:
+  - container
+  - boundary
+  - path
+relation_types:
+  - contain
+  - enable
+  - translate
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/a-problem-is-a-body-of-water.md
+++ b/catalog/entries/a-problem-is-a-body-of-water.md
@@ -27,6 +27,16 @@ transfers:
 - '[source] divides problems into visible surface and hidden depths (''these issues run deep'', ''tip of the iceberg''), importing the structure where what you can see is only part of the difficulty'
 - '[source] maps currents, tides, and eddies onto forces beyond the problem-solver''s control, giving the problem its own agency that carries you along independent of your will'
 updated: '2026-03-14'
+embodied_patterns:
+  - container
+  - surface-depth
+  - flow
+relation_types:
+  - contain
+  - cause
+  - prevent
+structure: boundary
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/a-problem-is-a-locked-container-for-its-solution.md
+++ b/catalog/entries/a-problem-is-a-locked-container-for-its-solution.md
@@ -27,6 +27,16 @@ transfers:
 - '[source] frames difficulty as the strength of the lock (''tough nut to crack'', ''intractable''), providing a natural scale where hard problems have stronger locks and failed attempts are failed entries'
 - '[source] treats expertise as possession of keys rather than capacity to build, mapping the problem-solver''s skill onto a repertoire of unlocking tools'
 updated: '2026-03-17'
+embodied_patterns:
+  - container
+  - blockage
+  - boundary
+relation_types:
+  - contain
+  - prevent
+  - transform
+structure: boundary
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/a-problem-is-a-region-in-a-landscape.md
+++ b/catalog/entries/a-problem-is-a-region-in-a-landscape.md
@@ -27,6 +27,16 @@ transfers:
 - '[source] maps confusion onto disorientation and clarity onto visibility, so not knowing the solution is being lost and understanding is seeing the way out'
 - '[source] gives problems depth and a center -- moving further in is getting worse, moving toward the edges is approaching relief -- providing a spatial scale of severity'
 updated: '2026-03-17'
+embodied_patterns:
+  - container
+  - path
+  - center-periphery
+relation_types:
+  - contain
+  - cause
+  - prevent
+structure: boundary
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/a-room-of-ones-own.md
+++ b/catalog/entries/a-room-of-ones-own.md
@@ -18,6 +18,16 @@ related:
 created: '2026-03-19'
 updated: '2026-03-19'
 grounding: established
+embodied_patterns:
+  - container
+  - boundary
+  - center-periphery
+relation_types:
+  - contain
+  - enable
+  - prevent
+structure: boundary
+abstraction_level: specific
 harness: Claude Code
 transfers:
   - '[source] every person in the household has at least one space where they control the arrangement, the access, and the duration of occupancy -- a space that cannot be reorganized by others without their consent'

--- a/catalog/entries/a-schedule-is-a-moving-object.md
+++ b/catalog/entries/a-schedule-is-a-moving-object.md
@@ -27,6 +27,16 @@ transfers:
 - '[source] frames missed deadlines as objects that passed through the observer''s location without being caught, registering temporal failure as spatial failure to intercept'
 - '[source] gives schedules inertia -- once a project is ''on track'' it resists being stopped or redirected -- importing physics of moving objects into the experienced difficulty of changing plans'
 updated: '2026-03-17'
+embodied_patterns:
+  - path
+  - force
+  - near-far
+relation_types:
+  - cause
+  - prevent
+  - translate
+structure: pipeline
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/abilities-are-entities-inside-a-person.md
+++ b/catalog/entries/abilities-are-entities-inside-a-person.md
@@ -26,6 +26,16 @@ transfers:
 - '[source] maps depth within the container onto importance -- deep abilities are fundamental and authentic while surface abilities are trivial -- giving talent a vertical dimension'
 - '[source] frames education and coaching as excavation -- drawing out what is already inside rather than installing something new -- with discovery as the key pedagogical act'
 updated: '2026-03-13'
+embodied_patterns:
+  - container
+  - surface-depth
+  - boundary
+relation_types:
+  - contain
+  - enable
+  - transform
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/above-board.md
+++ b/catalog/entries/above-board.md
@@ -7,6 +7,16 @@ categories:
 contributors: []
 created: '2026-03-14'
 dead: true
+embodied_patterns:
+  - surface-depth
+  - boundary
+  - container
+relation_types:
+  - contain
+  - prevent
+  - translate
+structure: boundary
+abstraction_level: generic
 kind: metaphor
 limits:
 - '[source] breaks because some concealment is morally required -- whistleblower protections, medical privacy, and sealed court records involve deliberate hiding for good reasons that the spatial logic

--- a/catalog/entries/accessible-green.md
+++ b/catalog/entries/accessible-green.md
@@ -26,6 +26,16 @@ transfers:
 - '[source] imports the structural insight that green spaces must be distributed throughout the built environment rather than concentrated in a single large park, because a distant resource -- no matter how grand -- is not accessible in daily practice'
 - '[source] carries the principle that the green space belongs to no single household or institution but to the surrounding community collectively, framing shared ownership as a design requirement rather than an ideological preference'
 updated: '2026-03-21'
+embodied_patterns:
+  - center-periphery
+  - near-far
+  - part-whole
+relation_types:
+  - enable
+  - coordinate
+  - accumulate
+structure: network
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/accidental-complexity.md
+++ b/catalog/entries/accidental-complexity.md
@@ -9,6 +9,16 @@ contributors: []
 created: '2026-03-17'
 dead: true
 grounding: established
+embodied_patterns:
+  - part-whole
+  - splitting
+  - removal
+relation_types:
+  - decompose
+  - cause
+  - select
+structure: hierarchy
+abstraction_level: generic
 harness: Claude Code
 kind: metaphor
 name: Accidental Complexity

--- a/catalog/entries/achilles-heel.md
+++ b/catalog/entries/achilles-heel.md
@@ -26,6 +26,16 @@ transfers:
   - "[source] imports the narrative structure where strength everywhere else is irrelevant once the weak point is found, teaching that overall robustness does not compensate for a localized critical flaw"
   - "[source] carries the implication that the vulnerability is hidden or non-obvious (the heel, not the chest), directing analysis toward obscure dependencies rather than conspicuous attack surfaces"
 updated: '2026-03-16'
+embodied_patterns:
+  - boundary
+  - part-whole
+  - surface-depth
+relation_types:
+  - cause
+  - prevent
+  - decompose
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/acting-compulsively-is-ingesting-a-substance-compulsively.md
+++ b/catalog/entries/acting-compulsively-is-ingesting-a-substance-compulsively.md
@@ -27,6 +27,16 @@ transfers:
 - '[source] imports the escalation logic of pharmacological tolerance: just as the body adapts to a substance and requires more for the same effect, the metaphor explains why compulsive behaviors intensify
   over time'
 updated: '2026-03-13'
+embodied_patterns:
+  - container
+  - flow
+  - scale
+relation_types:
+  - cause
+  - accumulate
+  - transform
+structure: cycle
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/acting-on-is-transferring-an-object.md
+++ b/catalog/entries/acting-on-is-transferring-an-object.md
@@ -25,6 +25,16 @@ transfers:
 - '[source] makes the intensity of action correspond to force of transfer -- gentle giving is gentle action, violent throwing is violent action -- scaling impact through the physics of the transferred object'
 - '[source] maps mutual action onto exchange (''they traded insults'', ''she gave as good as she got''), importing commercial or gift-exchange logic into reciprocal social interaction'
 updated: '2026-03-13'
+embodied_patterns:
+  - path
+  - force
+  - link
+relation_types:
+  - cause
+  - transform
+  - translate
+structure: pipeline
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/action-at-a-distance.md
+++ b/catalog/entries/action-at-a-distance.md
@@ -9,6 +9,16 @@ contributors:
 - fshot
 created: '2026-03-17'
 dead: false
+embodied_patterns:
+  - link
+  - near-far
+  - force
+relation_types:
+  - cause
+  - enable
+  - translate
+structure: network
+abstraction_level: generic
 harness: Claude Code
 kind: metaphor
 name: Action at a Distance

--- a/catalog/entries/action-is-control-over-possessions.md
+++ b/catalog/entries/action-is-control-over-possessions.md
@@ -25,6 +25,16 @@ transfers:
 - '[source] maps failure to act onto dispossession (''lost his composure'', ''lost control''), while gaining control maps onto acquisition (''seized the initiative'', ''gained the upper hand'')'
 - '[source] frames transfer of leadership as changing hands of possessions (''handed over the reins'', ''passed the torch''), making authority an object with a clear holder at any moment'
 updated: '2026-03-12'
+embodied_patterns:
+  - container
+  - force
+  - link
+relation_types:
+  - cause
+  - enable
+  - transform
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/action-is-motion.md
+++ b/catalog/entries/action-is-motion.md
@@ -27,6 +27,16 @@ transfers:
 - '[source] gives action crisp temporal boundaries defined by motion onset and cessation (''let''s get this moving'', ''put the brakes on''), framing starting and stopping as physical transitions'
 - '[source] serves as the grounding metaphor on which LIFE IS A JOURNEY, PURPOSES ARE DESTINATIONS, and the entire journey family of metaphors depend'
 updated: '2026-03-14'
+embodied_patterns:
+  - path
+  - force
+  - blockage
+relation_types:
+  - cause
+  - enable
+  - prevent
+structure: pipeline
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/actions-are-self-propelled-motions.md
+++ b/catalog/entries/actions-are-self-propelled-motions.md
@@ -30,6 +30,16 @@ transfers:
 - '[source] makes procrastination literally a failure to start moving, and persistence a refusal to stop, giving both initiation and perseverance a visceral physical character'
 - '[source] gives purposeful action a direction that maps onto purposiveness: aimless action is wandering, focused action is marching, and correct action is being on track'
 updated: '2026-03-13'
+embodied_patterns:
+  - path
+  - force
+  - blockage
+relation_types:
+  - cause
+  - enable
+  - prevent
+structure: pipeline
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/activation-energy.md
+++ b/catalog/entries/activation-energy.md
@@ -17,6 +17,16 @@ updated: '2026-03-13'
 transfers:
   - "[model] distinguishes the threshold barrier to starting a process from the energy required to sustain it, explaining why good intentions fail at initiation despite adequate ongoing capacity"
   - "[model] reframes the intervention question from 'how do I generate more motivation?' to 'how do I lower the barrier?' by introducing catalysts that reduce the threshold without being consumed"
+embodied_patterns:
+  - force
+  - blockage
+  - scale
+relation_types:
+  - enable
+  - cause
+  - prevent
+structure: transformation
+abstraction_level: generic
 limits:
   - "[model] breaks because chemical reactions have one precisely measurable activation energy, while behavior change involves multiple sequential barriers (initial decision, first attempt, first failure, recovery) that the single-threshold model collapses"
   - "[model] misleads because the metaphor encourages brute-force approaches (apply more energy), while in human systems more pressure often produces resistance, burnout, or resentment rather than the desired reaction"

--- a/catalog/entries/active-is-alive.md
+++ b/catalog/entries/active-is-alive.md
@@ -9,6 +9,16 @@ contributors:
 - fshot
 created: '2026-03-17'
 grounding: established
+embodied_patterns:
+  - force
+  - container
+  - scale
+relation_types:
+  - cause
+  - transform
+  - enable
+structure: cycle
+abstraction_level: primitive
 harness: Claude Code
 kind: metaphor
 name: Active Is Alive

--- a/catalog/entries/activities-are-containers.md
+++ b/catalog/entries/activities-are-containers.md
@@ -24,6 +24,16 @@ transfers:
 - '[source] imports containment as constraint -- being inside an activity means being subject to its rules and pressures, and the container can become a trap (''stuck in this project'')'
 - '[source] gives activities measurable extent (''a lot in this course'', ''full schedule''), treating content as stuff filling a bounded space with capacity limits'
 updated: '2026-03-14'
+embodied_patterns:
+  - container
+  - boundary
+  - scale
+relation_types:
+  - contain
+  - enable
+  - prevent
+structure: boundary
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/activity-nodes.md
+++ b/catalog/entries/activity-nodes.md
@@ -16,6 +16,16 @@ related:
 created: '2026-03-21'
 updated: '2026-03-21'
 grounding: established
+embodied_patterns:
+  - link
+  - center-periphery
+  - flow
+relation_types:
+  - coordinate
+  - enable
+  - accumulate
+structure: network
+abstraction_level: specific
 harness: Claude Code
 transfers:
   - '[source] activity concentrates at points where multiple circulation paths cross, because the intersection of routes guarantees a minimum flow of people regardless of any single route''s traffic'

--- a/catalog/entries/adaptive-cycle.md
+++ b/catalog/entries/adaptive-cycle.md
@@ -15,6 +15,16 @@ related:
 created: '2026-03-19'
 updated: '2026-03-19'
 grounding: established
+embodied_patterns:
+  - balance
+  - scale
+  - self-organization
+relation_types:
+  - transform
+  - accumulate
+  - restore
+structure: cycle
+abstraction_level: generic
 harness: Claude Code
 transfers:
   - '[model] divides system dynamics into four qualitatively different phases (rapid growth, conservation, release, reorganization) that recur in sequence, providing names for stages that linear growth narratives collapse into "up" and "down"'

--- a/catalog/entries/aegis.md
+++ b/catalog/entries/aegis.md
@@ -25,6 +25,16 @@ limits:
   - "[source] misleads because the aegis protects through divine terror (the Gorgon's head mounted on it), while modern aegis-protection is bureaucratic and procedural, not fearsome"
   - "[source] obscures because the myth grants aegis-protection only to gods, implying that institutional protection is divine right rather than a contingent political arrangement that can be revoked"
 updated: '2026-03-16'
+embodied_patterns:
+  - boundary
+  - force
+  - container
+relation_types:
+  - prevent
+  - enable
+  - contain
+structure: boundary
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/affection-is-warmth.md
+++ b/catalog/entries/affection-is-warmth.md
@@ -10,6 +10,16 @@ contributors:
 - fshot
 created: '2026-03-17'
 grounding: proven
+embodied_patterns:
+  - near-far
+  - scale
+  - flow
+relation_types:
+  - cause
+  - translate
+  - enable
+structure: equilibrium
+abstraction_level: primitive
 harness: Claude Code
 kind: metaphor
 name: Affection Is Warmth

--- a/catalog/entries/agent-swarm.md
+++ b/catalog/entries/agent-swarm.md
@@ -24,6 +24,16 @@ transfers:
 - '[source] imports the expendability of individual swarm insects onto AI agents, framing fault tolerance as a natural property where the swarm absorbs individual agent failures and continues functioning'
 - '[source] maps stigmergy (indirect coordination through environmental modification like pheromone trails) onto agent communication through shared state, message queues, and artifact repositories'
 updated: '2026-03-13'
+embodied_patterns:
+  - self-organization
+  - link
+  - scale
+relation_types:
+  - coordinate
+  - enable
+  - accumulate
+structure: emergence
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/ai-hallucination-is-perception-disorder.md
+++ b/catalog/entries/ai-hallucination-is-perception-disorder.md
@@ -16,6 +16,16 @@ related:
 slug: ai-hallucination-is-perception-disorder
 source_frame: medicine
 updated: '2026-03-13'
+embodied_patterns:
+  - container
+  - surface-depth
+  - matching
+relation_types:
+  - translate
+  - cause
+  - transform
+structure: boundary
+abstraction_level: specific
 transfers:
   - '[source] a hallucinating patient generates percepts without external stimulus, mapping onto a model generating assertions without grounding in retrieved evidence'
   - '[source] psychiatric hallucinations carry subjective certainty indistinguishable from veridical perception, importing the structural problem that AI false outputs are syntactically identical to true ones'

--- a/catalog/entries/ai-is-a-black-box.md
+++ b/catalog/entries/ai-is-a-black-box.md
@@ -15,6 +15,16 @@ related:
 slug: ai-is-a-black-box
 source_frame: containers
 updated: '2026-03-13'
+embodied_patterns:
+  - container
+  - boundary
+  - surface-depth
+relation_types:
+  - contain
+  - prevent
+  - translate
+structure: boundary
+abstraction_level: generic
 transfers:
   - '[source] a black box exposes only input and output terminals while sealing internal mechanism from inspection, mapping opacity as an engineering property rather than mere ignorance'
   - '[source] black-box testing validates behavior through input-output pairs without requiring structural knowledge, importing a methodology where functional correctness can be assessed despite internal opacity'

--- a/catalog/entries/ai-is-a-copilot.md
+++ b/catalog/entries/ai-is-a-copilot.md
@@ -17,6 +17,16 @@ related:
 slug: ai-is-a-copilot
 source_frame: aviation
 updated: '2026-03-13'
+embodied_patterns:
+  - link
+  - part-whole
+  - balance
+relation_types:
+  - coordinate
+  - enable
+  - select
+structure: hierarchy
+abstraction_level: specific
 transfers:
   - '[source] a copilot shares the cockpit but the pilot-in-command retains final authority and legal responsibility, importing a specific liability structure where the human remains accountable'
   - '[source] copilot duties include monitoring instruments, cross-checking the pilot, and taking over during incapacitation, framing AI as a redundancy layer rather than an autonomous agent'

--- a/catalog/entries/ai-is-a-magnifying-glass.md
+++ b/catalog/entries/ai-is-a-magnifying-glass.md
@@ -16,6 +16,16 @@ related:
 slug: ai-is-a-magnifying-glass
 source_frame: vision
 updated: '2026-03-13'
+embodied_patterns:
+  - scale
+  - surface-depth
+  - matching
+relation_types:
+  - transform
+  - enable
+  - cause
+structure: transformation
+abstraction_level: generic
 transfers:
   - '[source] a magnifying glass enlarges what is already present without adding new content, framing AI as an amplifier of existing patterns in training data rather than a generator of novel knowledge'
   - '[source] magnification makes both detail and defects more visible, importing the dual-use structure where AI reveals useful patterns and harmful biases simultaneously'

--- a/catalog/entries/ai-is-a-mirror.md
+++ b/catalog/entries/ai-is-a-mirror.md
@@ -15,6 +15,16 @@ related:
 slug: ai-is-a-mirror
 source_frame: vision
 updated: '2026-03-13'
+embodied_patterns:
+  - matching
+  - surface-depth
+  - scale
+relation_types:
+  - translate
+  - transform
+  - cause
+structure: transformation
+abstraction_level: generic
 transfers:
   - '[source] a mirror reflects what stands before it without originating its own image, framing AI outputs as reflections of training data and user prompts rather than autonomous thought'
   - '[source] a mirror reverses left and right while preserving overall structure, importing the insight that AI outputs resemble their sources but with systematic transformations'

--- a/catalog/entries/ai-is-a-pair-programmer.md
+++ b/catalog/entries/ai-is-a-pair-programmer.md
@@ -17,6 +17,16 @@ related:
 slug: ai-is-a-pair-programmer
 source_frame: collaborative-work
 updated: '2026-03-13'
+embodied_patterns:
+  - link
+  - part-whole
+  - iteration
+relation_types:
+  - coordinate
+  - enable
+  - select
+structure: network
+abstraction_level: specific
 transfers:
   - '[source] pair programming assigns distinct roles -- driver and navigator -- where the navigator catches errors the driver misses, importing a division of labor where AI reviews while the human authors'
   - '[source] the pair shares a single codebase and communicates in real time about design decisions, framing human-AI coding as a collaborative dialogue rather than batch delegation'

--- a/catalog/entries/ai-is-a-prosthesis.md
+++ b/catalog/entries/ai-is-a-prosthesis.md
@@ -16,6 +16,16 @@ related:
 slug: ai-is-a-prosthesis
 source_frame: medicine
 updated: '2026-03-13'
+embodied_patterns:
+  - merging
+  - part-whole
+  - boundary
+relation_types:
+  - enable
+  - transform
+  - translate
+structure: boundary
+abstraction_level: generic
 transfers:
   - '[source] a prosthesis replaces a specific lost function rather than augmenting an intact one, framing AI as compensating for human cognitive limitations like memory, calculation speed, or language translation'
   - '[source] a well-fitted prosthesis becomes transparent to its user -- the amputee reaches for a cup, not for the prosthetic hand -- importing the ideal of seamless integration where the tool disappears into the task'

--- a/catalog/entries/ai-is-a-spell-checker.md
+++ b/catalog/entries/ai-is-a-spell-checker.md
@@ -16,6 +16,16 @@ related:
 slug: ai-is-a-spell-checker
 source_frame: tool-use
 updated: '2026-03-13'
+embodied_patterns:
+  - matching
+  - boundary
+  - scale
+relation_types:
+  - select
+  - prevent
+  - translate
+structure: pipeline
+abstraction_level: specific
 transfers:
   - '[source] a spell checker applies deterministic rules against a known-correct dictionary, framing AI as a constraint-checker that flags deviations from established norms'
   - '[source] spell checkers process surface form without understanding meaning, importing the structural limitation that corrections may be formally valid but contextually wrong'

--- a/catalog/entries/ai-is-a-tool.md
+++ b/catalog/entries/ai-is-a-tool.md
@@ -18,6 +18,16 @@ related:
 slug: ai-is-a-tool
 source_frame: tool-use
 updated: '2026-03-13'
+embodied_patterns:
+  - force
+  - link
+  - part-whole
+relation_types:
+  - enable
+  - transform
+  - cause
+structure: hierarchy
+abstraction_level: generic
 transfers:
   - '[source] a tool extends human capability in a specific direction chosen by the user, importing the structure where the human provides intentionality and the tool provides mechanical advantage'
   - '[source] tools require skill to use effectively -- a saw in untrained hands produces rough cuts -- framing AI proficiency as a learned craft rather than plug-and-play automation'

--- a/catalog/entries/ai-is-an-agent.md
+++ b/catalog/entries/ai-is-an-agent.md
@@ -19,6 +19,16 @@ related:
 slug: ai-is-an-agent
 source_frame: governance
 updated: '2026-03-13'
+embodied_patterns:
+  - path
+  - link
+  - boundary
+relation_types:
+  - enable
+  - cause
+  - coordinate
+structure: hierarchy
+abstraction_level: generic
 transfers:
   - '[source] an agent acts on behalf of a principal under delegated authority, importing a fiduciary structure where the AI''s actions should serve the user''s interests and the user bears responsibility for outcomes'
   - '[source] agents exercise discretion within bounded authority -- a real estate agent negotiates but cannot change the listing price without permission -- framing AI autonomy as operating within human-defined constraints'

--- a/catalog/entries/ai-is-an-iceberg.md
+++ b/catalog/entries/ai-is-an-iceberg.md
@@ -16,6 +16,16 @@ related:
 slug: ai-is-an-iceberg
 source_frame: natural-phenomena
 updated: '2026-03-13'
+embodied_patterns:
+  - surface-depth
+  - container
+  - part-whole
+relation_types:
+  - contain
+  - cause
+  - enable
+structure: hierarchy
+abstraction_level: generic
 transfers:
   - '[source] roughly 90% of an iceberg''s mass is submerged and invisible from the surface, importing a specific ratio claim that the visible AI interface represents a small fraction of the total system'
   - '[source] the submerged mass determines the iceberg''s drift, stability, and danger to shipping, framing hidden infrastructure (training data, compute, human labor) as the causal driver of AI behavior'

--- a/catalog/entries/ai-is-an-intern.md
+++ b/catalog/entries/ai-is-an-intern.md
@@ -17,6 +17,16 @@ related:
 slug: ai-is-an-intern
 source_frame: social-roles
 updated: '2026-03-13'
+embodied_patterns:
+  - link
+  - part-whole
+  - scale
+relation_types:
+  - enable
+  - coordinate
+  - select
+structure: hierarchy
+abstraction_level: specific
 transfers:
   - '[source] an intern produces work that must be reviewed before it can be trusted, importing a mandatory supervision structure where AI output requires human verification'
   - '[source] interns are eager, fast, and confident in ways that occasionally mask incompetence, framing AI''s fluent but sometimes wrong outputs as a recognizable organizational pattern'

--- a/catalog/entries/ai-is-an-oracle.md
+++ b/catalog/entries/ai-is-an-oracle.md
@@ -16,6 +16,16 @@ related:
 slug: ai-is-an-oracle
 source_frame: religion
 updated: '2026-03-13'
+embodied_patterns:
+  - container
+  - surface-depth
+  - boundary
+relation_types:
+  - translate
+  - enable
+  - cause
+structure: hierarchy
+abstraction_level: generic
 transfers:
   - '[source] an oracle delivers answers from a source of knowledge inaccessible to the questioner, framing AI as possessing compressed knowledge that the user cannot directly inspect or verify'
   - '[source] oracular pronouncements are ambiguous and require interpretation by the recipient, importing the structural problem that AI outputs need contextual judgment to apply correctly'

--- a/catalog/entries/ai-safety-is-containment.md
+++ b/catalog/entries/ai-safety-is-containment.md
@@ -17,6 +17,16 @@ related:
 slug: ai-safety-is-containment
 source_frame: containers
 updated: '2026-03-13'
+embodied_patterns:
+  - container
+  - boundary
+  - force
+relation_types:
+  - contain
+  - prevent
+  - cause
+structure: boundary
+abstraction_level: generic
 transfers:
   - '[source] containment requires an unbroken barrier between a hazardous interior and a vulnerable exterior, framing AI safety as maintaining separation between capable systems and uncontrolled environments'
   - '[source] containment protocols escalate with the hazard level (BSL-1 through BSL-4), importing a tiered approach where more capable AI requires more stringent isolation measures'

--- a/catalog/entries/alchemy.md
+++ b/catalog/entries/alchemy.md
@@ -15,6 +15,16 @@ related:
 created: '2026-03-16'
 updated: '2026-03-16'
 harness: Claude Code
+embodied_patterns:
+  - container
+  - superimposition
+  - scale
+relation_types:
+  - transform
+  - cause
+  - enable
+structure: transformation
+abstraction_level: generic
 transfers:
   - "[source] alchemy requires a base material to be destroyed and reconstituted rather than merely improved, making transformation a process of fundamental change in kind rather than degree"
   - "[source] the philosopher's stone is a catalyst -- it enables transmutation without being consumed itself, separating the agent of transformation from the material being transformed"

--- a/catalog/entries/alcoves.md
+++ b/catalog/entries/alcoves.md
@@ -9,6 +9,16 @@ categories:
 contributors: []
 created: '2026-03-19'
 harness: Claude Code
+embodied_patterns:
+  - container
+  - part-whole
+  - boundary
+relation_types:
+  - decompose
+  - contain
+  - enable
+structure: hierarchy
+abstraction_level: specific
 kind: pattern
 limits:
 - '[source] breaks because architectural alcoves are physically bounded by walls and sightlines, while software namespaces and organizational sub-teams lack natural spatial limits and can grow until the "alcove" is as large and undifferentiated as the room it was meant to subdivide'

--- a/catalog/entries/alignment-is-physical-alignment.md
+++ b/catalog/entries/alignment-is-physical-alignment.md
@@ -16,6 +16,16 @@ related:
 slug: alignment-is-physical-alignment
 source_frame: physics
 updated: '2026-03-13'
+embodied_patterns:
+  - matching
+  - force
+  - balance
+relation_types:
+  - coordinate
+  - prevent
+  - cause
+structure: equilibrium
+abstraction_level: generic
 transfers:
   - '[source] physical alignment requires bringing two objects into a shared axis or orientation, framing value alignment as achieving correspondence between AI objectives and human values along measurable dimensions'
   - '[source] misalignment in machinery causes friction, wear, and eventual failure, importing the prediction that even small divergences between AI objectives and human values will compound into significant harm over time'

--- a/catalog/entries/all-bleeding-stops.md
+++ b/catalog/entries/all-bleeding-stops.md
@@ -19,6 +19,16 @@ provenance: scheins-surgical-aphorisms
 created: '2026-03-20'
 updated: '2026-03-20'
 grounding: folk
+embodied_patterns:
+  - flow
+  - force
+  - boundary
+relation_types:
+  - cause
+  - prevent
+  - restore
+structure: equilibrium
+abstraction_level: specific
 harness: Claude Code
 transfers:
   - '[source] All hemorrhage terminates -- either because the surgeon controls it or because the patient exsanguinates -- importing the structure where every crisis has a guaranteed endpoint but the outcome depends entirely on the quality of intervention before that endpoint arrives'

--- a/catalog/entries/all-day.md
+++ b/catalog/entries/all-day.md
@@ -15,6 +15,16 @@ related:
   - a-la-minute
   - in-the-weeds
 dead: false
+embodied_patterns:
+  - part-whole
+  - scale
+  - flow
+relation_types:
+  - accumulate
+  - coordinate
+  - select
+structure: pipeline
+abstraction_level: specific
 created: '2026-03-19'
 updated: '2026-03-19'
 grounding: folk

--- a/catalog/entries/all-warfare-is-deception.md
+++ b/catalog/entries/all-warfare-is-deception.md
@@ -16,6 +16,16 @@ provenance: napoleons-military-maxims
 created: '2026-03-21'
 updated: '2026-03-21'
 grounding: established
+embodied_patterns:
+  - surface-depth
+  - boundary
+  - matching
+relation_types:
+  - compete
+  - prevent
+  - cause
+structure: competition
+abstraction_level: generic
 harness: Claude Code
 transfers:
   - '[model] reframes competition as an information problem rather than a force problem, making the decisive advantage not how much power you have but how much your opponent misreads about your power, intentions, and position'


### PR DESCRIPTION
Adds embodied_patterns, relation_types, structure, and abstraction_level to 50 entries.

Part of the structural enrichment sweep.
See: docs/plans/2026-03-20-structural-enrichment-vocabulary.md

## Validation
```
uv run scripts/validate.py validate — 0 errors
```