### PR TITLE
Enrich: structural tags cleanup batch 1 (50 entries)

### DIFF
--- a/catalog/entries/jury-rigged.md
+++ b/catalog/entries/jury-rigged.md
@@ -24,12 +24,12 @@ transfers:
 - '[source] the standard for a jury rig was survival, not excellence -- it needed only enough sail area for steerage, mapping reduced adequacy standards onto solutions that work but barely'
 updated: '2026-03-14'
 embodied_patterns:
-  - force
-  - path
-  - boundary
+  - part-whole
+  - matching
+  - removal
 relation_types:
-  - cause
   - transform
+  - enable
 structure: transformation
 abstraction_level: specific
 ---

--- a/catalog/entries/just-in-time.md
+++ b/catalog/entries/just-in-time.md
@@ -27,13 +27,13 @@ limits:
   - "[paradigm] the deliberate removal of buffers that exposes problems also removes the resilience that buffers provide, making the system fragile to disruptions it has not yet learned to prevent"
 embodied_patterns:
   - flow
-  - matching
+  - balance
   - iteration
 relation_types:
-  - cause
-  - transform
-structure: pipeline
-abstraction_level: generic
+  - coordinate
+  - prevent
+structure: equilibrium
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/just-tell-the-story.md
+++ b/catalog/entries/just-tell-the-story.md
@@ -23,14 +23,14 @@ limits:
   - '[model] assumes the story is known before editing begins, but in exploratory work (research, prototyping, improvisation) the story emerges through the process and cannot serve as a filter until it has been discovered'
   - '[model] provides no guidance on which story to tell when multiple valid narratives compete, reducing a framing problem to an editing problem'
 embodied_patterns:
-  - force
   - path
   - matching
+  - removal
 relation_types:
-  - cause
-  - transform
-structure: transformation
-abstraction_level: generic
+  - coordinate
+  - enable
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/kaikaku.md
+++ b/catalog/entries/kaikaku.md
@@ -24,14 +24,14 @@ limits:
   - "[model] romanticizes discontinuous change by giving it a name, potentially encouraging premature abandonment of incremental improvement by leaders who prefer dramatic action to patient compounding"
 updated: '2026-03-18'
 embodied_patterns:
-  - flow
-  - matching
-  - iteration
+  - force
+  - path
+  - splitting
 relation_types:
-  - cause
   - transform
-structure: pipeline
-abstraction_level: generic
+  - cause
+structure: transformation
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/kaizen.md
+++ b/catalog/entries/kaizen.md
@@ -27,14 +27,13 @@ limits:
   - "[paradigm] assumes a stable-enough environment for incremental changes to accumulate before conditions shift; in rapidly disrupted markets, the increments may be invalidated faster than they can compound"
 updated: '2026-03-18'
 embodied_patterns:
-  - flow
-  - matching
   - iteration
+  - accretion
+  - path
 relation_types:
-  - cause
   - transform
-  - coordinate
-structure: pipeline
+  - accumulate
+structure: cycle
 abstraction_level: generic
 ---
 

--- a/catalog/entries/kanban.md
+++ b/catalog/entries/kanban.md
@@ -29,13 +29,13 @@ limits:
   - "[paradigm] assumes that work items are roughly interchangeable and flow through a repeatable sequence of stations, but knowledge work varies enormously in size, complexity, and routing, making the factory-floor token system a poor fit without significant adaptation"
 embodied_patterns:
   - flow
+  - container
   - matching
-  - iteration
 relation_types:
-  - cause
-  - contain
+  - coordinate
+  - prevent
 structure: pipeline
-abstraction_level: generic
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/karma.md
+++ b/catalog/entries/karma.md
@@ -25,13 +25,13 @@ limits:
   - '[source] misleads by implying a just universe where suffering is always deserved (earned through prior bad karma), which can rationalize victim-blaming and indifference to structural injustice'
   - '[source] breaks because the original concept requires rebirth across multiple lifetimes for the ledger to balance, while the popular Western usage expects karma to close accounts within a single life, collapsing the cosmological timescale into an impossibly short window'
 embodied_patterns:
