### PR TITLE
Fix kaizen #2371: gh pr review -> gh api for reviews

### DIFF
--- a/.claude/agents/assayer.md
+++ b/.claude/agents/assayer.md
@@ -52,11 +52,19 @@ First, check if your token is available:
 
 If the token is set, prefix EVERY `gh` command:
 ```bash
-GH_TOKEN="$M4X_REVIEWER_TOKEN" gh pr review ...
 GH_TOKEN="$M4X_REVIEWER_TOKEN" gh pr edit ...
 GH_TOKEN="$M4X_REVIEWER_TOKEN" gh issue edit ...
 GH_TOKEN="$M4X_REVIEWER_TOKEN" gh api ...
 ```
+
+**Submitting PR reviews:** Do NOT use `gh pr review` — it silently prints
+help text instead of submitting in non-interactive contexts. Use the REST API:
+```bash
+GH_TOKEN="$M4X_REVIEWER_TOKEN" gh api --method POST \
+  repos/{owner}/{repo}/pulls/<N>/reviews \
+  --field event=APPROVE --field body="..."
+```
+For requesting changes, use `--field event=REQUEST_CHANGES`.
 
 And EVERY `git commit`:
 ```bash

--- a/.claude/agents/surveyor.md
+++ b/.claude/agents/surveyor.md
@@ -58,11 +58,19 @@ First, check if your token is available:
 
 If the token is set, prefix EVERY `gh` command:
 ```bash
-GH_TOKEN="$M4X_REVIEWER_TOKEN" gh pr review ...
 GH_TOKEN="$M4X_REVIEWER_TOKEN" gh pr edit ...
 GH_TOKEN="$M4X_REVIEWER_TOKEN" gh issue edit ...
 GH_TOKEN="$M4X_REVIEWER_TOKEN" gh api ...
 ```
+
+**Submitting PR reviews:** Do NOT use `gh pr review` — it silently prints
+help text instead of submitting in non-interactive contexts. Use the REST API:
+```bash
+GH_TOKEN="$M4X_REVIEWER_TOKEN" gh api --method POST \
+  repos/{owner}/{repo}/pulls/<N>/reviews \
+  --field event=APPROVE --field body="..."
+```
+For requesting changes, use `--field event=REQUEST_CHANGES`.
 
 And EVERY `git commit`:
 ```bash


### PR DESCRIPTION
Fixes #2371

## What was broken

`gh pr review --approve --body "..."` silently prints help text instead of submitting the review in non-interactive agent contexts. This means Assayer and Surveyor reviews were never actually posted to GitHub.

## What this changes

- Removed `gh pr review ...` from the identity example blocks in both `assayer.md` and `surveyor.md`
- Added a dedicated "Submitting PR reviews" section with the `gh api` REST equivalent
- Includes a clear warning not to use `gh pr review`

## Not fixed (needs human edit)

The agent-identity skill file (line 51) also contains `gh pr review ...` as an example but is protected by the guard script. A human needs to update that file separately.

## Test plan

- [x] Verified no `gh pr review` usage remains in agent prompts (only warning text)
- [ ] Human: update the agent-identity skill file manually