### PR TITLE
Enrich: structural tags batch 2 (50 entries)

### DIFF
--- a/catalog/entries/an-instrument-is-a-companion.md
+++ b/catalog/entries/an-instrument-is-a-companion.md
@@ -17,6 +17,16 @@ related:
 slug: an-instrument-is-a-companion
 source_frame: social-roles
 updated: '2026-03-14'
+embodied_patterns:
+  - link
+  - matching
+  - attraction
+relation_types:
+  - transform
+  - coordinate
+  - accumulate
+structure: network
+abstraction_level: generic
 transfers:
   - '[source] a companion is chosen, carried through time, and develops a shared history with its owner, framing the musician-instrument relationship as accumulating irreplaceable mutual adaptation'
   - '[source] companions respond differently to different people based on the relationship, importing the phenomenon that the same instrument sounds different under different players'' hands'

--- a/catalog/entries/anchor-point.md
+++ b/catalog/entries/anchor-point.md
@@ -17,6 +17,16 @@ provenance: firefighting-maxims
 created: '2026-03-20'
 updated: '2026-03-20'
 grounding: established
+embodied_patterns:
+  - boundary
+  - link
+  - force
+relation_types:
+  - enable
+  - prevent
+  - restore
+structure: boundary
+abstraction_level: specific
 harness: Claude Code
 transfers:
   - '[source] the anchor point is a barrier -- a road, a river, a rock face -- from which fireline construction begins, guaranteeing the fire cannot outflank the crew from that direction'

--- a/catalog/entries/andon.md
+++ b/catalog/entries/andon.md
@@ -17,6 +17,16 @@ related:
 created: '2026-03-18'
 updated: '2026-03-18'
 grounding: established
+embodied_patterns:
+  - blockage
+  - flow
+  - link
+relation_types:
+  - prevent
+  - enable
+  - coordinate
+structure: pipeline
+abstraction_level: specific
 harness: Claude Code
 transfers:
   - "[paradigm] distributes quality authority to the lowest-level operator, making the person closest to the defect the one empowered to stop the entire line rather than routing the signal through management hierarchy"

--- a/catalog/entries/anger-is-a-heated-fluid-in-a-container.md
+++ b/catalog/entries/anger-is-a-heated-fluid-in-a-container.md
@@ -23,6 +23,17 @@ related:
 slug: anger-is-a-heated-fluid-in-a-container
 source_frame: fluid-dynamics
 updated: '2026-03-13'
+embodied_patterns:
+  - container
+  - force
+  - flow
+  - scale
+relation_types:
+  - cause
+  - contain
+  - transform
+structure: boundary
+abstraction_level: generic
 transfers:
   - '[source] a heated fluid in a sealed container builds pressure proportional to temperature, framing anger as an internal force that intensifies over time and requires either controlled release or risks catastrophic failure'
   - '[source] the container has a finite capacity and a failure threshold, importing the structural claim that emotional suppression has limits beyond which explosive expression is inevitable'

--- a/catalog/entries/anger-is-heat.md
+++ b/catalog/entries/anger-is-heat.md
@@ -10,6 +10,16 @@ contributors:
 - fshot
 created: '2026-03-17'
 grounding: proven
+embodied_patterns:
+  - container
+  - force
+  - scale
+relation_types:
+  - cause
+  - transform
+  - contain
+structure: boundary
+abstraction_level: primitive
 harness: Claude Code
 kind: metaphor
 name: Anger Is Heat

--- a/catalog/entries/animals-are-moral-agents.md
+++ b/catalog/entries/animals-are-moral-agents.md
@@ -8,6 +8,16 @@ categories:
 contributors: []
 created: '2026-03-16'
 grounding: folk
+embodied_patterns:
+  - scale
+  - matching
+  - center-periphery
+relation_types:
+  - transform
+  - translate
+  - select
+structure: hierarchy
+abstraction_level: generic
 harness: Claude Code
 kind: metaphor
 name: Animals Are Moral Agents

--- a/catalog/entries/ansible-is-instant-communication.md
+++ b/catalog/entries/ansible-is-instant-communication.md
@@ -10,6 +10,16 @@ contributors: []
 created: '2026-03-17'
 dead: true
 grounding: folk