-  - force
+  - balance
   - path
-  - boundary
+  - accretion
 relation_types:
   - cause
-  - transform
-structure: transformation
+  - restore
+structure: cycle
 abstraction_level: generic
 ---
 

--- a/catalog/entries/kata.md
+++ b/catalog/entries/kata.md
@@ -26,14 +26,14 @@ limits:
   - "[paradigm] imports the martial-arts assumption of a single sensei-student relationship, which maps poorly onto organizations where coaching responsibilities are diffuse, contested, or absent"
 updated: '2026-03-18'
 embodied_patterns:
-  - force
+  - iteration
   - path
   - matching
 relation_types:
-  - cause
   - transform
-structure: transformation
-abstraction_level: generic
+  - accumulate
+structure: cycle
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/keelhauled.md
+++ b/catalog/entries/keelhauled.md
@@ -25,11 +25,11 @@ limits:
 embodied_patterns:
   - force
   - path
-  - boundary
+  - container
 relation_types:
   - cause
   - transform
-structure: transformation
+structure: pipeline
 abstraction_level: specific
 ---
 

--- a/catalog/entries/kernel.md
+++ b/catalog/entries/kernel.md
@@ -25,14 +25,14 @@ limits:
   - '[source] a botanical kernel germinates once and becomes something entirely different (a plant), whereas an OS kernel persists unchanged as a running service rather than transforming into its progeny'
   - '[source] botanical kernels are passive until conditions trigger germination, but an OS kernel is continuously active and responsive, never dormant in the way a seed is'
 embodied_patterns:
-  - accretion
-  - path
   - container
+  - center-periphery
+  - boundary
 relation_types:
-  - cause
   - contain
-structure: growth
-abstraction_level: generic
+  - enable
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/kernighans-law.md
+++ b/catalog/entries/kernighans-law.md
@@ -25,13 +25,13 @@ limits:
   - '[model] assumes the writer and the debugger are the same person with the same cognitive ceiling, but in practice debugging is often done by different people, by teams, or by the same person with better tools (debuggers, logging, tests) -- the law overpredicts difficulty when the debugging context is richer than the writing context'
   - '[model] treats cleverness as a single dimension, but code can be clever in ways that are easy to debug (a clever algorithm with clear invariants) or simple in ways that are hard to debug (straightforward code with subtle state interactions) -- the law conflates syntactic complexity with diagnostic difficulty'
 embodied_patterns:
-  - force
+  - scale
   - path
   - matching
 relation_types:
   - cause
-  - transform
-structure: transformation
+  - prevent
+structure: hierarchy
 abstraction_level: generic
 ---
 

--- a/catalog/entries/keystone-species.md
+++ b/catalog/entries/keystone-species.md
@@ -28,12 +28,12 @@ limits:
   - '[source] breaks because ecological keystones are species-level roles shaped by evolution over millennia, not individual actors who can be hired, fired, or reassigned'
   - '[source] misleads by implying a single removal event, when organizational dependency usually develops gradually through accumulated institutional knowledge that could have been distributed'
 embodied_patterns:
+  - center-periphery
   - link
   - balance
-  - flow
 relation_types:
+  - coordinate
   - cause
-  - compete
 structure: network
 abstraction_level: generic
 ---

--- a/catalog/entries/kill-your-darlings.md
+++ b/catalog/entries/kill-your-darlings.md
@@ -25,13 +25,13 @@ limits:
   - '[model] "darling" is doing diagnostic work the heuristic does not explain -- it offers no method for distinguishing a darling (something loved because of attachment) from a jewel (something loved because it is genuinely the best part), and practitioners who apply it indiscriminately produce flat, cautious work stripped of vitality'
   - '[model] the heuristic is asymmetric: it provides no equivalent warning against the opposite error of killing too much, which produces safe mediocrity -- the editor who kills every distinctive element creates work that is coherent but lifeless'
 embodied_patterns:
