### PR TITLE
Enrich: structural tags batch 16 (50 entries)

### DIFF
--- a/catalog/entries/poison-pill.md
+++ b/catalog/entries/poison-pill.md
@@ -25,6 +25,15 @@ transfers:
 - "[source] imports the toxicological principle that small quantities of the right substance can produce disproportionately large effects, explaining how a few poisoned training examples or cache entries can compromise an entire system"
 - "[source] carries the concept of a contamination vector -- the specific pathway by which poison enters the organism -- onto the analysis of how malicious data enters systems through caches, training sets, memory stores, and configuration files"
 updated: '2026-03-18'
+embodied_patterns:
+  - container
+  - force
+  - boundary
+relation_types:
+  - prevent
+  - transform
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/poka-yoke.md
+++ b/catalog/entries/poka-yoke.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - "[paradigm] breaks in creative or exploratory domains where the 'error' is indistinguishable from experimentation -- mistake-proofing a brainstorming process or an artistic practice would eliminate the productive accidents the domain depends on"
   - "[paradigm] assumes errors are classifiable in advance, but in novel or complex systems the failure modes are emergent and cannot be enumerated before they occur, making the design-time constraint approach insufficient"
+embodied_patterns:
+  - matching
+  - boundary
+  - blockage
+relation_types:
+  - prevent
+  - enable
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/polished.md
+++ b/catalog/entries/polished.md
@@ -27,6 +27,15 @@ transfers:
 limits:
   - '[source] breaks because polishing requires an already well-prepared substrate -- sanding scratches that were not removed by the previous grit will be amplified, not hidden, by polish -- but the metaphor is used as if polishing alone can rescue fundamentally flawed work'
   - '[source] misleads by framing quality as surface appearance, licensing a culture where a "polished presentation" is valued over the structural soundness of the underlying argument, and where effort spent on surface refinement substitutes for substantive improvement'
+embodied_patterns:
+  - removal
+  - iteration
+  - matching
+relation_types:
+  - transform
+  - accumulate
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/pollinator-as-metaphor.md
+++ b/catalog/entries/pollinator-as-metaphor.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because biological pollinators are unaware of the transfer they perform -- they do not select which pollen to carry or which flower to deliver it to -- whereas human "pollinators" are conscious agents who choose what ideas to carry and where to deposit them, introducing intentionality absent from the source'
   - '[source] misleads because ecological pollination is species-specific (a given pollinator services a narrow range of plants), but the metaphor is typically invoked to celebrate generalism -- the person who connects any domain to any other -- erasing the specialization that makes biological pollination effective'
+embodied_patterns:
+  - flow
+  - link
+  - path
+relation_types:
+  - enable
+  - translate
+structure: network
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/positive-outdoor-space.md
+++ b/catalog/entries/positive-outdoor-space.md
@@ -27,6 +27,15 @@ transfers:
 limits:
   - '[source] architectural outdoor space is experienced bodily through enclosure, sunlight, and shelter, but the "space between" software components has no sensory dimension and must be made visible through tooling rather than felt through presence'
   - '[source] the pattern assumes that shaping the gaps is always desirable, but in software, deliberately unstructured interfaces (duck typing, convention over configuration) can enable flexibility that rigid boundary design would prevent'
+embodied_patterns:
+  - container
+  - boundary
+  - part-whole
+relation_types:
+  - contain
+  - coordinate
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/possessing-is-holding.md
+++ b/catalog/entries/possessing-is-holding.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because physical holding requires continuous exertion, while legal possession persists without ongoing effort through institutional recognition'
   - '[source] misleads because you can only hold a few physical objects at once, while a person or entity can possess unlimited abstract properties simultaneously'
+embodied_patterns:
+  - container
+  - force
+  - link
+relation_types:
+  - contain
+  - cause
+structure: boundary
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/possession-is-nine-tenths-of-the-law.md
+++ b/catalog/entries/possession-is-nine-tenths-of-the-law.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - "[source] breaks because the legal systems the maxim describes have evolved sophisticated mechanisms for separating title from possession (registries, deeds, intellectual property law), making the 'nine-tenths' claim historically contingent rather than structurally necessary"
   - "[source] misleads because it frames possession as a near-guarantee of legal victory, when in practice courts regularly rule against possessors in favor of documented titleholders -- the maxim overstates the legal weight of physical control"
