### PR TITLE
Enrich: structural tags batch 9 (50 entries)

### DIFF
--- a/catalog/entries/conscious-is-up.md
+++ b/catalog/entries/conscious-is-up.md
@@ -27,6 +27,15 @@ transfers:
 limits:
   - '[source] breaks because sleep architecture involves cycles (light, deep, REM) that do not map onto a single depth axis -- REM is neurologically active yet metaphorically "deep"'
   - '[source] misleads because altered states like meditation, flow, and hypnosis involve changes in consciousness that are neither up nor down on the vertical axis'
+embodied_patterns:
+  - scale
+  - surface-depth
+  - force
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/constancy-of-purpose.md
+++ b/catalog/entries/constancy-of-purpose.md
@@ -21,6 +21,15 @@ transfers:
 limits:
   - "[law] breaks when the environment changes so rapidly that constancy becomes rigidity -- the model assumes a stable enough world that patient investment pays off, but in genuinely discontinuous environments, stubborn consistency is a path to irrelevance"
   - "[law] misleads by framing the choice as binary (constant vs. inconstant) when real organizations must simultaneously maintain strategic direction and adapt tactically, a tension the model acknowledges but does not resolve"
+embodied_patterns:
+  - path
+  - force
+  - balance
+relation_types:
+  - prevent
+  - enable
+structure: equilibrium
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/context-window-is-working-memory.md
+++ b/catalog/entries/context-window-is-working-memory.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because working memory actively manipulates and integrates information, while a context window is passive input where all tokens sit with equal ontological status until processed'
   - '[source] misleads because human forgetting is selective (emotionally significant items persist) while context truncation is mechanical FIFO that drops tokens regardless of importance'
+embodied_patterns:
+  - container
+  - scale
+  - removal
+relation_types:
+  - contain
+  - transform
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/continuous-flow.md
+++ b/catalog/entries/continuous-flow.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - "[source] breaks because fluid is homogeneous and every drop is interchangeable, while work items differ in complexity, skill requirements, and failure modes -- forcing heterogeneous work into a single-piece stream can create more turbulence than batching would"
   - "[source] misleads because fluid flow is passive (gravity or pressure does the work), while continuous flow in knowledge work requires active coordination, constant communication, and deliberate handoff protocols that the metaphor makes invisible"
+embodied_patterns:
+  - flow
+  - blockage
+  - path
+relation_types:
+  - coordinate
+  - cause
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/cookie.md
+++ b/catalog/entries/cookie.md
@@ -25,6 +25,15 @@ transfers:
   - "[source] imports the handoff structure of fortune cookies -- given to the recipient at the end of a transaction, carrying information relevant to future encounters -- onto the server-client exchange where a token is passed after a request to enable stateful future interactions"
   - "[source] carries the 'magic cookie' lineage from Unix, where an opaque token is passed between programs without the intermediary inspecting its contents, mapping the sealed-container property of a fortune cookie onto a data structure whose meaning is opaque to the carrier"
 updated: '2026-03-17'
+embodied_patterns:
+  - container
+  - link
+  - matching
+relation_types:
+  - contain
+  - translate
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/copper-bottomed.md
+++ b/catalog/entries/copper-bottomed.md
@@ -19,6 +19,15 @@ transfers:
 - '[source] the expense of coppering signaled that the ship was worth protecting, carrying the implication that the cost of the guarantee is itself evidence of commitment'
 - '[source] the copper was below the waterline and invisible during normal operation, mapping hidden-but-essential protection onto guarantees that guard against risks people forget until disaster strikes'
 updated: '2026-03-14'
+embodied_patterns:
+  - surface-depth
+  - boundary
+  - force
+relation_types:
+  - prevent
+  - enable
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/cornucopia.md
+++ b/catalog/entries/cornucopia.md
@@ -25,6 +25,15 @@ limits:
   - "[source] misleads because the horn requires no management or stewardship -- it simply gives -- while real sources of abundance require maintenance, investment, and careful allocation"
   - "[source] obscures because the myth frames abundance as a gift (from a goat, from a god), importing passivity into situations that actually require active creation and distribution"
 updated: '2026-03-16'