+  - removal
   - force
-  - scale
-  - path
+  - matching
 relation_types:
-  - cause
-  - compete
-structure: hierarchy
+  - select
+  - transform
+structure: transformation
 abstraction_level: generic
 ---
 

--- a/catalog/entries/killing-kittens.md
+++ b/catalog/entries/killing-kittens.md
@@ -28,14 +28,14 @@ transfers:
   - '[source] Kittens multiply quickly and unnoticeably -- a single indulged bit breeds similar indulgences until the work is overrun, mapping onto how one unjustified inclusion establishes a precedent that weakens editorial discipline throughout'
 updated: '2026-03-21'
 embodied_patterns:
+  - removal
   - force
-  - path
   - matching
 relation_types:
+  - prevent
   - cause
-  - transform
-structure: transformation
-abstraction_level: generic
+structure: competition
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/knock-down-joint.md
+++ b/catalog/entries/knock-down-joint.md
@@ -32,11 +32,11 @@ limits:
 embodied_patterns:
   - part-whole
   - matching
-  - force
+  - splitting
 relation_types:
-  - cause
-  - transform
-structure: pipeline
+  - coordinate
+  - enable
+structure: hierarchy
 abstraction_level: specific
 ---
 

--- a/catalog/entries/knotty-problem.md
+++ b/catalog/entries/knotty-problem.md
@@ -28,14 +28,13 @@ limits:
   - '[source] misleads by importing the assumption that the knot is a localized defect in otherwise clean grain, when many metaphorical knotty problems are knotty all the way through -- there is no surrounding straight grain to return to once you get past the hard part'
   - '[source] breaks because the carpenter''s response to a knot is avoidance where possible (cut around it, discard the board, place it where it won''t bear load), but the metaphor is typically invoked for problems that cannot be avoided and must be solved directly'
 embodied_patterns:
-  - part-whole
-  - matching
+  - link
+  - blockage
   - force
 relation_types:
-  - cause
   - prevent
-  - transform
-structure: pipeline
+  - cause
+structure: network
 abstraction_level: specific
 ---
 

--- a/catalog/entries/know-the-ropes.md
+++ b/catalog/entries/know-the-ropes.md
@@ -23,13 +23,13 @@ limits:
   - '[source] on a ship the ropes are physically fixed in location and finite in number, whereas organizational know-how involves shifting procedures and informal norms with no stable inventory'
   - '[source] shipboard rope knowledge can be taught by walking a novice through every line in a single tour, implying a bounded learning curve that most institutional knowledge does not have'
 embodied_patterns:
-  - force
+  - matching
   - path
-  - boundary
+  - link
 relation_types:
-  - cause
-  - transform
-structure: transformation
+  - enable
+  - coordinate
+structure: network
 abstraction_level: specific
 ---
 

--- a/catalog/entries/know-your-enemy-know-yourself.md
+++ b/catalog/entries/know-your-enemy-know-yourself.md
@@ -23,14 +23,14 @@ limits:
   - '[model] assumes a bilateral adversarial structure with a discrete "enemy" whose capabilities can be assessed, and breaks in multi-agent environments where the competitive landscape is diffuse, shifting, and partially cooperative'
   - '[model] implies that sufficient knowledge produces certainty of outcome ("need not fear"), while in practice both self-assessment and adversary-assessment are probabilistic and subject to deception, self-deception, and rapid change'
 embodied_patterns:
-  - force
-  - path
-  - center-periphery
+  - matching
+  - surface-depth
+  - balance
 relation_types:
-  - cause
+  - enable
   - compete
 structure: competition
-abstraction_level: generic
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/knowing-is-seeing.md
+++ b/catalog/entries/knowing-is-seeing.md
@@ -30,8 +30,8 @@ embodied_patterns:
   - surface-depth
   - matching
 relation_types:
+  - enable
   - cause
-  - transform
 structure: boundary
 abstraction_level: primitive
 ---

--- a/catalog/entries/knowing-when-not-to-operate.md
+++ b/catalog/entries/knowing-when-not-to-operate.md
@@ -29,11 +29,11 @@ limits:
   - '[source] In surgery, not operating has a clear meaning -- the patient is not cut open -- but in domains like management or policy, "not acting" is ambiguous because there are many possible actions and declining one does not foreclose others, making the surgical binary misleading'
   - '[source] The aphorism privileges the individual expert''s judgment as the mechanism of restraint, but in medicine the best protection against unnecessary surgery is systemic (second opinions, tumor boards, evidence-based guidelines), and the metaphor''s emphasis on individual wisdom obscures the need for institutional checks'
 embodied_patterns:
+  - removal
+  - boundary
   - matching
-  - surface-depth
-  - balance
 relation_types:
-  - compete
+  - prevent
   - select
 structure: boundary
 abstraction_level: specific

--- a/catalog/entries/knowledge-of-past-events-is-an-external-event-exerting-force-on.md
+++ b/catalog/entries/knowledge-of-past-events-is-an-external-event-exerting-force-on.md
@@ -30,14 +30,13 @@ limits:
   - '[source] a physical force has a single vector and magnitude, while the impact of learning about past events can simultaneously push in contradictory emotional directions (relief and grief at once)'
 embodied_patterns:
   - force
-  - scale
-  - balance
+  - path
+  - near-far
 relation_types:
   - cause
   - transform
-  - contain
-structure: equilibrium
-abstraction_level: generic
+structure: pipeline
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/koan.md
+++ b/catalog/entries/koan.md
@@ -24,14 +24,14 @@ limits:
   - "[source] breaks because a Zen koan operates within a structured teacher-student relationship with years of practice, while calling a business problem 'a koan' strips away the contemplative discipline that makes the paradox productive"
   - "[source] misleads because koans have recognized responses validated by a lineage of masters, while the metaphorical use implies that any sufficiently puzzling question is a koan, erasing the distinction between genuine paradox and mere confusion"
 embodied_patterns:
-  - force
-  - path
-  - boundary
+  - matching
+  - blockage
+  - splitting
 relation_types:
-  - cause
+  - transform
   - prevent
 structure: transformation
-abstraction_level: generic
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/labor-is-a-resource.md
+++ b/catalog/entries/labor-is-a-resource.md
@@ -29,14 +29,13 @@ limits:
   - '[source] resources do not improve through being used (coal does not become better coal by burning), whereas labor skill typically increases with practice, inverting the depletion assumption'
   - '[source] resources are passive and have no preferences about their allocation, obscuring that workers have agency, morale, and context-dependent productivity'
 embodied_patterns:
-  - balance
+  - container
   - flow
   - scale
 relation_types:
+  - accumulate
   - cause
-  - transform
-  - compete
-structure: cycle
+structure: pipeline
 abstraction_level: generic
 ---
 

--- a/catalog/entries/labyrinth.md
+++ b/catalog/entries/labyrinth.md
@@ -25,13 +25,13 @@ limits:
   - "[source] breaks because the mythological labyrinth has a single correct path and a single center, while real bureaucratic and systemic complexity typically has multiple overlapping paths, no center, and goals that shift as you navigate"
   - "[source] misleads because the metaphor implies the complexity is deliberate (someone designed this to trap you), encouraging paranoia about intentional obfuscation when most real complexity is emergent and unplanned"
 embodied_patterns:
-  - force
   - path
-  - boundary
+  - blockage
+  - container
 relation_types:
-  - enable
-  - accumulate
-structure: transformation
+  - prevent
+  - cause
+structure: pipeline
 abstraction_level: generic
 ---
 