+embodied_patterns:
+  - near-far
+  - link
+  - flow
+relation_types:
+  - translate
+  - coordinate
+  - enable
+structure: network
+abstraction_level: specific
 harness: Claude Code
 kind: metaphor
 limits:

--- a/catalog/entries/ant-is-pure-empiricist.md
+++ b/catalog/entries/ant-is-pure-empiricist.md
@@ -13,6 +13,16 @@ related: []
 slug: ant-is-pure-empiricist
 source_frame: animal-behavior
 updated: '2026-03-13'
+embodied_patterns:
+  - accretion
+  - iteration
+  - part-whole
+relation_types:
+  - accumulate
+  - decompose
+  - select
+structure: growth
+abstraction_level: generic
 transfers:
   - "[source] the ant collects indiscriminately, carrying back everything encountered without a framework to distinguish signal from noise"
   - "[source] individual ants follow chemical trails and simple rules, producing collective output without any individual comprehending the whole"

--- a/catalog/entries/apex-predator.md
+++ b/catalog/entries/apex-predator.md
@@ -15,6 +15,16 @@ limits:
   - '[source] breaks because apex predators regulate prey populations through direct consumption, keeping the ecosystem in balance -- dominant corporations regulate competitors through pricing, acquisition, and lobbying, mechanisms that can destabilize markets rather than stabilize them'
   - '[source] misleads by importing the ecological principle that apex predator removal degrades the ecosystem, when removing a monopolist often improves market health by releasing suppressed competition (Standard Oil''s breakup increased industry output)'
   - '[source] obscures that ecological apex predators have low reproductive rates and small populations, making them the most vulnerable to extinction -- dominant corporations are often the most resilient entities in their markets, inverting the fragility the metaphor implies'
+embodied_patterns:
+  - scale
+  - center-periphery
+  - force
+relation_types:
+  - compete
+  - contain
+  - cause
+structure: hierarchy
+abstraction_level: generic
 name: Apex Predator
 provenance: ecological-metaphors
 related:

--- a/catalog/entries/apprenticeship-in-thinking.md
+++ b/catalog/entries/apprenticeship-in-thinking.md
@@ -19,6 +19,16 @@ related:
 slug: apprenticeship-in-thinking
 source_frame: education
 updated: '2026-03-20'
+embodied_patterns:
+  - path
+  - scale
+  - center-periphery
+relation_types:
+  - enable
+  - transform
+  - accumulate
+structure: growth
+abstraction_level: generic
 transfers:
   - '[source] the apprentice learns by working on real products alongside the master, not by studying theory first and applying it later -- the metaphor collapses the instruction-practice gap that formal education assumes'
   - '[source] competence transfers gradually through increasing responsibility: the apprentice moves from peripheral tasks to central ones as skill grows, importing the medieval guild''s progression structure into cognitive development'

--- a/catalog/entries/argument-is-a-building.md
+++ b/catalog/entries/argument-is-a-building.md
@@ -19,6 +19,16 @@ related:
 slug: argument-is-a-building
 source_frame: architecture-and-building
 updated: '2026-03-14'
+embodied_patterns:
+  - part-whole
+  - force
+  - surface-depth
+relation_types:
+  - cause
+  - decompose
+  - enable
+structure: hierarchy
+abstraction_level: generic
 transfers:
   - '[source] a building requires a foundation laid before walls can rise, framing argument construction as requiring premises established before conclusions can be supported'
   - '[source] structural loads must be distributed through load-bearing elements to the foundation, importing the insight that each claim in an argument must connect to supporting evidence through a traceable chain'

--- a/catalog/entries/argument-is-a-container.md
+++ b/catalog/entries/argument-is-a-container.md
@@ -20,6 +20,15 @@ related:
 slug: argument-is-a-container
 source_frame: containers
 updated: '2026-03-13'