+embodied_patterns:
+  - container
+  - flow
+  - scale
+relation_types:
+  - cause
+  - enable
+structure: growth
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/courage-is-strength.md
+++ b/catalog/entries/courage-is-strength.md
@@ -26,6 +26,15 @@ transfers:
 - "[source] strength is built through repeated exertion against resistance"
 - "[source] a strong structure holds firm under pressure while a weak one buckles and breaks"
 updated: '2026-03-16'
+embodied_patterns:
+  - force
+  - balance
+  - scale
+relation_types:
+  - enable
+  - prevent
+structure: competition
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/creating-is-birthing.md
+++ b/catalog/entries/creating-is-birthing.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] breaks because birthing centers on a single mother-child relationship, making collaborative creation by hundreds of people structurally invisible'
   - '[source] misleads because gestation implies passive organic development, licensing procrastination disguised as biological inevitability ("I''m incubating the idea")'
+embodied_patterns:
+  - container
+  - path
+  - splitting
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/creating-is-giving-an-object.md
+++ b/catalog/entries/creating-is-giving-an-object.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] breaks because the giving frame skips the entire process of making, jumping from completed object to transfer and rendering drafts, revision, and iteration invisible'
   - '[source] misleads because creation addressed to no recipient (a diary, a private project) is rendered pointless by a frame that requires a receiver'
+embodied_patterns:
+  - link
+  - path
+  - part-whole
+relation_types:
+  - cause
+  - coordinate
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/creating-is-making-visible.md
+++ b/catalog/entries/creating-is-making-visible.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] breaks because the metaphor presupposes that the created thing pre-exists in hidden form, importing Platonic mysticism about a realm of latent objects'
   - '[source] misleads because revelation is passive (removing a veil), downplaying the labor, skill, and struggle involved in genuine making'
+embodied_patterns:
+  - surface-depth
+  - removal
+  - matching
+relation_types:
+  - transform
+  - enable
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/creating-is-making.md
+++ b/catalog/entries/creating-is-making.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] breaks because manufacturing requires knowing the product in advance (the mold precedes the casting), while important creative work discovers its form during the process'
   - '[source] misleads because the material in manufacturing is inert, hiding the reciprocal dialogue between creator and medium where language pushes back against the poet'
+embodied_patterns:
+  - force
+  - part-whole
+  - matching
+relation_types:
+  - transform
+  - cause
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/creating-is-moving-to-a-location.md
+++ b/catalog/entries/creating-is-moving-to-a-location.md
@@ -27,6 +27,15 @@ transfers:
 limits:
   - '[source] breaks because there is no actual location where uncreated ideas reside, yet the spatial frame invites Platonic mysticism about a realm of forms'
   - '[source] misleads because arrival implies completeness (a package arrives whole), but creative work typically arrives in fragments requiring extensive shaping on site'
+embodied_patterns:
+  - path
+  - near-far
+  - container
+relation_types:
+  - cause
+  - transform
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/creation-is-cultivation.md
+++ b/catalog/entries/creation-is-cultivation.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] breaks because a seed contains the oak teleologically, but a poem does not exist in potential before the poet writes it, importing false inevitability'
   - '[source] misleads because "organic growth" carries positive valence, making it hard to criticize growth that may be cancerous or to recognize ideologies that "take root" as invasive species'
+embodied_patterns:
+  - path
+  - accretion
+  - self-organization
+relation_types:
+  - enable
+  - transform
+structure: growth
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/creative-destruction.md
+++ b/catalog/entries/creative-destruction.md
@@ -24,6 +24,16 @@ limits:
   - "[paradigm] breaks because not all destruction is creative -- asset-stripping destroys without producing successors, but the paradigm blesses both with the same vocabulary"
   - "[paradigm] misleads because the biological analogy implies a natural process, but market destruction is driven by people with interests, power, and political connections"
   - "[paradigm] obscures that ecological succession happens over decades allowing adaptation, but market disruption can happen in months, faster than communities can adjust"
+embodied_patterns:
+  - splitting
+  - removal
+  - force
+relation_types:
+  - transform
+  - select
+  - cause
+structure: cycle
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/creative-process-is-construction.md
+++ b/catalog/entries/creative-process-is-construction.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - '[source] breaks because construction assumes you know what you are building before you build it, while creative work often must discover its goal through the process of making'
   - '[source] misleads because buildings are static once constructed -- they do not grow, adapt, or reproduce -- making ongoing evolution feel like renovation rather than natural change'