--- a/catalog/entries/latticework-of-mental-models.md
+++ b/catalog/entries/latticework-of-mental-models.md
@@ -23,13 +23,13 @@ transfers:
 - '[model] predicts that a well-organized set of models makes ignorance legible -- gaps in coverage are visible, unlike a disorganized collection that hides its blind spots'
 updated: '2026-03-13'
 embodied_patterns:
+  - link
   - part-whole
-  - boundary
-  - container
+  - superimposition
 relation_types:
-  - cause
-  - transform
-structure: hierarchy
+  - coordinate
+  - enable
+structure: network
 abstraction_level: generic
 ---
 

--- a/catalog/entries/laughter-is-a-substance.md
+++ b/catalog/entries/laughter-is-a-substance.md
@@ -27,13 +27,12 @@ limits:
   - '[source] a physical substance persists after release and must be cleaned up, while laughter dissipates immediately and leaves no residue to manage'
   - '[source] substances have consistent properties regardless of context, but laughter''s quality (joyful, nervous, cruel) depends entirely on social and emotional circumstances'
 embodied_patterns:
+  - container
   - flow
-  - path
-  - blockage
+  - force
 relation_types:
   - cause
-  - prevent
-  - contain
+  - transform
 structure: pipeline
 abstraction_level: generic
 ---

--- a/catalog/entries/lava-flow.md
+++ b/catalog/entries/lava-flow.md
@@ -26,14 +26,14 @@ limits:
   - '[source] lava flows are natural and directionless -- they have no author or intent -- whereas legacy code was written by people making deliberate (if now-forgotten) design choices'
   - '[source] geological lava is chemically homogeneous within a single flow, while legacy code layers may use entirely different languages, frameworks, and paradigms'
 embodied_patterns:
-  - force
-  - path
-  - matching
+  - flow
+  - accretion
+  - blockage
 relation_types:
-  - cause
+  - accumulate
   - prevent
-structure: transformation
-abstraction_level: generic
+structure: growth
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/laying-pipe.md
+++ b/catalog/entries/laying-pipe.md
@@ -26,14 +26,14 @@ limits:
   - '[source] breaks because plumbing is a closed system with predictable flow, while audience cognition is open and unpredictable -- viewers may not retain the exposition, may misinterpret it, or may arrive with prior knowledge that makes the pipe redundant'
   - '[source] misleads by framing exposition as infrastructure that should be invisible, encouraging writers to hide necessary information so thoroughly that audiences miss it entirely, producing confusion rather than the intended seamless experience'
 embodied_patterns:
-  - force
   - path
-  - matching
+  - flow
+  - part-whole
 relation_types:
-  - cause
-  - transform
-structure: transformation
-abstraction_level: generic
+  - enable
+  - coordinate
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/lces.md
+++ b/catalog/entries/lces.md
@@ -25,14 +25,14 @@ limits:
   - '[model] breaks because fire behavior is governed by physical laws (wind, slope, fuel) that make prediction tractable within hours, while organizational and software threats involve adversarial or emergent dynamics where the equivalent of "where is the fire going" has no reliable answer'
   - '[model] misleads when teams treat the four components as a checklist to be satisfied once at the start, rather than continuously maintained -- a safety zone that was adequate when conditions were assessed may become untenable as the situation evolves, and the model''s acronym format encourages static rather than dynamic evaluation'
 embodied_patterns:
+  - part-whole
+  - link
   - matching
-  - path
-  - boundary
 relation_types:
+  - coordinate
   - prevent
-  - decompose
 structure: hierarchy
-abstraction_level: generic
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/leeway.md
+++ b/catalog/entries/leeway.md
@@ -22,13 +22,13 @@ transfers:
 - '[source] drift is always in one direction -- toward the hazard -- mapping onto situations where the default trajectory leads toward failure without active corrective effort'
 updated: '2026-03-14'
 embodied_patterns:
-  - force
-  - path
+  - container
   - boundary
+  - balance
 relation_types:
-  - cause
-  - transform
-structure: transformation
+  - enable
+  - contain
+structure: boundary
 abstraction_level: specific
 ---
 