+embodied_patterns:
+  - container
+  - force
+  - balance
+relation_types:
+  - contain
+  - prevent
+structure: boundary
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/potential-space.md
+++ b/catalog/entries/potential-space.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - '[source] physical space is inert and persists whether or not anyone uses it, but Winnicott''s potential space is actively maintained by the holding environment and collapses into either fantasy or compliance the moment trust breaks down'
   - '[source] spatial metaphors imply measurable extension and clear location, but potential space has no definite size or position -- it is not a place in the brain or between two bodies, and treating it as literally spatial leads to confused attempts to "create" or "open" it through environmental design alone'
+embodied_patterns:
+  - container
+  - boundary
+  - matching
+relation_types:
+  - enable
+  - contain
+structure: boundary
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/power-laws.md
+++ b/catalog/entries/power-laws.md
@@ -22,6 +22,15 @@ transfers:
 - '[law] predicts that in power-law distributions, extreme events are rare but so large they dominate the total -- the largest earthquake releases more energy than all smaller ones combined'
 - '[law] connects the shape of the distribution to its generating mechanism: multiplicative processes (wealth grows proportionally, popularity breeds popularity) produce power-law outcomes'
 updated: '2026-03-13'
+embodied_patterns:
+  - scale
+  - part-whole
+  - balance
+relation_types:
+  - cause
+  - accumulate
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/praise-the-ripe-field-not-the-green-corn.md
+++ b/catalog/entries/praise-the-ripe-field-not-the-green-corn.md
@@ -27,6 +27,15 @@ limits:
   - '[source] breaks because agricultural ripeness is unambiguous and binary (the grain is either harvestable or it is not), while most real-world "ripeness" is a judgment call with no clear threshold, making the metaphor import a false precision about when evaluation becomes legitimate'
   - '[source] misleads by implying that early assessment has no value, when in agriculture itself farmers constantly evaluate green fields to decide irrigation, fertilization, and pest control -- the metaphor erases the entire discipline of formative evaluation by privileging only summative judgment'
   - '[source] imports a single-harvest model where the crop either succeeds or fails once, ignoring domains with continuous delivery, iterative releases, or rolling evaluation where waiting for "ripeness" means waiting forever'
+embodied_patterns:
+  - path
+  - near-far
+  - scale
+relation_types:
+  - select
+  - prevent
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/prep.md
+++ b/catalog/entries/prep.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] breaks because kitchen prep has a fixed, knowable scope determined by the menu and the expected cover count, while most organizational prep work (infrastructure setup, sprint planning, onboarding) faces an open-ended scope where "how much prep is enough" has no objectively correct answer'
   - '[source] misleads by importing the kitchen''s sharp temporal boundary between prep and service into domains where the two overlap -- software teams cannot "finish all the prep" before beginning execution because requirements, tools, and environments change continuously during the work'
+embodied_patterns:
+  - path
+  - part-whole
+  - matching
+relation_types:
+  - enable
+  - coordinate
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/pride-of-workmanship.md
+++ b/catalog/entries/pride-of-workmanship.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - "[model] romanticizes craft motivation as universal, but not all work is craft-like and not all workers derive identity from work quality -- some workers are instrumentally motivated and respond better to clear extrinsic incentives"
   - "[model] offers no framework for distinguishing barriers that management should remove from standards that management should enforce, risking a permissive interpretation where all performance expectations become 'barriers to pride'"
+embodied_patterns:
+  - force
+  - matching
+  - accretion
+relation_types:
+  - enable
+  - cause
+structure: cycle
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/primary-maternal-preoccupation.md
+++ b/catalog/entries/primary-maternal-preoccupation.md
@@ -23,6 +23,15 @@ transfers:
   - '[model] introduces a temporal arc — onset, peak intensity, gradual recovery — that distinguishes adaptive immersion from chronic enmeshment by making duration the diagnostic variable'
   - '[model] identifies that the capacity for this state must already exist latently and be "switched on" by circumstance, structuring the claim that deep responsiveness is a dormant capability activated by dependency, not a skill acquired through training'
 updated: '2026-03-20'