+embodied_patterns:
+  - container
+  - boundary
+  - part-whole
+relation_types:
+  - contain
+  - decompose
+structure: boundary
+abstraction_level: primitive
 transfers:
   - '[source] a container has an inside and an outside with a boundary between them, framing arguments as having content that is either included in or excluded from the argument''s scope'
   - '[source] containers can be full, empty, or partially filled, importing the assessment that arguments have varying amounts of substance or content'

--- a/catalog/entries/argument-is-a-journey.md
+++ b/catalog/entries/argument-is-a-journey.md
@@ -20,6 +20,16 @@ related:
 slug: argument-is-a-journey
 source_frame: journeys
 updated: '2026-03-14'
+embodied_patterns:
+  - path
+  - near-far
+  - link
+relation_types:
+  - enable
+  - coordinate
+  - transform
+structure: pipeline
+abstraction_level: generic
 transfers:
   - '[source] a journey proceeds step by step from a starting point toward a destination, framing argument as a sequential process where each step follows from and depends on the previous one'
   - '[source] travelers can take wrong turns, reach dead ends, and retrace their steps, importing the structure where arguments can go astray and require backtracking to recover'

--- a/catalog/entries/argument-is-dance.md
+++ b/catalog/entries/argument-is-dance.md
@@ -15,6 +15,16 @@ related:
 slug: argument-is-dance
 source_frame: dance
 updated: '2026-03-09'
+embodied_patterns:
+  - matching
+  - balance
+  - flow
+relation_types:
+  - coordinate
+  - transform
+  - enable
+structure: equilibrium
+abstraction_level: generic
 transfers:
   - '[source] dance requires partners to coordinate their movements in real time, framing argument as mutual responsiveness rather than unilateral attack'
   - '[source] the quality of a dance depends on both participants and cannot be achieved solo, importing the insight that argument quality is a joint production, not an individual achievement'

--- a/catalog/entries/argument-is-war.md
+++ b/catalog/entries/argument-is-war.md
@@ -14,6 +14,16 @@ related:
 slug: argument-is-war
 source_frame: war
 updated: '2026-03-09'
+embodied_patterns:
+  - force
+  - boundary
+  - near-far
+relation_types:
+  - compete
+  - prevent
+  - cause
+structure: competition
+abstraction_level: generic
 transfers:
   - "[source] the objective is to destroy the adversary's capacity to continue, not merely to prevail in the current engagement"
   - "[source] participants occupy and defend territorial positions"

--- a/catalog/entries/army-marches-on-its-stomach.md
+++ b/catalog/entries/army-marches-on-its-stomach.md
@@ -17,6 +17,16 @@ provenance: napoleons-military-maxims
 created: '2026-03-21'
 updated: '2026-03-21'
 grounding: established
+embodied_patterns:
+  - flow
+  - link
+  - blockage
+relation_types:
+  - enable
+  - cause
+  - prevent
+structure: pipeline
+abstraction_level: generic
 harness: Claude Code
 transfers:
   - '[source] an army that outruns its supply chain loses combat effectiveness regardless of tactical superiority, importing the structure where capability depends on the continuous flow of unglamorous inputs rather than on peak performance at the point of action'

--- a/catalog/entries/arranging-spaces-perfecting-movements.md
+++ b/catalog/entries/arranging-spaces-perfecting-movements.md
@@ -13,6 +13,16 @@ related:
   - cleaning-as-you-go
   - five-s
 dead: false
+embodied_patterns:
+  - near-far
+  - iteration
+  - matching
+relation_types:
+  - enable
+  - transform
+  - coordinate
+structure: cycle
+abstraction_level: specific
 created: '2026-03-21'
 updated: '2026-03-21'
 grounding: established

--- a/catalog/entries/art-is-a-battle-a-mill-that-grinds.md
+++ b/catalog/entries/art-is-a-battle-a-mill-that-grinds.md
@@ -18,6 +18,16 @@ provenance: bannard-aphorisms
 created: '2026-03-21'
 updated: '2026-03-21'
 grounding: folk
+embodied_patterns:
+  - force
+  - iteration
+  - removal
+relation_types:
+  - transform
+  - compete
+  - cause
+structure: transformation
+abstraction_level: generic
 harness: Claude Code
 transfers:
   - '[source] a battle is decided by sustained engagement under conditions of uncertainty, not by a single decisive stroke, importing the structure where creative work requires prolonged confrontation with resistant material rather than a flash of inspiration'