--- a/catalog/entries/less-is-more.md
+++ b/catalog/entries/less-is-more.md
@@ -27,15 +27,14 @@ limits:
   - '[source] misleads by implying that complexity is always a defect, when many domains require irreducible complexity -- a tax code cannot be minimalist without becoming unjust, and a programming language cannot be minimal without becoming inexpressive'
   - '[source] hides the survivorship bias in its own evidence: we see the successful minimalist designs (iPhone, Mies''s Farnsworth House) and not the many stripped-down designs that failed because they removed something essential, so the principle appears more reliable than it is'
 embodied_patterns:
-  - part-whole
-  - boundary
-  - container
+  - removal
+  - scale
+  - matching
 relation_types:
-  - cause
   - transform
-  - compete
-structure: hierarchy
-abstraction_level: specific
+  - select
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/let-justice-be-done-though-the-heavens-fall.md
+++ b/catalog/entries/let-justice-be-done-though-the-heavens-fall.md
@@ -25,11 +25,11 @@ limits:
   - "[paradigm] misleads because it presents deontological commitment as costless to the speaker while the consequences fall on others, creating a structural asymmetry where the person invoking the principle bears none of the burden of the falling heavens"
 embodied_patterns:
   - force
-  - scale
-  - path
+  - boundary
+  - balance
 relation_types:
   - cause
-  - transform
+  - prevent
 structure: hierarchy
 abstraction_level: generic
 ---

--- a/catalog/entries/let-the-buyer-beware.md
+++ b/catalog/entries/let-the-buyer-beware.md
@@ -22,13 +22,13 @@ limits:
   - "[model] treats all transactions as arm's-length exchanges between equals, ignoring power asymmetries"
   - "[model] provides moral cover for fraud by shifting blame from the deceiver to the deceived"
 embodied_patterns:
+  - boundary
+  - surface-depth
   - balance
-  - flow
-  - scale
 relation_types:
-  - cause
-  - transform
-structure: cycle
+  - prevent
+  - select
+structure: boundary
 abstraction_level: generic
 ---
 

--- a/catalog/entries/let-the-master-answer.md
+++ b/catalog/entries/let-the-master-answer.md
@@ -26,13 +26,12 @@ transfers:
   - "[paradigm] provides the conceptual foundation for holding organizations rather than individuals accountable, enabling the entire vocabulary of corporate liability, command responsibility, and institutional negligence"
 updated: '2026-03-16'
 embodied_patterns:
-  - boundary
+  - link
   - force
-  - balance
+  - center-periphery
 relation_types:
   - cause
-  - prevent
-  - enable
+  - coordinate
 structure: hierarchy
 abstraction_level: generic
 ---

--- a/catalog/entries/let-the-tool-do-the-work.md
+++ b/catalog/entries/let-the-tool-do-the-work.md
@@ -24,14 +24,14 @@ transfers:
 - '[model] carries the prediction that increasing operator force will degrade rather than improve results -- a forced plane chatters and tears grain, a forced framework produces brittle workarounds -- because the tool''s design encodes constraints that force violates'
 updated: '2026-03-21'
 embodied_patterns:
-  - part-whole
-  - matching
   - force
+  - matching
+  - removal
 relation_types:
-  - cause
+  - enable
   - transform
 structure: pipeline
-abstraction_level: generic
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/lethal-trifecta.md
+++ b/catalog/entries/lethal-trifecta.md
@@ -26,14 +26,14 @@ transfers:
   - "[paradigm] carries the fire triangle's insight that each condition is individually safe, reframing the security conversation from 'is this agent dangerous?' to 'which combination of capabilities does it have?'"
 updated: '2026-03-18'
 embodied_patterns:
+  - link
+  - part-whole
   - matching
-  - path
-  - boundary
 relation_types:
   - cause