+embodied_patterns:
+  - part-whole
+  - path
+  - superimposition
+relation_types:
+  - transform
+  - coordinate
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/creative-process-is-gardening.md
+++ b/catalog/entries/creative-process-is-gardening.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because pure emergence without curation produces wilderness, not a garden -- the metaphor needs the gardener''s active agency to work'
   - '[source] misleads because gardens are slow and seasonal, importing patience as a universal virtue when some creative work demands urgency and speed'
+embodied_patterns:
+  - self-organization
+  - removal
+  - accretion
+relation_types:
+  - enable
+  - transform
+structure: emergence
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/creative-works-are-food.md
+++ b/catalog/entries/creative-works-are-food.md
@@ -25,6 +25,15 @@ limits:
   - '[source] breaks because food is destroyed on consumption while a poem, song, or film survives intact after being read, heard, or watched -- the metaphor erases the non-rivalrous nature of creative works'
   - '[source] misleads because food quality is largely objective (spoiled vs. fresh, nutritious vs. empty) while creative quality is irreducibly subjective, so "slop" borrows a false consensus about what counts as edible'
   - '[source] obscures that the same "consumer" is often also a creator -- the food frame casts people as mouths at the end of a supply chain, hiding the participatory and generative dimension of culture'
+embodied_patterns:
+  - flow
+  - part-whole
+  - container
+relation_types:
+  - transform
+  - accumulate
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/critical-mass.md
+++ b/catalog/entries/critical-mass.md
@@ -18,6 +18,15 @@ transfers:
 limits:
   - "[model] breaks because nuclear critical mass is a precise physical constant while social 'critical mass' is fuzzy, context-dependent, and usually identifiable only in retrospect, importing false precision into social phenomena"
   - "[model] misleads because the binary framing (critical or sub-critical) devalues sustainable linear growth by implicitly comparing everything to exponential growth -- a niche product with loyal users is not a failure just because it has not tipped"
+embodied_patterns:
+  - scale
+  - boundary
+  - force
+relation_types:
+  - cause
+  - enable
+structure: growth
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/cron-job.md
+++ b/catalog/entries/cron-job.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - "[source] breaks because employment involves ongoing negotiation, compensation, and worker agency, whereas the mapped entity executes a fixed script with no capacity to refuse or renegotiate"
   - "[source] misleads because the 'job' framing implies a human-scale task with meaningful duration, when the mapped entity may execute in milliseconds"
+embodied_patterns:
+  - iteration
+  - path
+  - force
+relation_types:
+  - coordinate
+  - cause
+structure: cycle
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/cryonics-is-death-deferral.md
+++ b/catalog/entries/cryonics-is-death-deferral.md
@@ -21,6 +21,15 @@ transfers:
 - "[source] preservation in ice arrests biological processes, converting continuous decay into a fixed state that can theoretically be resumed later"
 - "[source] the sleeper delegates the problem of death to future generations who may possess technology the present lacks"
 updated: '2026-03-16'
+embodied_patterns:
+  - container
+  - path
+  - blockage
+relation_types:
+  - prevent
+  - transform
+structure: transformation
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/culture-as-a-control-system.md
+++ b/catalog/entries/culture-as-a-control-system.md
@@ -23,6 +23,16 @@ transfers:
 limits:
   - "[paradigm] breaks because culture is emergent from thousands of interactions rather than engineered with precise specifications -- leaders can influence culture but cannot design it with thermostat-level precision"
   - "[paradigm] misleads because a control system faithfully maintains whatever setpoint it is given, including a dysfunctional one -- Enron had a strong culture that was strongly wrong, and the model does not distinguish healthy from pathological equilibria"
+embodied_patterns:
+  - balance
+  - container
+  - force
+relation_types:
+  - coordinate
+  - prevent
+  - restore
+structure: equilibrium
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/cut-and-run.md
+++ b/catalog/entries/cut-and-run.md
@@ -22,6 +22,15 @@ transfers:
 limits:
   - '[source] breaks because the original nautical act was often the rational tactical choice, but modern usage inverts the moral valence to imply cowardice'
   - '[source] misleads because the metaphor hides the threat being fled from, focusing on the departure and ignoring the conditions that motivated it'