--- a/catalog/entries/art-is-making-something-better-without-knowing-what-better-is.md
+++ b/catalog/entries/art-is-making-something-better-without-knowing-what-better-is.md
@@ -17,6 +17,16 @@ related:
 created: '2026-03-21'
 updated: '2026-03-21'
 grounding: folk
+embodied_patterns:
+  - iteration
+  - path
+  - self-organization
+relation_types:
+  - transform
+  - select
+  - cause
+structure: emergence
+abstraction_level: generic
 harness: Claude Code
 provenance: bannard-aphorisms
 transfers:

--- a/catalog/entries/art-is-never-finished-only-abandoned.md
+++ b/catalog/entries/art-is-never-finished-only-abandoned.md
@@ -6,6 +6,15 @@ categories:
 contributors: []
 created: '2026-03-21'
 grounding: folk
+embodied_patterns:
+  - iteration
+  - scale
+  - path
+relation_types:
+  - transform
+  - select
+structure: cycle
+abstraction_level: generic
 harness: Claude Code
 kind: mental-model
 limits:

--- a/catalog/entries/aspects-of-the-self-are-distinct-individuals.md
+++ b/catalog/entries/aspects-of-the-self-are-distinct-individuals.md
@@ -10,6 +10,16 @@ contributors:
 - fshot
 created: '2026-03-17'
 grounding: established
+embodied_patterns:
+  - splitting
+  - part-whole
+  - force
+relation_types:
+  - compete
+  - contain
+  - coordinate
+structure: competition
+abstraction_level: generic
 harness: Claude Code
 kind: metaphor
 name: Aspects Of The Self Are Distinct Individuals

--- a/catalog/entries/assimilation-and-accommodation.md
+++ b/catalog/entries/assimilation-and-accommodation.md
@@ -9,6 +9,16 @@ categories:
 contributors: []
 created: '2026-03-20'
 grounding: established
+embodied_patterns:
+  - container
+  - matching
+  - balance
+relation_types:
+  - transform
+  - contain
+  - accumulate
+structure: equilibrium
+abstraction_level: generic
 harness: Claude Code
 kind: metaphor
 name: Assimilation and Accommodation

--- a/catalog/entries/at-loggerheads.md
+++ b/catalog/entries/at-loggerheads.md
@@ -7,6 +7,15 @@ harness: Claude Code
 created: '2026-03-14'
 kind: metaphor
 dead: true
+embodied_patterns:
+  - force
+  - balance
+  - blockage
+relation_types:
+  - compete
+  - prevent
+structure: competition
+abstraction_level: generic
 name: At Loggerheads
 related:
 - fathom

--- a/catalog/entries/attachment-as-bond.md
+++ b/catalog/entries/attachment-as-bond.md
@@ -15,6 +15,16 @@ limits:
   - '[source] Physical bonds have measurable tensile strength and a single failure mode (they snap), but emotional attachment fails through diverse mechanisms -- withdrawal, betrayal, ambivalence, neglect -- that the bond metaphor collapses into one image'
   - '[source] A material bond connects two objects of similar ontological status, but attachment bonds connect agents with radically asymmetric needs, power, and mobility -- the infant cannot "strain" the bond in the same way the caregiver can'
   - '[source] Broken physical bonds leave clean surfaces that can be re-bonded with the same material, but ruptured attachment relationships leave complex psychological residues (grief, defensive patterns, internal working models) that reshape the person''s capacity for future bonding'
+embodied_patterns:
+  - link
+  - force
+  - near-far
+relation_types:
+  - enable
+  - cause
+  - contain
+structure: network
+abstraction_level: generic
 name: Attachment as Bond
 related:
 - facilitating-environment

--- a/catalog/entries/attachment-styles.md
+++ b/catalog/entries/attachment-styles.md
@@ -5,6 +5,16 @@ categories:
 contributors: []
 created: '2026-03-20'
 grounding: established