-  - transform
-structure: hierarchy
-abstraction_level: generic
+  - prevent
+structure: network
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/letter-vs-spirit-of-the-law.md
+++ b/catalog/entries/letter-vs-spirit-of-the-law.md
@@ -25,14 +25,13 @@ limits:
   - "[source] breaks because natural language ambiguity is a feature of communication (enabling nuance, politeness, flexibility), while legal ambiguity is a defect that creates exploitable gaps -- the metaphor treats a linguistic property as though it maps cleanly onto an institutional problem"
   - "[source] misleads because in language the 'spirit' is anchored to a specific speaker's intention, while in law the 'spirit' is often a post-hoc reconstruction by interpreters who may disagree about what the legislators intended or whether original intent even matters"
 embodied_patterns:
-  - force
-  - path
+  - surface-depth
   - matching
+  - boundary
 relation_types:
-  - cause
-  - compete
   - translate
-structure: transformation
+  - prevent
+structure: boundary
 abstraction_level: generic
 ---
 

--- a/catalog/entries/leverage.md
+++ b/catalog/entries/leverage.md
@@ -25,11 +25,11 @@ updated: '2026-03-13'
 embodied_patterns:
   - force
   - scale
-  - balance
+  - center-periphery
 relation_types:
   - cause
-  - transform
-structure: equilibrium
+  - enable
+structure: hierarchy
 abstraction_level: generic
 ---
 

--- a/catalog/entries/life-is-a-container.md
+++ b/catalog/entries/life-is-a-container.md
@@ -31,8 +31,8 @@ embodied_patterns:
   - boundary
   - flow
 relation_types:
+  - contain
   - cause
-  - transform
 structure: boundary
 abstraction_level: primitive
 ---

--- a/catalog/entries/life-is-a-gambling-game.md
+++ b/catalog/entries/life-is-a-gambling-game.md
@@ -28,13 +28,13 @@ limits:
   - '[source] gambling games have explicit odds that can be calculated, while most life decisions involve Knightian uncertainty where the probability distribution itself is unknown'
   - '[source] a gambling loss is cleanly quantified (you lose your stake), whereas life setbacks often have cascading, qualitative consequences that resist measurement'
 embodied_patterns:
+  - splitting
+  - balance
   - force
-  - path
-  - matching
 relation_types:
-  - cause
-  - transform
-structure: transformation
+  - select
+  - compete
+structure: competition
 abstraction_level: generic
 ---
 

--- a/catalog/entries/life-is-a-journey.md
+++ b/catalog/entries/life-is-a-journey.md
@@ -32,10 +32,10 @@ limits:
 embodied_patterns:
   - path
   - near-far
-  - force
+  - boundary
 relation_types:
-  - prevent
-  - select
+  - cause
+  - transform
 structure: pipeline
 abstraction_level: primitive
 ---

--- a/catalog/entries/life-is-a-performance.md
+++ b/catalog/entries/life-is-a-performance.md
@@ -29,13 +29,13 @@ limits:
   - "[source] misleads because theater has a script written in advance, implying life events are predetermined"
   - "[source] obscures genuine feeling by framing all emotional expression as performance for an audience"
 embodied_patterns:
-  - force
-  - path
   - matching
+  - boundary
+  - surface-depth
 relation_types:
-  - enable
-  - translate
-structure: transformation
+  - transform
+  - coordinate
+structure: boundary
 abstraction_level: generic
 ---
 

--- a/catalog/entries/life-is-a-story.md
+++ b/catalog/entries/life-is-a-story.md
@@ -27,13 +27,13 @@ limits:
   - '[source] stories are composed after the fact with the ending known, imposing retrospective coherence that was not available to the protagonist living forward in time'
   - '[source] stories require a narrator who selects what to include, but life as lived has no editor -- every moment is equally present and unedited until memory and retelling impose selection'
 embodied_patterns:
-  - force
   - path
   - matching
+  - part-whole
 relation_types:
-  - cause
-  - accumulate
-structure: transformation
+  - coordinate
+  - transform
+structure: pipeline
 abstraction_level: generic
 ---
 