+embodied_patterns:
+  - container
+  - merging
+  - balance
+relation_types:
+  - enable
+  - transform
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/prime-directive-is-non-interference.md
+++ b/catalog/entries/prime-directive-is-non-interference.md
@@ -38,6 +38,15 @@ transfers:
   \ individual judgment and compassion -- mapping the principle that\
   \ systemic restraint must override situational impulse"
 updated: '2026-03-16'
+embodied_patterns:
+  - boundary
+  - force
+  - container
+relation_types:
+  - prevent
+  - contain
+structure: boundary
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/principal-agent-problem.md
+++ b/catalog/entries/principal-agent-problem.md
@@ -21,6 +21,15 @@ transfers:
 - '[model] predicts that whenever work is delegated, information asymmetry creates structural opportunities for the agent to serve themselves at the principal''s expense'
 - '[model] reframes governance structures (boards, audits, regulations) not as bureaucratic overhead but as rational monitoring responses to the principal-agent gap'
 updated: '2026-03-13'
+embodied_patterns:
+  - link
+  - surface-depth
+  - balance
+relation_types:
+  - compete
+  - prevent
+structure: competition
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/prisoners-dilemma.md
+++ b/catalog/entries/prisoners-dilemma.md
@@ -26,6 +26,15 @@ transfers:
 - '[paradigm] establishes that the problem of cooperation is not ignorance or malice but incentive structure, shifting analysis from character to architecture'
 - '[paradigm] predicts that iteration (repeated play) transforms the strategic landscape, making cooperation sustainable through reciprocity and punishment in ways impossible in one-shot encounters'
 updated: '2026-03-19'
+embodied_patterns:
+  - splitting
+  - balance
+  - force
+relation_types:
+  - compete
+  - prevent
+structure: competition
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/problem-is-a-constructed-object.md
+++ b/catalog/entries/problem-is-a-constructed-object.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because constructed objects have a builder with intent, while many problems emerge from systemic interactions with no designing agent'
   - '[source] misleads because physical constructions can be fully dismantled into known parts, while problems often have emergent properties that disappear when decomposed'
+embodied_patterns:
+  - part-whole
+  - matching
+  - container
+relation_types:
+  - decompose
+  - cause
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/problem-is-a-tangle.md
+++ b/catalog/entries/problem-is-a-tangle.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because tangles are resolved by restoring an original untangled state, while many problems have no prior state of simplicity to return to'
   - '[source] misleads because a tangle involves a finite number of strands with deterministic interactions, while real problems often involve uncertain causal relationships and feedback loops'
+embodied_patterns:
+  - link
+  - blockage
+  - force
+relation_types:
+  - prevent
+  - cause
+structure: network
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/problem-is-a-target.md
+++ b/catalog/entries/problem-is-a-target.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because targets are stationary and well-defined, while many real problems are diffuse, systemic, and shift in response to intervention'
   - '[source] misleads because the marksman frame treats the solver as a lone agent taking individual shots, while most significant problems require coordinated collective action'
+embodied_patterns:
+  - center-periphery
+  - force
+  - matching
+relation_types:
+  - cause
+  - select
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/problems-are-puzzles.md
+++ b/catalog/entries/problems-are-puzzles.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - '[source] breaks because puzzles are designed to be solvable, while many real problems are wicked problems with no definitive solution'
   - '[source] misleads because puzzle difficulty is calibrated by the designer to be fair, while real-world problem difficulty is arbitrary and often exceeds available cognitive resources'
+embodied_patterns:
+  - matching
+  - part-whole
+  - container
+relation_types:
+  - decompose
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/process-fork.md
+++ b/catalog/entries/process-fork.md
@@ -25,6 +25,15 @@ limits:
   - "[source] breaks because at a physical fork a single traveler takes one path, whereas fork() produces two travelers (parent and child) who each take a different branch simultaneously"
   - "[source] misleads because the two paths at a road fork diverge in different directions, but after fork() the parent and child initially execute identical code and only diverge based on the return value"
 updated: '2026-03-17'
+embodied_patterns:
+  - splitting
+  - path
+  - part-whole
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/process-kill.md
+++ b/catalog/entries/process-kill.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - "[source] breaks because biological killing destroys the entity permanently, whereas the mapped target can be restarted immediately with no loss of template"
   - "[source] misleads because the moral weight of killing imports unjustified alarm into a routine administrative action"