+embodied_patterns:
+  - matching
+  - link
+  - near-far
+relation_types:
+  - select
+  - cause
+  - enable
+structure: boundary
+abstraction_level: specific
 harness: Claude Code
 kind: mental-model
 limits:

--- a/catalog/entries/attack-surface.md
+++ b/catalog/entries/attack-surface.md
@@ -8,6 +8,16 @@ categories:
 contributors: []
 created: '2026-03-18'
 dead: true
+embodied_patterns:
+  - boundary
+  - surface-depth
+  - scale
+relation_types:
+  - prevent
+  - compete
+  - contain
+structure: boundary
+abstraction_level: generic
 harness: Claude Code
 kind: metaphor
 limits:

--- a/catalog/entries/attributes-are-entities.md
+++ b/catalog/entries/attributes-are-entities.md
@@ -10,6 +10,16 @@ contributors:
 - fshot
 created: '2026-03-17'
 grounding: established
+embodied_patterns:
+  - container
+  - part-whole
+  - near-far
+relation_types:
+  - contain
+  - transform
+  - cause
+structure: network
+abstraction_level: primitive
 harness: Claude Code
 kind: metaphor
 name: Attributes Are Entities

--- a/catalog/entries/augean-stables.md
+++ b/catalog/entries/augean-stables.md
@@ -8,6 +8,16 @@ categories:
 contributors: []
 created: '2026-03-14'
 dead: true
+embodied_patterns:
+  - accretion
+  - container
+  - flow
+relation_types:
+  - accumulate
+  - restore
+  - transform
+structure: transformation
+abstraction_level: generic
 harness: Claude Code
 kind: metaphor
 name: Augean Stables

--- a/catalog/entries/authority-is-height.md
+++ b/catalog/entries/authority-is-height.md
@@ -18,6 +18,16 @@ related:
 slug: authority-is-height
 source_frame: spatial-location
 updated: '2026-03-16'
+embodied_patterns:
+  - scale
+  - center-periphery
+  - force
+relation_types:
+  - cause
+  - contain
+  - enable
+structure: hierarchy
+abstraction_level: primitive
 transfers:
   - "[source] higher elevation provides greater visibility and surveillance range over surrounding terrain"
   - "[source] ascending requires effort against gravity while descending is effortless or uncontrolled"

--- a/catalog/entries/bad-is-stinky.md
+++ b/catalog/entries/bad-is-stinky.md
@@ -18,6 +18,15 @@ related:
 slug: bad-is-stinky
 source_frame: embodied-experience
 updated: '2026-03-13'
+embodied_patterns:
+  - near-far
+  - boundary
+  - container
+relation_types:
+  - cause
+  - prevent
+structure: boundary
+abstraction_level: primitive
 transfers:
   - '[source] stench triggers involuntary disgust and physical recoil before conscious evaluation, framing moral judgment as a visceral pre-cognitive response rather than a deliberated conclusion'
   - '[source] smell operates at a distance and permeates a space, importing the structure where moral contamination spreads beyond the immediate source and affects bystanders'

--- a/catalog/entries/baklava-code.md
+++ b/catalog/entries/baklava-code.md
@@ -15,6 +15,16 @@ related:
 slug: baklava-code
 source_frame: food-and-cooking
 updated: '2026-03-14'
+embodied_patterns:
+  - superimposition
+  - part-whole
+  - surface-depth
+relation_types:
+  - decompose
+  - contain
+  - prevent
+structure: hierarchy
+abstraction_level: specific
 transfers:
   - '[source] baklava consists of many thin layers of phyllo dough stacked atop one another, framing over-layered software as having excessive thin abstraction levels that each add minimal value'
   - '[source] each phyllo layer is fragile and transparent individually but the stack becomes rigid and difficult to modify, importing the paradox where individually reasonable abstractions collectively create brittleness'