--- a/catalog/entries/light-is-a-fluid.md
+++ b/catalog/entries/light-is-a-fluid.md
@@ -28,13 +28,13 @@ limits:
   - '[source] fluid mixes when two streams converge (changing both), but light beams cross without interacting, preserving their independent properties'
 embodied_patterns:
   - flow
+  - container
   - path
-  - blockage
 relation_types:
   - cause
   - transform
 structure: pipeline
-abstraction_level: generic
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/light-is-a-line.md
+++ b/catalog/entries/light-is-a-line.md
@@ -27,13 +27,13 @@ limits:
   - '[source] lines have no thickness and extend infinitely, but real light beams diverge, scatter, and attenuate with distance'
   - '[source] lines cannot bend around obstacles, but light diffracts around edges and refracts through media, behaviors that require wave models rather than ray geometry'
 embodied_patterns:
-  - matching
-  - container
-  - boundary
+  - path
+  - force
+  - near-far
 relation_types:
   - cause
-  - transform
-structure: transformation
+  - enable
+structure: pipeline
 abstraction_level: primitive
 ---
 

--- a/catalog/entries/light-on-two-sides.md
+++ b/catalog/entries/light-on-two-sides.md
@@ -27,14 +27,13 @@ limits:
   - '[source] architectural cross-lighting works because light is additive (two sources always produce more light), but in information design, two perspectives can produce confusion rather than clarity if they contradict'
   - '[source] the pattern assumes both light sources are desirable, but in architecture unwanted glare from a second source can be worse than controlled single-sided illumination'
 embodied_patterns:
-  - part-whole
   - boundary
-  - container
+  - balance
+  - flow
 relation_types:
-  - cause
-  - prevent
-  - compete
-structure: hierarchy
+  - enable
+  - coordinate
+structure: boundary
 abstraction_level: specific
 ---
 

--- a/catalog/entries/lightning-rod-joke.md
+++ b/catalog/entries/lightning-rod-joke.md
@@ -29,14 +29,14 @@ transfers:
   - '[source] The sacrificial element must be plausibly intended (not obviously fake) so the reviewer experiences genuine discovery rather than suspecting manipulation'
 updated: '2026-03-21'
 embodied_patterns:
+  - center-periphery
   - force
-  - path
-  - matching
+  - flow
 relation_types:
   - cause
-  - transform
-structure: transformation
-abstraction_level: generic
+  - translate
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/linear-scales-are-paths.md
+++ b/catalog/entries/linear-scales-are-paths.md
@@ -28,8 +28,8 @@ limits:
   - '[source] travel along a path takes effort proportional to distance, but moving along an abstract scale involves no physical cost -- going from 1 to 100 is no harder than going from 1 to 2'
 embodied_patterns:
   - path
+  - scale
   - near-far
-  - force
 relation_types:
   - cause
   - transform

--- a/catalog/entries/load-bearing-pun.md
+++ b/catalog/entries/load-bearing-pun.md
@@ -27,10 +27,10 @@ transfers:
 updated: '2026-03-19'
 embodied_patterns:
   - part-whole
-  - boundary
-  - container
+  - matching
+  - superimposition
 relation_types:
-  - cause
+  - coordinate
   - transform
 structure: hierarchy
 abstraction_level: specific

--- a/catalog/entries/logic-is-gravity.md
+++ b/catalog/entries/logic-is-gravity.md
@@ -29,13 +29,13 @@ limits:
   - '[source] gravity operates on passive objects that have no capacity to reinterpret the force acting on them, whereas logical agents can challenge definitions, reveal hidden assumptions, or change the rules of inference'
 embodied_patterns:
   - force
+  - path
   - scale
-  - balance
 relation_types:
   - cause
   - transform
-structure: equilibrium
-abstraction_level: generic
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers


### PR DESCRIPTION
Covers entries missed by conflicting PRs #2406, #2409, #2411 (now closed). Part of structural enrichment sweep completion.