+embodied_patterns:
+  - force
+  - removal
+  - boundary
+relation_types:
+  - cause
+  - prevent
+structure: transformation
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/process-parent-child.md
+++ b/catalog/entries/process-parent-child.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - "[source] breaks because human families involve bidirectional emotional bonds, whereas the mapped relationship is a one-way supervisory channel"
   - "[source] misleads because biological inheritance blends traits from two parents, whereas the mapped mechanism copies one parent's state wholesale"
+embodied_patterns:
+  - splitting
+  - link
+  - container
+relation_types:
+  - cause
+  - coordinate
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/process-sleep.md
+++ b/catalog/entries/process-sleep.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - "[source] breaks because biological sleep involves active processes like memory consolidation and dreaming, whereas the mapped state is total inactivity"
   - "[source] misleads because biological sleep depth varies continuously, while the mapped state is binary -- either scheduled or not"
+embodied_patterns:
+  - blockage
+  - container
+  - iteration
+relation_types:
+  - prevent
+  - restore
+structure: cycle
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/process-thread.md
+++ b/catalog/entries/process-thread.md
@@ -22,6 +22,15 @@ transfers:
 limits:
   - '[source] breaks because textile threads do not compete for shared resources or deadlock against each other, while computational threads contend for locks, memory, and CPU time'
   - '[source] misleads because threads in cloth are physically parallel and non-interfering, while process threads share mutable state and require explicit synchronization to avoid corruption'
+embodied_patterns:
+  - flow
+  - link
+  - part-whole
+relation_types:
+  - coordinate
+  - enable
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/process-trap.md
+++ b/catalog/entries/process-trap.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because physical traps are hostile and harmful to the trapped entity, while process traps are a normal, designed part of system operation'
   - '[source] misleads because a physical trap immobilizes the captured animal, while a process trap transfers control temporarily and the trapped process typically resumes execution afterward'
+embodied_patterns:
+  - container
+  - force
+  - matching
+relation_types:
+  - prevent
+  - cause
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/procrustean-bed.md
+++ b/catalog/entries/procrustean-bed.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - '[source] breaks because Procrustes acted on individuals one at a time, while procrustean systems typically operate on populations through standardized bureaucratic processes'
   - '[source] misleads because the myth involves deliberate malice, while most procrustean standardization arises from institutional convenience rather than intent to harm'
+embodied_patterns:
+  - force
+  - matching
+  - container
+relation_types:
+  - transform
+  - prevent
+structure: boundary
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/produce-no-waste.md
+++ b/catalog/entries/produce-no-waste.md
@@ -23,6 +23,15 @@ transfers:
 - '[model] waste signals a design gap rather than an operational inevitability: if something leaves the system unused, the system boundary is drawn too narrowly or a connection is missing'
 - '[model] the model reframes efficiency from "minimize inputs" to "maximize the number of useful transformations per unit of material," shifting attention from cost reduction to circulation design'
 updated: '2026-03-20'
+embodied_patterns:
+  - flow
+  - link
+  - removal
+relation_types:
+  - transform
+  - coordinate
+structure: cycle
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/prognosis-as-forecast.md
+++ b/catalog/entries/prognosis-as-forecast.md
@@ -28,6 +28,15 @@ limits:
   - '[source] breaks because medical prognosis assumes a single patient with a knowable disease trajectory, while organizational or economic "prognoses" involve complex adaptive systems where the act of announcing the forecast changes the outcome (reflexivity), a dynamic absent from clinical medicine'
   - '[source] misleads by importing the physician''s moral authority -- the doctor who delivers a prognosis has examined the patient -- onto commentators who pronounce organizational prognoses without comparable diagnostic access, lending unearned clinical credibility to punditry'
   - '[source] obscures that medical prognosis is explicitly probabilistic and physicians are trained to communicate uncertainty, while metaphorical prognosis ("the prognosis for this company is poor") typically drops the probability framing entirely, converting calibrated uncertainty into false certainty'