--- a/catalog/entries/balance-of-nature.md
+++ b/catalog/entries/balance-of-nature.md
@@ -15,6 +15,16 @@ limits:
   - '[paradigm] most ecosystems are non-equilibrium systems driven by disturbance, succession, and stochastic events, making the "balance" framing empirically wrong as a description of how nature actually works'
   - '[paradigm] the paradigm implies that human intervention is inherently destabilizing, which can paradoxically prevent beneficial management actions like controlled burns that ecosystems require because natural fire regimes have been suppressed'
   - '[paradigm] frames ecological change as pathological deviation from a norm, making it unable to account for the fact that ecosystems are always in flux and that no historical baseline represents a "correct" state'
+embodied_patterns:
+  - balance
+  - self-organization
+  - part-whole
+relation_types:
+  - restore
+  - contain
+  - coordinate
+structure: equilibrium
+abstraction_level: generic
 name: Balance of Nature
 related:
 - adaptive-cycle

--- a/catalog/entries/banach-tarski-paradox.md
+++ b/catalog/entries/banach-tarski-paradox.md
@@ -16,6 +16,15 @@ provenance: mathematical-folklore
 created: '2026-03-21'
 updated: '2026-03-21'
 grounding: proven
+embodied_patterns:
+  - splitting
+  - part-whole
+  - matching
+relation_types:
+  - decompose
+  - transform
+structure: transformation
+abstraction_level: specific
 harness: Claude Code
 transfers:
   - '[model] demonstrates that decomposing a whole into parts and reassembling them can yield more than the original, exposing the hidden dependence of conservation laws on measurability -- the pieces are so irregular that "volume" is undefined for them, so no volume is created or destroyed'

--- a/catalog/entries/bankrupt.md
+++ b/catalog/entries/bankrupt.md
@@ -7,6 +7,16 @@ categories:
 contributors: []
 created: '2026-03-13'
 dead: true
+embodied_patterns:
+  - removal
+  - boundary
+  - container
+relation_types:
+  - cause
+  - prevent
+  - transform
+structure: boundary
+abstraction_level: generic
 harness: Claude Code
 kind: metaphor
 name: Bankrupt

--- a/catalog/entries/base-actions-on-current-and-expected-fire-behavior.md
+++ b/catalog/entries/base-actions-on-current-and-expected-fire-behavior.md
@@ -15,6 +15,16 @@ related:
 created: '2026-03-21'
 updated: '2026-03-21'
 grounding: established
+embodied_patterns:
+  - path
+  - flow
+  - matching
+relation_types:
+  - cause
+  - enable
+  - select
+structure: cycle
+abstraction_level: specific
 harness: Claude Code
 transfers:
   - '[model] forces a separation between current state observation and trajectory prediction, requiring the decision-maker to answer "what IS the fire doing" and "what WILL it do" as distinct questions, which prevents the common error of assuming current conditions are stable'

--- a/catalog/entries/batten-down-the-hatches.md
+++ b/catalog/entries/batten-down-the-hatches.md
@@ -7,6 +7,15 @@ harness: Claude Code
 created: '2026-03-14'
 kind: metaphor
 dead: true
+embodied_patterns:
+  - boundary
+  - container
+  - blockage
+relation_types:
+  - prevent
+  - contain
+structure: boundary
+abstraction_level: generic
 name: Batten Down the Hatches
 related:
 - dead-in-the-water

--- a/catalog/entries/bayesian-updating.md
+++ b/catalog/entries/bayesian-updating.md
@@ -14,6 +14,16 @@ related:
 slug: bayesian-updating
 source_frame: probability
 updated: '2026-03-13'
+embodied_patterns:
+  - balance
+  - scale
+  - iteration
+relation_types:
+  - transform
+  - accumulate
+  - select
+structure: cycle
+abstraction_level: generic
 transfers:
   - "[model] revises probability estimates proportionally to the strength of new evidence rather than replacing them wholesale"
   - "[model] forces consideration of base rates before evaluating the significance of specific observations"

--- a/catalog/entries/beachhead-strategy.md
+++ b/catalog/entries/beachhead-strategy.md
@@ -17,6 +17,18 @@ provenance: napoleons-military-maxims
 created: '2026-03-21'
 updated: '2026-03-21'
 grounding: established