+embodied_patterns:
+  - path
+  - force
+  - splitting
+relation_types:
+  - cause
+  - prevent
+structure: competition
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/cyberspace-is-a-place.md
+++ b/catalog/entries/cyberspace-is-a-place.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - "[source] breaks because places have singular location -- you cannot be in two places at once -- but a user can have simultaneous sessions across dozens of services, and data is routinely replicated across continents"
   - "[source] misleads because spatial metaphors import scarcity (there is only so much land), but digital resources can be copied infinitely at near-zero cost, making spatial intuitions about territory and possession systematically wrong"
+embodied_patterns:
+  - container
+  - boundary
+  - path
+relation_types:
+  - contain
+  - enable
+structure: boundary
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/daemon.md
+++ b/catalog/entries/daemon.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - '[source] breaks because daimons had judgment and could warn or choose, while a Unix daemon follows its configuration with perfect literal obedience and no agency'
   - '[source] misleads because the entire numinous framework (the uncanny, the liminal, the sacred) has been bleached into a technical term, losing the sense that autonomous agents deserve respect and caution'
+embodied_patterns:
+  - self-organization
+  - surface-depth
+  - force
+relation_types:
+  - coordinate
+  - enable
+structure: emergence
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/damocles-sword.md
+++ b/catalog/entries/damocles-sword.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - '[source] breaks because Damocles chose the seat voluntarily, but most modern applications describe involuntary exposure to structural threat'
   - '[source] misleads because the sword never falls in the original story -- the power of the image depends on permanent suspension, but users extend it to describe actual catastrophe'
+embodied_patterns:
+  - force
+  - balance
+  - near-far
+relation_types:
+  - prevent
+  - cause
+structure: equilibrium
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/dangerous-beliefs-are-contagious-diseases.md
+++ b/catalog/entries/dangerous-beliefs-are-contagious-diseases.md
@@ -26,6 +26,16 @@ transfers:
 limits:
   - '[source] breaks because belief adoption involves agency and reasons, while catching a disease does not -- the metaphor strips believers of rational motivation'
   - '[source] misleads because "which beliefs are dangerous" is a contested political question, but the disease frame disguises evaluation as neutral medical diagnosis'
+embodied_patterns:
+  - flow
+  - link
+  - boundary
+relation_types:
+  - cause
+  - prevent
+  - transform
+structure: network
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/dark-forest.md
+++ b/catalog/entries/dark-forest.md
@@ -22,6 +22,15 @@ transfers:
 limits:
   - "[source] breaks because the dark forest assumes all unknown agents are potential predators, but real environments contain a distribution of cooperative, neutral, and hostile actors, and treating all unknowns as threats produces self-fulfilling hostility"
   - "[source] misleads because forests are ecosystems with symbiotic relationships, not arenas of pure predation -- the metaphor selects for the forest's danger while ignoring its ecological interdependence"
+embodied_patterns:
+  - container
+  - surface-depth
+  - boundary
+relation_types:
+  - prevent
+  - compete
+structure: competition
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/darkness-is-a-cover.md
+++ b/catalog/entries/darkness-is-a-cover.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because covers are placed by agents with purpose, but darkness arrives through planetary rotation without intention or agency'
   - '[source] misleads because the cover metaphor implies concealment implies something worth hiding, biasing darkness toward suspicion and moral charge'
+embodied_patterns:
+  - container
+  - surface-depth
+  - boundary
+relation_types:
+  - contain
+  - prevent
+structure: boundary
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/darkness-is-a-solid.md
+++ b/catalog/entries/darkness-is-a-solid.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because darkness is the absence of photons, not the presence of matter -- the metaphor reifies an absence into a substance'
   - '[source] misleads because if darkness is solid then illumination must be violent (cutting, piercing, shattering), framing understanding as an aggressive act rather than gradual dawning'