+embodied_patterns:
+  - path
+  - near-far
+  - matching
+relation_types:
+  - cause
+  - enable
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/program-failure-is-bodily-failure.md
+++ b/catalog/entries/program-failure-is-bodily-failure.md
@@ -21,6 +21,15 @@ transfers:
 limits:
   - '[source] breaks because bodily failure involves subjective suffering, while program failure involves no experience at all'
   - '[source] misleads because biological organisms heal themselves through immune response, while programs lack self-repair mechanisms and require external intervention to recover'
+embodied_patterns:
+  - force
+  - removal
+  - container
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/prometheus.md
+++ b/catalog/entries/prometheus.md
@@ -22,6 +22,15 @@ transfers:
 limits:
   - "[source] breaks because Prometheus acts alone as a single heroic figure, while real technology democratization is distributed across institutions, teams, and incremental contributions with no singular gift-giver"
   - "[source] misleads because the archetype frames the gods' punishment as unjust, biasing the narrative toward the innovator's perspective and making regulatory or cautionary responses seem like divine overreaction"
+embodied_patterns:
+  - path
+  - force
+  - boundary
+relation_types:
+  - transform
+  - enable
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/prompt-engineering-is-programming.md
+++ b/catalog/entries/prompt-engineering-is-programming.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - '[source] breaks because programming produces deterministic output for identical inputs, while the same prompt can yield different outputs across runs due to sampling and model updates'
   - '[source] misleads because programs execute instructions literally, while language models interpret prompts through statistical patterns and may creatively deviate from stated intent'
+embodied_patterns:
+  - matching
+  - path
+  - container
+relation_types:
+  - translate
+  - transform
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/prompt-injection.md
+++ b/catalog/entries/prompt-injection.md
@@ -27,6 +27,15 @@ transfers:
 limits:
   - "[source] breaks because medical injection requires a physical instrument (needle) that leaves evidence of penetration, while prompt injection leaves no trace of the boundary violation in the output"
   - "[source] misleads because the medical metaphor implies a passive patient, but prompt injection targets an active reasoning system whose own cognitive process becomes the attack vector"
+embodied_patterns:
+  - boundary
+  - container
+  - force
+relation_types:
+  - compete
+  - transform
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/proof-by-construction.md
+++ b/catalog/entries/proof-by-construction.md
@@ -25,6 +25,15 @@ transfers:
 - '[paradigm] introduces the concept of a "witness" -- a specific object whose existence settles the question -- transferring the mathematical requirement for tangible evidence into engineering and design contexts'
 - '[paradigm] distinguishes constructive knowledge (knowing how to build the thing) from non-constructive knowledge (knowing the thing exists), privileging actionable understanding over abstract assurance'
 updated: '2026-03-19'
+embodied_patterns:
+  - part-whole
+  - path
+  - matching
+relation_types:
+  - cause
+  - enable
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/proof-by-contradiction.md
+++ b/catalog/entries/proof-by-contradiction.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[paradigm] fails in domains that admit degrees or partial truth -- a policy can be "mostly effective," a design can be "partly correct," and showing that the negation leads to absurdity does not help when the proposition was never binary'
   - '[paradigm] produces conviction without construction -- you know the thing exists but cannot point to it, which is useless in engineering, design, and any domain where the answer must be built, not merely shown to be possible'
+embodied_patterns:
+  - boundary
+  - splitting
+  - force
+relation_types:
+  - prevent
+  - cause
+structure: boundary
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/proof-by-exhaustion.md
+++ b/catalog/entries/proof-by-exhaustion.md
@@ -28,6 +28,15 @@ transfers:
 limits:
   - '[source] breaks when the case space is infinite or combinatorially explosive, since the method requires literal enumeration of every possibility -- real testing and compliance domains routinely face spaces too large to exhaust'
   - '[source] misleads by implying that exhaustive checking and genuine understanding are substitutes, when in mathematics exhaustion is a last resort that forecloses the deeper insight a general proof would provide'
+embodied_patterns:
+  - iteration
+  - part-whole
+  - matching
+relation_types:
+  - select
+  - cause
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/proof-by-handwaving.md
+++ b/catalog/entries/proof-by-handwaving.md
@@ -23,6 +23,15 @@ transfers:
 - '[source] imports the physical image of hands moving through the air to create an illusion of connection between two points, framing the arguer''s body language as a substitute for the structural work their words fail to do'
 - '[source] carries the mathematical community''s social norm that handwaving is shameful -- a failure of rigor that peers will call out -- into non-mathematical contexts where the same gaps might otherwise go unchallenged'
 updated: '2026-03-19'