+embodied_patterns:
+  - boundary
+  - center-periphery
+  - force
+relation_types:
+  - enable
+  - compete
+  - contain
+structure:
+  - boundary
+  - growth
+abstraction_level: specific
 harness: Claude Code
 transfers:
   - '[source] the initial landing force secures a small, defensible perimeter before any expansion begins, importing the structure where market entry requires dominating a narrow segment completely rather than competing broadly at insufficient strength'

--- a/catalog/entries/beauty-is-a-flower.md
+++ b/catalog/entries/beauty-is-a-flower.md
@@ -9,6 +9,15 @@ categories:
 contributors: []
 created: '2026-03-16'
 grounding: established
+embodied_patterns:
+  - scale
+  - path
+  - surface-depth
+relation_types:
+  - transform
+  - cause
+structure: cycle
+abstraction_level: primitive
 harness: Claude Code
 kind: metaphor
 name: Beauty Is a Flower

--- a/catalog/entries/beliefs-are-beings-with-a-life-cycle.md
+++ b/catalog/entries/beliefs-are-beings-with-a-life-cycle.md
@@ -18,6 +18,16 @@ related:
 slug: beliefs-are-beings-with-a-life-cycle
 source_frame: life-course
 updated: '2026-03-12'
+embodied_patterns:
+  - path
+  - scale
+  - self-organization
+relation_types:
+  - transform
+  - cause
+  - accumulate
+structure: cycle
+abstraction_level: generic
 transfers:
   - '[source] beings are born, grow, reproduce, and die through a determinate life cycle, framing beliefs as entities that emerge, develop, spread to new hosts, and eventually expire'
   - '[source] beings reproduce by transmitting their essential pattern to offspring, importing the structure where beliefs propagate by being communicated and adopted by new minds'

--- a/catalog/entries/beliefs-are-fashions.md
+++ b/catalog/entries/beliefs-are-fashions.md
@@ -21,6 +21,16 @@ related:
 slug: beliefs-are-fashions
 source_frame: social-behavior
 updated: '2026-03-17'
+embodied_patterns:
+  - flow
+  - scale
+  - center-periphery
+relation_types:
+  - select
+  - transform
+  - compete
+structure: cycle
+abstraction_level: generic
 transfers:
   - "[source] fashions cycle through adoption, peak popularity, and obsolescence without regard for intrinsic quality"
   - "[source] early adopters gain social distinction that erodes as the fashion spreads to the mainstream"

--- a/catalog/entries/beliefs-are-guides.md
+++ b/catalog/entries/beliefs-are-guides.md
@@ -21,6 +21,16 @@ related:
 slug: beliefs-are-guides
 source_frame: journeys
 updated: '2026-03-17'
+embodied_patterns:
+  - path
+  - link
+  - near-far
+relation_types:
+  - enable
+  - cause
+  - select
+structure: pipeline
+abstraction_level: generic
 transfers:
   - "[source] a guide leads the traveler along a path the guide has already traversed"
   - "[source] following a guide requires trusting someone else's knowledge of the terrain"

--- a/catalog/entries/beliefs-are-locations.md
+++ b/catalog/entries/beliefs-are-locations.md
@@ -21,6 +21,16 @@ related:
 slug: beliefs-are-locations
 source_frame: journeys
 updated: '2026-03-17'
+embodied_patterns:
+  - container
+  - near-far
+  - path
+relation_types:
+  - contain
+  - transform
+  - enable
+structure: network
+abstraction_level: primitive
 transfers:
   - "[source] a location is a fixed point in space that can be occupied, departed from, or returned to"
   - "[source] two travelers at the same location share a vantage point and see the same landscape"

--- a/catalog/entries/beliefs-are-love-objects.md
+++ b/catalog/entries/beliefs-are-love-objects.md
@@ -20,6 +20,16 @@ related:
 slug: beliefs-are-love-objects
 source_frame: love-and-relationships
 updated: '2026-03-17'
+embodied_patterns:
+  - attraction
+  - link
+  - force
+relation_types:
+  - cause
+  - contain
+  - prevent
+structure: network
+abstraction_level: generic
 transfers:
   - "[source] love objects inspire devotion that resists rational cost-benefit analysis"
   - "[source] the beloved is idealized, with flaws minimized or rendered invisible"