+embodied_patterns:
+  - force
+  - blockage
+  - surface-depth
+relation_types:
+  - prevent
+  - contain
+structure: boundary
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/dashboard.md
+++ b/catalog/entries/dashboard.md
@@ -23,6 +23,15 @@ limits:
   - "[source] breaks because an automobile dashboard displays real-time physical measurements (speed, fuel, temperature), while a software dashboard often displays aggregated historical data that may be minutes or hours old"
   - "[source] misleads because a car dashboard has a fixed set of instruments chosen by the manufacturer, while software dashboards are endlessly customizable, leading to information overload that the source domain would never produce"
   - "[source] obscures that the original dashboard (horse-drawn carriage) was a physical barrier protecting the driver from mud, not an information display at all"
+embodied_patterns:
+  - container
+  - boundary
+  - matching
+relation_types:
+  - translate
+  - coordinate
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/data-flow-is-fluid-flow.md
+++ b/catalog/entries/data-flow-is-fluid-flow.md
@@ -24,6 +24,15 @@ limits:
   - "[paradigm] breaks because fluids are continuous, but data arrives in discrete packets with headers, delimiters, and schemas"
   - "[paradigm] misleads because fluids obey physics and cannot flow uphill without a pump, but data can be copied, broadcast, and sent in any direction at near-zero cost"
   - "[paradigm] obscures that merging two fluid streams produces fluid, but merging two data streams produces schema conflicts"
+embodied_patterns:
+  - flow
+  - blockage
+  - path
+relation_types:
+  - transform
+  - coordinate
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/data-is-fuel.md
+++ b/catalog/entries/data-is-fuel.md
@@ -24,6 +24,16 @@ transfers:
 limits:
   - '[source] breaks because data is not consumed -- it persists after use, can be copied infinitely at near-zero cost, and does not deplete with training'
   - '[source] misleads because data is produced by human creative labor, not formed by geological processes, but the "natural resource" frame obscures the workers who generate it'
+embodied_patterns:
+  - flow
+  - part-whole
+  - container
+relation_types:
+  - cause
+  - transform
+  - enable
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/data-stream.md
+++ b/catalog/entries/data-stream.md
@@ -25,6 +25,15 @@ limits:
   - "[source] breaks because water in a stream is continuous fluid, but data is discrete packets with gaps between them"
   - "[source] misleads because a stream's flow rate is determined by gravity and terrain, not by a consumer pulling data on demand"
   - "[source] obscures that streams in nature cannot be paused, rewound, or replayed, while data streams routinely support all three operations"
+embodied_patterns:
+  - flow
+  - path
+  - scale
+relation_types:
+  - cause
+  - coordinate
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/dead-in-the-water.md
+++ b/catalog/entries/dead-in-the-water.md
@@ -22,6 +22,15 @@ transfers:
 limits:
   - '[source] breaks because most stalled projects have internal causes (poor leadership, unresolved conflict), but the nautical frame externalizes blame onto absent wind'
   - '[source] misleads because the metaphor implies waiting is the correct response to a calm, but for stalled projects active intervention is almost always both possible and necessary'
+embodied_patterns:
+  - blockage
+  - force
+  - path
+relation_types:
+  - prevent
+  - cause
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/dead-plate.md
+++ b/catalog/entries/dead-plate.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] breaks because a dead plate is physically irreversible -- food cannot be uncooked -- while most organizational "dead work" (abandoned PRs, shelved features, canceled projects) can be partially salvaged, forked, or repurposed, making the kitchen''s total-loss framing too severe for domains with recoverable artifacts'
   - '[source] misleads by implying that waste should be zero, when some rate of dead plates (and dead code, abandoned experiments, spiked articles) is the unavoidable cost of operating in uncertain environments, and a system that produces zero waste is likely too conservative'
+embodied_patterns:
+  - flow
+  - blockage
+  - path
+relation_types:
+  - coordinate
+  - cause
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/deadline.md
+++ b/catalog/entries/deadline.md
@@ -22,6 +22,15 @@ limits:
   - "[source] breaks because crossing a Civil War prison deadline meant death, but missing a modern deadline rarely carries lethal or even serious consequences"
   - "[source] misleads because the original deadline was a spatial boundary (a line in dirt), not a temporal one (a moment in time), and the space-to-time mapping is itself a buried metaphor"
   - "[source] obscures that prison deadlines were visible and unambiguous, while modern deadlines are often vague, negotiable, and quietly extended"