+embodied_patterns:
+  - removal
+  - surface-depth
+  - path
+relation_types:
+  - prevent
+  - cause
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/proof-by-intimidation.md
+++ b/catalog/entries/proof-by-intimidation.md
@@ -21,6 +21,15 @@ transfers:
 limits:
   - '[model] fails to distinguish between genuine pedagogical shorthand ("this follows by a standard argument the audience knows") and actual intimidation -- experienced mathematicians routinely skip steps their audience can fill in, and labeling all such omissions as intimidation collapses a real distinction'
   - '[model] implies the audience is passive, but in functional mathematical culture the audience interrupts and asks for clarification; the model predicts intimidation will succeed more than it actually does in communities with strong norms of skeptical inquiry'
+embodied_patterns:
+  - force
+  - scale
+  - boundary
+relation_types:
+  - prevent
+  - cause
+structure: competition
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/properties-are-contents.md
+++ b/catalog/entries/properties-are-contents.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] breaks because container contents are independent of the container, while properties are constitutive of the entity that bears them'
   - '[source] misleads because contents can be exhaustively enumerated by inspection, while an entity''s properties are potentially infinite and context-dependent'
+embodied_patterns:
+  - container
+  - part-whole
+  - matching
+relation_types:
+  - contain
+  - cause
+structure: boundary
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/properties-are-physical-properties.md
+++ b/catalog/entries/properties-are-physical-properties.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because physical properties are observer-independent and measurable, while abstract properties like goodness or importance are perspective-dependent and contested'
   - '[source] misleads because physical properties exist on fixed scales, while abstract qualities often resist ranking and comparison due to incommensurability'
+embodied_patterns:
+  - matching
+  - force
+  - scale
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/properties-are-possessions.md
+++ b/catalog/entries/properties-are-possessions.md
@@ -27,6 +27,15 @@ transfers:
 limits:
   - '[source] breaks because possessions are external to the owner and can be transferred, while properties are intrinsic to the bearer and often cannot be given away'
   - '[source] misleads because the possession frame implies that all properties are equally detachable, while some attributes are constitutive of identity and cannot be alienated'
+embodied_patterns:
+  - container
+  - link
+  - force
+relation_types:
+  - contain
+  - cause
+structure: boundary
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/prosperity-is-plant-growth.md
+++ b/catalog/entries/prosperity-is-plant-growth.md
@@ -27,6 +27,15 @@ limits:
   - "[source] misleads because plant growth is bounded by biological limits, while economic growth is theoretically unbounded -- making the metaphor both too optimistic (growth is natural) and too modest (growth has a ceiling)"
   - "[source] obscures that prosperity is distributed among people with competing interests, while a plant's growth benefits only the plant (and its cultivator)"
 updated: '2026-03-16'
+embodied_patterns:
+  - accretion
+  - path
+  - scale
+relation_types:
+  - cause
+  - accumulate
+structure: growth
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/proximity-maintenance.md
+++ b/catalog/entries/proximity-maintenance.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - '[model] breaks because spatial closeness is continuous and measurable, but the infant''s subjective sense of security is not linearly related to physical distance -- a caregiver can be spatially close but emotionally unavailable, and the model has no variable for that'
   - '[model] misleads by implying the system has a single goal (proximity), when attachment behavior simultaneously serves exploration, affect regulation, and social learning -- collapsing these into one spatial metric oversimplifies the behavioral repertoire'
+embodied_patterns:
+  - near-far
+  - link
+  - force
+relation_types:
+  - coordinate
+  - enable
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/pruning-for-growth.md
+++ b/catalog/entries/pruning-for-growth.md
@@ -25,6 +25,15 @@ limits:
   - '[source] breaks because a pruned branch does not suffer or resist; it has no interests, no alternative plan, and no social network that is disrupted by its removal -- making the metaphor structurally unable to represent the human cost of organizational cuts'
   - '[source] the gardener can see the entire plant and predict where energy will flow after a cut, but organizational leaders cannot see the full network of dependencies, so cuts intended to redirect energy often redirect it in unpredictable directions or dissipate it entirely'
   - '[source] pruning assumes the root system and trunk are healthy and that the constraint on growth is branch proliferation, but many organizational problems originate in the root system (culture, incentives, leadership) where pruning branches has no therapeutic effect'