--- a/catalog/entries/beliefs-are-possessions.md
+++ b/catalog/entries/beliefs-are-possessions.md
@@ -22,6 +22,16 @@ related:
 slug: beliefs-are-possessions
 source_frame: economics
 updated: '2026-03-13'
+embodied_patterns:
+  - container
+  - near-far
+  - force
+relation_types:
+  - contain
+  - cause
+  - transform
+structure: boundary
+abstraction_level: primitive
 transfers:
   - '[source] possessions are acquired, held, defended, and can be lost or stolen, framing beliefs as objects over which a person exercises ownership and control'
   - '[source] possessions can be given to others without the giver necessarily losing them, importing the structure of belief-sharing where teaching does not diminish the teacher''s conviction'

--- a/catalog/entries/berserker.md
+++ b/catalog/entries/berserker.md
@@ -13,6 +13,16 @@ contributors: []
 related:
   - the-trickster
 dead: true
+embodied_patterns:
+  - force
+  - boundary
+  - removal
+relation_types:
+  - transform
+  - cause
+  - compete
+structure: transformation
+abstraction_level: specific
 created: '2026-03-16'
 updated: '2026-03-16'
 harness: Claude Code

--- a/catalog/entries/best-carpenters-fewest-chips.md
+++ b/catalog/entries/best-carpenters-fewest-chips.md
@@ -6,6 +6,16 @@ categories:
 contributors: []
 created: '2026-03-21'
 grounding: folk
+embodied_patterns:
+  - removal
+  - iteration
+  - scale
+relation_types:
+  - transform
+  - select
+  - cause
+structure: pipeline
+abstraction_level: generic
 harness: Claude Code
 kind: mental-model
 limits:

--- a/catalog/entries/between-devil-and-deep-blue-sea.md
+++ b/catalog/entries/between-devil-and-deep-blue-sea.md
@@ -7,6 +7,15 @@ created: '2026-03-14'
 harness: Claude Code
 kind: metaphor
 dead: true
+embodied_patterns:
+  - boundary
+  - near-far
+  - blockage
+relation_types:
+  - prevent
+  - compete
+structure: competition
+abstraction_level: generic
 name: Between the Devil and the Deep Blue Sea
 related: []
 slug: between-devil-and-deep-blue-sea

--- a/catalog/entries/bicycle-for-the-mind.md
+++ b/catalog/entries/bicycle-for-the-mind.md
@@ -16,6 +16,15 @@ related:
 slug: bicycle-for-the-mind
 source_frame: embodied-experience
 updated: '2026-03-13'
+embodied_patterns:
+  - force
+  - scale
+  - path
+relation_types:
+  - enable
+  - transform
+structure: pipeline
+abstraction_level: generic
 transfers:
   - '[source] a bicycle converts human pedaling into locomotion more efficiently than any other mechanism, framing the computer as achieving maximum cognitive output per unit of human mental effort'
   - '[source] the rider provides all energy and directional control while the bicycle provides only mechanical advantage, importing a strict division where the human originates and the machine amplifies'

--- a/catalog/entries/big-ball-of-mud.md
+++ b/catalog/entries/big-ball-of-mud.md
@@ -16,6 +16,15 @@ related:
 slug: big-ball-of-mud
 source_frame: embodied-experience
 updated: '2026-03-14'
+embodied_patterns:
+  - accretion
+  - merging
+  - container
+relation_types:
+  - accumulate
+  - cause
+structure: growth
+abstraction_level: generic
 transfers:
   - '[source] mud is structureless, undifferentiated, and takes whatever shape its container imposes, framing the codebase as lacking internal boundaries or organizing principles'
   - '[source] a ball of mud accumulates incrementally as material sticks to its surface, importing the growth pattern where expedient additions accrete without deliberate architecture'


### PR DESCRIPTION
Adds embodied_patterns, relation_types, structure, and abstraction_level to 50 entries (alphabetical entries 51-100).

Part of the structural enrichment sweep.
See: docs/plans/2026-03-20-structural-enrichment-vocabulary.md

## Validation
```
uv run scripts/validate.py validate — 0 errors
```