+embodied_patterns:
+  - boundary
+  - force
+  - near-far
+relation_types:
+  - prevent
+  - contain
+structure: boundary
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/death-is-a-journey.md
+++ b/catalog/entries/death-is-a-journey.md
@@ -28,6 +28,15 @@ transfers:
 - "[source] the traveler persists as an entity throughout the journey, arriving somewhere else rather than ceasing to exist"
 - "[source] those left behind can only accompany the traveler to the point of departure, not beyond"
 updated: '2026-03-16'
+embodied_patterns:
+  - path
+  - near-far
+  - boundary
+relation_types:
+  - transform
+  - cause
+structure: pipeline
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/death-is-departure.md
+++ b/catalog/entries/death-is-departure.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because there is no traveler -- death is cessation, not relocation, but the departure metaphor preserves the person as an entity that has merely changed address'
   - '[source] misleads because if death is departure then reunion is possible ("I''ll see you on the other side"), generating false hope that is a structural entailment of the journey frame'
+embodied_patterns:
+  - path
+  - near-far
+  - splitting
+relation_types:
+  - transform
+  - cause
+structure: pipeline
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/decision-is-a-path.md
+++ b/catalog/entries/decision-is-a-path.md
@@ -28,6 +28,15 @@ limits:
   - "[source] breaks because paths are continuous and incremental, but many real decisions are discrete and irreversible jumps"
   - "[source] misleads because forks typically offer two or three branches, collapsing the often-unlimited option space of real decisions"
   - "[source] obscures that paths pre-exist the traveler, while decision options are frequently created by the decider"
+embodied_patterns:
+  - path
+  - splitting
+  - near-far
+relation_types:
+  - select
+  - cause
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/decisive-point.md
+++ b/catalog/entries/decisive-point.md
@@ -28,6 +28,16 @@ limits:
   - '[source] breaks because a geographic decisive point is observable and fixed (a bridge, a hill, a crossroads), while a strategic decisive point in business or politics is constructed through interpretation and may only be visible in retrospect'
   - '[source] misleads by implying every contest has a single decisive moment, when many competitive outcomes result from sustained cumulative advantage with no identifiable turning point'
   - '[source] obscures that Napoleon''s decisive-point doctrine assumed a peer adversary playing by similar rules -- it transfers poorly to asymmetric contests where the weaker party refuses to concentrate forces and instead disperses (guerrilla warfare, startup disruption from below)'
+embodied_patterns:
+  - center-periphery
+  - force
+  - blockage
+relation_types:
+  - cause
+  - select
+  - compete
+structure: competition
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/deep-magic.md
+++ b/catalog/entries/deep-magic.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - '[source] breaks because software is deterministic -- every behavior has a traceable causal chain -- but calling it "magic" concedes understanding prematurely and dignifies ignorance as mystery'
   - '[source] misleads because labeling code as deep magic rewards obscurity (the wizard-developer accrues status from monopoly on comprehension) and discourages investigation by other developers'
+embodied_patterns:
+  - surface-depth
+  - container
+  - boundary
+relation_types:
+  - enable
+  - prevent
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/deep-reveals.md
+++ b/catalog/entries/deep-reveals.md
@@ -26,6 +26,15 @@ transfers:
 - '[source] imports the structural fact that deep reveals are a consequence of thick, substantial walls, framing rich error messages and detailed API contracts as evidence that the boundary was designed with care, not as afterthought decoration'
 - '[source] structures the observation that a deep reveal creates shelter and a sense of enclosure at the threshold, mapping onto the user experience of encountering a software boundary (error, API response, documentation) that provides enough context to orient rather than leaving the user exposed'
 updated: '2026-03-19'
+embodied_patterns:
+  - boundary
+  - surface-depth
+  - container
+relation_types:
+  - translate
+  - contain
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/deep-roots-are-not-reached-by-frost.md
+++ b/catalog/entries/deep-roots-are-not-reached-by-frost.md
@@ -27,6 +27,15 @@ transfers:
 - '[source] imports the botanical fact that depth is achieved through slow, sustained growth rather than rapid extension, structuring resilience as a function of patient accumulation rather than reactive fortification'
 - '[source] carries the agricultural knowledge that the same frost that kills shallow-rooted annuals leaves deep-rooted perennials unharmed, mapping onto the distinction between fragile quick-growth strategies and durable slow-growth ones'
 updated: '2026-03-20'