+embodied_patterns:
+  - removal
+  - accretion
+  - path
+relation_types:
+  - transform
+  - enable
+structure: growth
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/psychohistory-is-predictive-social-science.md
+++ b/catalog/entries/psychohistory-is-predictive-social-science.md
@@ -18,6 +18,15 @@ limits:
 - "[model] Psychohistory assumes human societies are closed systems without exogenous shocks from genuinely novel agents or events"
 - "[model] The mathematical laws governing gas molecules are time-reversible; social processes are not -- history has a direction that thermodynamics does not"
 updated: '2026-03-16'
+embodied_patterns:
+  - scale
+  - path
+  - matching
+relation_types:
+  - cause
+  - coordinate
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/psychological-forces-are-physical-forces.md
+++ b/catalog/entries/psychological-forces-are-physical-forces.md
@@ -28,6 +28,15 @@ transfers:
 limits:
   - '[source] breaks because physical forces are measurable and predictable, while psychological forces vary with context, interpretation, and the subject''s narrative about their own experience'
   - '[source] misleads because physical force dynamics involve passive objects, while the psychological self actively reinterprets the forces acting on it, sometimes converting an attraction into a repulsion through reframing'
+embodied_patterns:
+  - force
+  - path
+  - balance
+relation_types:
+  - cause
+  - transform
+structure: competition
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/psychological-states-are-warfare.md
+++ b/catalog/entries/psychological-states-are-warfare.md
@@ -30,6 +30,15 @@ limits:
   - "[source] misleads because war aims to destroy the opponent, but psychological integration requires reconciling conflicting parts rather than annihilating them"
   - "[source] obscures that psychological well-being often requires acceptance rather than combat -- the opposite of what the war frame prescribes"
 updated: '2026-03-16'
+embodied_patterns:
+  - force
+  - boundary
+  - balance
+relation_types:
+  - compete
+  - transform
+structure: competition
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/purposes-are-desired-objects.md
+++ b/catalog/entries/purposes-are-desired-objects.md
@@ -29,6 +29,15 @@ transfers:
 limits:
   - '[source] breaks because physical objects provide the same value regardless of how they were obtained, while purposes often derive their meaning from the process of pursuit rather than the outcome'
   - '[source] misleads because objects are finite and possessable by one party, while many purposes (knowledge, justice, understanding) are non-rivalrous and cannot be depleted by sharing'
+embodied_patterns:
+  - near-far
+  - force
+  - path
+relation_types:
+  - cause
+  - enable
+structure: pipeline
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/purposes-are-destinations.md
+++ b/catalog/entries/purposes-are-destinations.md
@@ -28,6 +28,15 @@ transfers:
 limits:
   - '[source] breaks because destinations exist before the traveler arrives, while many purposes are constructed during the process of pursuing them'
   - '[source] misleads because arriving at a destination ends the journey, while achieving a purpose often reveals further purposes beyond it'
+embodied_patterns:
+  - path
+  - near-far
+  - force
+relation_types:
+  - cause
+  - enable
+structure: pipeline
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/put-out-to-pasture.md
+++ b/catalog/entries/put-out-to-pasture.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because livestock put to pasture genuinely cannot perform their former work due to physical decline, while humans "put out to pasture" may retain full capability and are often sidelined for political or age-discriminatory reasons unrelated to actual performance'
   - '[source] misleads by framing forced retirement as pastoral kindness -- green fields, gentle grazing -- when the actual experience for the person is often loss of identity, social isolation, and involuntary irrelevance'
+embodied_patterns:
+  - path
+  - removal
+  - container
+relation_types:
+  - transform
+  - prevent
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers


### PR DESCRIPTION
Adds embodied_patterns, relation_types, structure, and abstraction_level to 50 entries (pyrrhic-victory through secure-base).

Part of the structural enrichment sweep.
See: docs/plans/2026-03-20-structural-enrichment-vocabulary.md