+embodied_patterns:
+  - surface-depth
+  - accretion
+  - force
+relation_types:
+  - prevent
+  - accumulate
+structure: growth
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/deep-space-is-the-unknown-frontier.md
+++ b/catalog/entries/deep-space-is-the-unknown-frontier.md
@@ -22,6 +22,15 @@ transfers:
 - "[source] what lies beyond the frontier is simultaneously threatening and promising -- terra incognita holds both monsters and treasure"
 - "[source] exploration converts mystery into knowledge by making the unfamiliar familiar through direct encounter"
 updated: '2026-03-16'
+embodied_patterns:
+  - near-far
+  - boundary
+  - path
+relation_types:
+  - transform
+  - enable
+structure: boundary
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/defense-in-depth.md
+++ b/catalog/entries/defense-in-depth.md
@@ -26,6 +26,15 @@ transfers:
 - "[source] imports the principle that no single defensive position is expected to hold indefinitely, structuring security thinking around graceful degradation rather than perimeter invincibility"
 - "[source] carries the spatial concept of depth -- territory between the front line and the vital interior -- onto the idea that security controls should be distributed across multiple system layers rather than concentrated at a single boundary"
 updated: '2026-03-18'
+embodied_patterns:
+  - boundary
+  - surface-depth
+  - superimposition
+relation_types:
+  - prevent
+  - contain
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/defense-to-offense-transition.md
+++ b/catalog/entries/defense-to-offense-transition.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - '[source] misleads because military transitions occur between two clearly defined postures (defend territory vs. take territory), while most organizational transitions lack such binary states -- a company "pivoting" from cost reduction to growth is not switching between two discrete modes but adjusting a continuous mix of activities'
   - '[source] assumes a single adversary whose behavior can be read for timing cues, but most competitive environments involve multiple actors whose independent decisions make the "right moment" for transition unreadable'
+embodied_patterns:
+  - force
+  - balance
+  - path
+relation_types:
+  - transform
+  - compete
+structure: transformation
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/degrees-of-publicness.md
+++ b/catalog/entries/degrees-of-publicness.md
@@ -25,6 +25,16 @@ transfers:
 limits:
   - '[source] breaks because physical transitions between zones are experienced sequentially (you must pass through the foyer to reach the hallway), while digital access controls can be bypassed entirely if a single credential grants access to the innermost zone'
   - '[source] misleads by implying that the gradient is spatial and continuous, when digital access is typically discrete (you either have the API key or you do not) with no meaningful intermediate states'
+embodied_patterns:
+  - boundary
+  - container
+  - center-periphery
+relation_types:
+  - contain
+  - prevent
+  - select
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/design-from-patterns-to-details.md
+++ b/catalog/entries/design-from-patterns-to-details.md
@@ -23,6 +23,15 @@ transfers:
 - '[model] details placed without reference to the governing pattern will fight the pattern continuously, requiring external energy to sustain -- a garden bed placed against the drainage gradient requires pumped irrigation'
 - '[model] the model inverts the common impulse to start with components and assemble upward; instead it starts with context and decomposes downward, ensuring coherence between scale levels'
 updated: '2026-03-20'
+embodied_patterns:
+  - part-whole
+  - scale
+  - matching
+relation_types:
+  - coordinate
+  - decompose
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/desire-is-hunger.md
+++ b/catalog/entries/desire-is-hunger.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] breaks because hunger has a biological endpoint (fullness) but many desires like status and wealth have no satiation mechanism -- fulfillment generates new desire'
   - '[source] misleads because hunger is universal and involuntary while most desires beyond basic needs are culturally constructed, but the metaphor naturalizes socially shaped wants as biological drives'
+embodied_patterns:
+  - force
+  - container
+  - scale
+relation_types:
+  - cause
+  - transform
+structure: cycle
+abstraction_level: primitive
 ---
 
 ## Transfers


### PR DESCRIPTION
Adds embodied_patterns, relation_types, structure, and abstraction_level to 50 entries (conscious-is-up through desire-is-hunger).

Replaces closed PR #2405 which had a batch overlap bug (100 files instead of 50). See kaizen #2412.

Part of the structural enrichment sweep.