### PR TITLE
Enrich: structural tags cleanup (200 entries)

### DIFF
--- a/catalog/entries/jury-rigged.md
+++ b/catalog/entries/jury-rigged.md
@@ -22,6 +22,15 @@ transfers:
 - '[source] the jury rig was explicitly temporary -- meant to last only until the ship reached port for proper repairs -- mapping onto solutions that should be replaced as soon as possible'
 - '[source] the standard for a jury rig was survival, not excellence -- it needed only enough sail area for steerage, mapping reduced adequacy standards onto solutions that work but barely'
 updated: '2026-03-14'
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/just-in-time.md
+++ b/catalog/entries/just-in-time.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - "[paradigm] assumes a stable, predictable demand signal that allows production to be synchronized, which breaks in environments with high demand variability, unpredictable disruptions, or long lead times"
   - "[paradigm] the deliberate removal of buffers that exposes problems also removes the resilience that buffers provide, making the system fragile to disruptions it has not yet learned to prevent"
+embodied_patterns:
+  - flow
+  - matching
+  - iteration
+relation_types:
+  - cause
+  - transform
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/just-tell-the-story.md
+++ b/catalog/entries/just-tell-the-story.md
@@ -21,6 +21,15 @@ transfers:
 limits:
   - '[model] assumes the story is known before editing begins, but in exploratory work (research, prototyping, improvisation) the story emerges through the process and cannot serve as a filter until it has been discovered'
   - '[model] provides no guidance on which story to tell when multiple valid narratives compete, reducing a framing problem to an editing problem'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/kaikaku.md
+++ b/catalog/entries/kaikaku.md
@@ -22,6 +22,15 @@ limits:
   - "[model] breaks because it provides no reliable signal for when to switch from kaizen to kaikaku -- the boundary between 'needs more refinement' and 'needs radical redesign' is indeterminate, and both camps can always produce arguments for their position"
   - "[model] romanticizes discontinuous change by giving it a name, potentially encouraging premature abandonment of incremental improvement by leaders who prefer dramatic action to patient compounding"
 updated: '2026-03-18'
+embodied_patterns:
+  - flow
+  - matching
+  - iteration
+relation_types:
+  - cause
+  - transform
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/kaizen.md
+++ b/catalog/entries/kaizen.md
@@ -25,6 +25,16 @@ limits:
   - "[paradigm] breaks when the system requires architectural redesign rather than incremental refinement -- no amount of small adjustments to a fundamentally flawed structure will fix it, which is precisely the gap that kaikaku addresses"
   - "[paradigm] assumes a stable-enough environment for incremental changes to accumulate before conditions shift; in rapidly disrupted markets, the increments may be invalidated faster than they can compound"
 updated: '2026-03-18'
+embodied_patterns:
+  - flow
+  - matching
+  - iteration
+relation_types:
+  - cause
+  - transform
+  - coordinate
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/kanban.md
+++ b/catalog/entries/kanban.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - "[paradigm] breaks when demand is genuinely unpredictable and cannot be smoothed -- pull signals assume a downstream station that knows what it needs next, but in creative, research, or emergency domains the next task is unknowable until the current one completes"
   - "[paradigm] assumes that work items are roughly interchangeable and flow through a repeatable sequence of stations, but knowledge work varies enormously in size, complexity, and routing, making the factory-floor token system a poor fit without significant adaptation"
+embodied_patterns:
+  - flow
+  - matching
+  - iteration
+relation_types:
+  - cause
+  - contain
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/karma.md
+++ b/catalog/entries/karma.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - '[source] misleads by implying a just universe where suffering is always deserved (earned through prior bad karma), which can rationalize victim-blaming and indifference to structural injustice'
   - '[source] breaks because the original concept requires rebirth across multiple lifetimes for the ledger to balance, while the popular Western usage expects karma to close accounts within a single life, collapsing the cosmological timescale into an impossibly short window'
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/kata.md
+++ b/catalog/entries/kata.md
@@ -24,6 +24,15 @@ limits:
   - "[paradigm] breaks when the improvement challenge requires creative divergence rather than disciplined convergence -- the kata's fixed routine can suppress novel approaches that do not fit the prescribed pattern"
   - "[paradigm] imports the martial-arts assumption of a single sensei-student relationship, which maps poorly onto organizations where coaching responsibilities are diffuse, contested, or absent"
 updated: '2026-03-18'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/keelhauled.md
+++ b/catalog/entries/keelhauled.md
@@ -21,6 +21,15 @@ transfers:
 limits:
   - '[source] misleads because keelhauling was frequently fatal or permanently disfiguring, while the idiomatic usage describes harsh verbal criticism that leaves no lasting damage, trivializing the violence of the source'
   - '[source] breaks when the person "keelhauled" in modern usage deserved the criticism, since the nautical punishment was notorious for being disproportionate and cruel, and the metaphor carries a sympathy-for-the-victim framing that may not apply'
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/kernel.md
+++ b/catalog/entries/kernel.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - '[source] a botanical kernel germinates once and becomes something entirely different (a plant), whereas an OS kernel persists unchanged as a running service rather than transforming into its progeny'
   - '[source] botanical kernels are passive until conditions trigger germination, but an OS kernel is continuously active and responsive, never dormant in the way a seed is'
+embodied_patterns:
+  - accretion
+  - path
+  - container
+relation_types:
+  - cause
+  - contain
+structure: growth
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/kernighans-law.md
+++ b/catalog/entries/kernighans-law.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - '[model] assumes the writer and the debugger are the same person with the same cognitive ceiling, but in practice debugging is often done by different people, by teams, or by the same person with better tools (debuggers, logging, tests) -- the law overpredicts difficulty when the debugging context is richer than the writing context'
   - '[model] treats cleverness as a single dimension, but code can be clever in ways that are easy to debug (a clever algorithm with clear invariants) or simple in ways that are hard to debug (straightforward code with subtle state interactions) -- the law conflates syntactic complexity with diagnostic difficulty'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/keystone-species.md
+++ b/catalog/entries/keystone-species.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] breaks because ecological keystones are species-level roles shaped by evolution over millennia, not individual actors who can be hired, fired, or reassigned'
   - '[source] misleads by implying a single removal event, when organizational dependency usually develops gradually through accumulated institutional knowledge that could have been distributed'
+embodied_patterns:
+  - link
+  - balance
+  - flow
+relation_types:
+  - cause
+  - compete
+structure: network
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/kill-your-darlings.md
+++ b/catalog/entries/kill-your-darlings.md
@@ -23,6 +23,15 @@ limits:
   - '[model] the heuristic assumes a zero-sum relationship between parts and whole, but in some domains (research programs, ecosystems, product suites) a brilliant component can generate value that exceeds its cost to coherence -- killing it destroys genuine capability, not just ego investment'
   - '[model] "darling" is doing diagnostic work the heuristic does not explain -- it offers no method for distinguishing a darling (something loved because of attachment) from a jewel (something loved because it is genuinely the best part), and practitioners who apply it indiscriminately produce flat, cautious work stripped of vitality'
   - '[model] the heuristic is asymmetric: it provides no equivalent warning against the opposite error of killing too much, which produces safe mediocrity -- the editor who kills every distinctive element creates work that is coherent but lifeless'
+embodied_patterns:
+  - force
+  - scale
+  - path
+relation_types:
+  - cause
+  - compete
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/killing-kittens.md
+++ b/catalog/entries/killing-kittens.md
@@ -26,6 +26,15 @@ transfers:
   - '[source] The act of killing requires overriding a strong instinctive aversion, mapping the emotional difficulty of cutting good-but-obstructive material onto the visceral revulsion of harming something cute and defenseless'
   - '[source] Kittens multiply quickly and unnoticeably -- a single indulged bit breeds similar indulgences until the work is overrun, mapping onto how one unjustified inclusion establishes a precedent that weakens editorial discipline throughout'
 updated: '2026-03-21'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/knock-down-joint.md
+++ b/catalog/entries/knock-down-joint.md
@@ -28,6 +28,15 @@ transfers:
 limits:
   - '[source] breaks because a physical knock-down joint has a finite number of assembly cycles before the mating surfaces wear and tolerances loosen, while software interfaces can be connected and disconnected indefinitely without mechanical degradation'
   - '[source] misleads by implying that disassembly is as simple as undoing a single fastener, when real software component removal typically involves migration of state, data, and dependent consumers -- a complexity the joint does not encode'
+embodied_patterns:
+  - part-whole
+  - matching
+  - force
+relation_types:
+  - cause
+  - transform
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/knotty-problem.md
+++ b/catalog/entries/knotty-problem.md
@@ -26,6 +26,16 @@ limits:
   - '[source] breaks because a knot has a fixed location visible on the wood''s surface -- the carpenter can see it before cutting -- while most metaphorical "knotty problems" cannot be surveyed in advance, and the tangle is discovered only by engaging with the material'
   - '[source] misleads by importing the assumption that the knot is a localized defect in otherwise clean grain, when many metaphorical knotty problems are knotty all the way through -- there is no surrounding straight grain to return to once you get past the hard part'
   - '[source] breaks because the carpenter''s response to a knot is avoidance where possible (cut around it, discard the board, place it where it won''t bear load), but the metaphor is typically invoked for problems that cannot be avoided and must be solved directly'
+embodied_patterns:
+  - part-whole
+  - matching
+  - force
+relation_types:
+  - cause
+  - prevent
+  - transform
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/know-the-ropes.md
+++ b/catalog/entries/know-the-ropes.md
@@ -21,6 +21,15 @@ transfers:
 limits:
   - '[source] on a ship the ropes are physically fixed in location and finite in number, whereas organizational know-how involves shifting procedures and informal norms with no stable inventory'
   - '[source] shipboard rope knowledge can be taught by walking a novice through every line in a single tour, implying a bounded learning curve that most institutional knowledge does not have'
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/know-your-enemy-know-yourself.md
+++ b/catalog/entries/know-your-enemy-know-yourself.md
@@ -21,6 +21,15 @@ transfers:
 limits:
   - '[model] assumes a bilateral adversarial structure with a discrete "enemy" whose capabilities can be assessed, and breaks in multi-agent environments where the competitive landscape is diffuse, shifting, and partially cooperative'
   - '[model] implies that sufficient knowledge produces certainty of outcome ("need not fear"), while in practice both self-assessment and adversary-assessment are probabilistic and subject to deception, self-deception, and rapid change'
+embodied_patterns:
+  - force
+  - path
+  - center-periphery
+relation_types:
+  - cause
+  - compete
+structure: competition
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/knowing-is-seeing.md
+++ b/catalog/entries/knowing-is-seeing.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - '[source] vision is passive and instantaneous (you see or you don''t), obscuring forms of knowing that require active construction, effort, and time'
   - '[source] seeing implies a single correct perspective from a fixed viewpoint, hiding that understanding often requires integrating multiple contradictory frameworks'
+embodied_patterns:
+  - near-far
+  - surface-depth
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: boundary
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/knowing-when-not-to-operate.md
+++ b/catalog/entries/knowing-when-not-to-operate.md
@@ -27,6 +27,15 @@ limits:
   - '[source] The aphorism assumes the decision-maker has full competence to act and is choosing restraint, but it is frequently invoked to dignify inaction that stems from indecision, risk aversion, or lack of skill rather than expert judgment'
   - '[source] In surgery, not operating has a clear meaning -- the patient is not cut open -- but in domains like management or policy, "not acting" is ambiguous because there are many possible actions and declining one does not foreclose others, making the surgical binary misleading'
   - '[source] The aphorism privileges the individual expert''s judgment as the mechanism of restraint, but in medicine the best protection against unnecessary surgery is systemic (second opinions, tumor boards, evidence-based guidelines), and the metaphor''s emphasis on individual wisdom obscures the need for institutional checks'
+embodied_patterns:
+  - matching
+  - surface-depth
+  - balance
+relation_types:
+  - compete
+  - select
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/knowledge-of-past-events-is-an-external-event-exerting-force-on.md
+++ b/catalog/entries/knowledge-of-past-events-is-an-external-event-exerting-force-on.md
@@ -27,6 +27,16 @@ transfers:
 limits:
   - '[source] physical forces act instantaneously on contact, but knowledge of past events often produces delayed or accumulating emotional effects that build over time'
   - '[source] a physical force has a single vector and magnitude, while the impact of learning about past events can simultaneously push in contradictory emotional directions (relief and grief at once)'
+embodied_patterns:
+  - force
+  - scale
+  - balance
+relation_types:
+  - cause
+  - transform
+  - contain
+structure: equilibrium
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/koan.md
+++ b/catalog/entries/koan.md
@@ -22,6 +22,15 @@ transfers:
 limits:
   - "[source] breaks because a Zen koan operates within a structured teacher-student relationship with years of practice, while calling a business problem 'a koan' strips away the contemplative discipline that makes the paradox productive"
   - "[source] misleads because koans have recognized responses validated by a lineage of masters, while the metaphorical use implies that any sufficiently puzzling question is a koan, erasing the distinction between genuine paradox and mere confusion"
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - prevent
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/labor-is-a-resource.md
+++ b/catalog/entries/labor-is-a-resource.md
@@ -27,6 +27,16 @@ transfers:
 limits:
   - '[source] resources do not improve through being used (coal does not become better coal by burning), whereas labor skill typically increases with practice, inverting the depletion assumption'
   - '[source] resources are passive and have no preferences about their allocation, obscuring that workers have agency, morale, and context-dependent productivity'
+embodied_patterns:
+  - balance
+  - flow
+  - scale
+relation_types:
+  - cause
+  - transform
+  - compete
+structure: cycle
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/labyrinth.md
+++ b/catalog/entries/labyrinth.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - "[source] breaks because the mythological labyrinth has a single correct path and a single center, while real bureaucratic and systemic complexity typically has multiple overlapping paths, no center, and goals that shift as you navigate"
   - "[source] misleads because the metaphor implies the complexity is deliberate (someone designed this to trap you), encouraging paranoia about intentional obfuscation when most real complexity is emergent and unplanned"
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - enable
+  - accumulate
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/latticework-of-mental-models.md
+++ b/catalog/entries/latticework-of-mental-models.md
@@ -21,6 +21,15 @@ transfers:
 - '[model] reframes learning as structural engineering where individual models are useless alone but woven together become load-bearing, with the connections between models doing the real explanatory work'
 - '[model] predicts that a well-organized set of models makes ignorance legible -- gaps in coverage are visible, unlike a disorganized collection that hides its blind spots'
 updated: '2026-03-13'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/laughter-is-a-substance.md
+++ b/catalog/entries/laughter-is-a-substance.md
@@ -25,6 +25,16 @@ transfers:
 limits:
   - '[source] a physical substance persists after release and must be cleaned up, while laughter dissipates immediately and leaves no residue to manage'
   - '[source] substances have consistent properties regardless of context, but laughter''s quality (joyful, nervous, cruel) depends entirely on social and emotional circumstances'
+embodied_patterns:
+  - flow
+  - path
+  - blockage
+relation_types:
+  - cause
+  - prevent
+  - contain
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/lava-flow.md
+++ b/catalog/entries/lava-flow.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - '[source] lava flows are natural and directionless -- they have no author or intent -- whereas legacy code was written by people making deliberate (if now-forgotten) design choices'
   - '[source] geological lava is chemically homogeneous within a single flow, while legacy code layers may use entirely different languages, frameworks, and paradigms'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - prevent
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/laying-pipe.md
+++ b/catalog/entries/laying-pipe.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - '[source] breaks because plumbing is a closed system with predictable flow, while audience cognition is open and unpredictable -- viewers may not retain the exposition, may misinterpret it, or may arrive with prior knowledge that makes the pipe redundant'
   - '[source] misleads by framing exposition as infrastructure that should be invisible, encouraging writers to hide necessary information so thoroughly that audiences miss it entirely, producing confusion rather than the intended seamless experience'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/lces.md
+++ b/catalog/entries/lces.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - '[model] breaks because fire behavior is governed by physical laws (wind, slope, fuel) that make prediction tractable within hours, while organizational and software threats involve adversarial or emergent dynamics where the equivalent of "where is the fire going" has no reliable answer'
   - '[model] misleads when teams treat the four components as a checklist to be satisfied once at the start, rather than continuously maintained -- a safety zone that was adequate when conditions were assessed may become untenable as the situation evolves, and the model''s acronym format encourages static rather than dynamic evaluation'
+embodied_patterns:
+  - matching
+  - path
+  - boundary
+relation_types:
+  - prevent
+  - decompose
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/leeway.md
+++ b/catalog/entries/leeway.md
@@ -20,6 +20,15 @@ transfers:
 - '[source] leeway is consumed passively by wind pushing the ship sideways whether the crew acts or not, mapping onto margins that shrink through the mere passage of events rather than through mistakes'
 - '[source] drift is always in one direction -- toward the hazard -- mapping onto situations where the default trajectory leads toward failure without active corrective effort'
 updated: '2026-03-14'
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/less-is-more.md
+++ b/catalog/entries/less-is-more.md
@@ -25,6 +25,16 @@ limits:
   - '[source] breaks because the principle provides no criterion for what to remove versus what to keep: "less" of what? Mies kept steel and glass and removed ornament, but that choice reflects his aesthetic values, not a universal rule derivable from the principle itself'
   - '[source] misleads by implying that complexity is always a defect, when many domains require irreducible complexity -- a tax code cannot be minimalist without becoming unjust, and a programming language cannot be minimal without becoming inexpressive'
   - '[source] hides the survivorship bias in its own evidence: we see the successful minimalist designs (iPhone, Mies''s Farnsworth House) and not the many stripped-down designs that failed because they removed something essential, so the principle appears more reliable than it is'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+  - compete
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/let-justice-be-done-though-the-heavens-fall.md
+++ b/catalog/entries/let-justice-be-done-though-the-heavens-fall.md
@@ -22,6 +22,15 @@ transfers:
 limits:
   - "[paradigm] breaks because the maxim presupposes agreement on what justice requires, when in practice the content of justice is the primary dispute -- the heavens-falling framing short-circuits the deliberation that justice demands"
   - "[paradigm] misleads because it presents deontological commitment as costless to the speaker while the consequences fall on others, creating a structural asymmetry where the person invoking the principle bears none of the burden of the falling heavens"
+embodied_patterns:
+  - force
+  - scale
+  - path
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/let-the-buyer-beware.md
+++ b/catalog/entries/let-the-buyer-beware.md
@@ -20,6 +20,15 @@ limits:
   - "[model] assumes buyers have the capacity and access to evaluate what they're acquiring, which fails for complex or opaque goods"
   - "[model] treats all transactions as arm's-length exchanges between equals, ignoring power asymmetries"
   - "[model] provides moral cover for fraud by shifting blame from the deceiver to the deceived"
+embodied_patterns:
+  - balance
+  - flow
+  - scale
+relation_types:
+  - cause
+  - transform
+structure: cycle
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/let-the-master-answer.md
+++ b/catalog/entries/let-the-master-answer.md
@@ -24,6 +24,16 @@ transfers:
   - "[paradigm] generates the institutional design principle that risk should be allocated to the party best positioned to prevent, insure against, or absorb it -- which is typically the party with hierarchical authority"
   - "[paradigm] provides the conceptual foundation for holding organizations rather than individuals accountable, enabling the entire vocabulary of corporate liability, command responsibility, and institutional negligence"
 updated: '2026-03-16'
+embodied_patterns:
+  - boundary
+  - force
+  - balance
+relation_types:
+  - cause
+  - prevent
+  - enable
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/let-the-tool-do-the-work.md
+++ b/catalog/entries/let-the-tool-do-the-work.md
@@ -22,6 +22,15 @@ transfers:
 - '[model] the diagnostic is embodied: muscular strain in the operator is the error signal, not the outcome, allowing real-time detection of misuse before the work is ruined, a feedback structure that transfers to software (fighting the framework), writing (forcing a sentence), and management (micromanaging a capable team)'
 - '[model] carries the prediction that increasing operator force will degrade rather than improve results -- a forced plane chatters and tears grain, a forced framework produces brittle workarounds -- because the tool''s design encodes constraints that force violates'
 updated: '2026-03-21'
+embodied_patterns:
+  - part-whole
+  - matching
+  - force
+relation_types:
+  - cause
+  - transform
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/lethal-trifecta.md
+++ b/catalog/entries/lethal-trifecta.md
@@ -24,6 +24,15 @@ transfers:
   - "[paradigm] imports the subtraction principle -- eliminate any one of the three elements and the agent cannot be exploited for data exfiltration -- giving security engineers a concrete design checklist"
   - "[paradigm] carries the fire triangle's insight that each condition is individually safe, reframing the security conversation from 'is this agent dangerous?' to 'which combination of capabilities does it have?'"
 updated: '2026-03-18'
+embodied_patterns:
+  - matching
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/letter-vs-spirit-of-the-law.md
+++ b/catalog/entries/letter-vs-spirit-of-the-law.md
@@ -23,6 +23,16 @@ transfers:
 limits:
   - "[source] breaks because natural language ambiguity is a feature of communication (enabling nuance, politeness, flexibility), while legal ambiguity is a defect that creates exploitable gaps -- the metaphor treats a linguistic property as though it maps cleanly onto an institutional problem"
   - "[source] misleads because in language the 'spirit' is anchored to a specific speaker's intention, while in law the 'spirit' is often a post-hoc reconstruction by interpreters who may disagree about what the legislators intended or whether original intent even matters"
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - compete
+  - translate
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/leverage.md
+++ b/catalog/entries/leverage.md
@@ -21,6 +21,15 @@ transfers:
   ratio'
 - '[model] predicts that amplification is symmetric -- leverage magnifies both gains and losses -- making it the critical structural feature that distinguishes leverage from a free lunch'
 updated: '2026-03-13'
+embodied_patterns:
+  - force
+  - scale
+  - balance
+relation_types:
+  - cause
+  - transform
+structure: equilibrium
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/life-is-a-container.md
+++ b/catalog/entries/life-is-a-container.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] containers are rigid and their capacity is fixed at construction, but a human life''s capacity for experience, relationships, and meaning can expand or contract over time'
   - '[source] container contents don''t interact with each other (marbles in a jar stay separate), whereas life experiences transform each other through memory, reinterpretation, and emotional resonance'
+embodied_patterns:
+  - container
+  - boundary
+  - flow
+relation_types:
+  - cause
+  - transform
+structure: boundary
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/life-is-a-gambling-game.md
+++ b/catalog/entries/life-is-a-gambling-game.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] gambling games have explicit odds that can be calculated, while most life decisions involve Knightian uncertainty where the probability distribution itself is unknown'
   - '[source] a gambling loss is cleanly quantified (you lose your stake), whereas life setbacks often have cascading, qualitative consequences that resist measurement'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/life-is-a-journey.md
+++ b/catalog/entries/life-is-a-journey.md
@@ -28,6 +28,15 @@ limits:
   - "[source] breaks because journeys have fixed destinations, but many lives lack a single overarching purpose"
   - "[source] misleads because backward travel is always regression on a journey, hiding the value of return and revisitation"
   - "[source] obscures depth by equating progress with distance covered, leaving no vocabulary for the value of staying put"
+embodied_patterns:
+  - path
+  - near-far
+  - force
+relation_types:
+  - prevent
+  - select
+structure: pipeline
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/life-is-a-performance.md
+++ b/catalog/entries/life-is-a-performance.md
@@ -27,6 +27,15 @@ limits:
   - "[source] breaks because performances end and the actor goes home, but in life there is no offstage self to return to"
   - "[source] misleads because theater has a script written in advance, implying life events are predetermined"
   - "[source] obscures genuine feeling by framing all emotional expression as performance for an audience"
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - enable
+  - translate
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/life-is-a-story.md
+++ b/catalog/entries/life-is-a-story.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] stories are composed after the fact with the ending known, imposing retrospective coherence that was not available to the protagonist living forward in time'
   - '[source] stories require a narrator who selects what to include, but life as lived has no editor -- every moment is equally present and unedited until memory and retelling impose selection'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - accumulate
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/light-is-a-fluid.md
+++ b/catalog/entries/light-is-a-fluid.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] fluid is subject to gravity and always flows downward, whereas light propagates in straight lines regardless of gravitational direction under everyday conditions'
   - '[source] fluid mixes when two streams converge (changing both), but light beams cross without interacting, preserving their independent properties'
+embodied_patterns:
+  - flow
+  - path
+  - blockage
+relation_types:
+  - cause
+  - transform
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/light-is-a-line.md
+++ b/catalog/entries/light-is-a-line.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] lines have no thickness and extend infinitely, but real light beams diverge, scatter, and attenuate with distance'
   - '[source] lines cannot bend around obstacles, but light diffracts around edges and refracts through media, behaviors that require wave models rather than ray geometry'
+embodied_patterns:
+  - matching
+  - container
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/light-on-two-sides.md
+++ b/catalog/entries/light-on-two-sides.md
@@ -25,6 +25,16 @@ transfers:
 limits:
   - '[source] architectural cross-lighting works because light is additive (two sources always produce more light), but in information design, two perspectives can produce confusion rather than clarity if they contradict'
   - '[source] the pattern assumes both light sources are desirable, but in architecture unwanted glare from a second source can be worse than controlled single-sided illumination'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - prevent
+  - compete
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/lightning-rod-joke.md
+++ b/catalog/entries/lightning-rod-joke.md
@@ -27,6 +27,15 @@ transfers:
   - '[source] The decoy works because reviewers operate under a cognitive budget -- having found and excised one objectionable element, they feel their job is done and scrutinize the remainder less carefully'
   - '[source] The sacrificial element must be plausibly intended (not obviously fake) so the reviewer experiences genuine discovery rather than suspecting manipulation'
 updated: '2026-03-21'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/linear-scales-are-paths.md
+++ b/catalog/entries/linear-scales-are-paths.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] paths can fork, loop back, or dead-end, but linear scales by definition have no branches or reversals, making the path metaphor over-rich for the target'
   - '[source] travel along a path takes effort proportional to distance, but moving along an abstract scale involves no physical cost -- going from 1 to 100 is no harder than going from 1 to 2'
+embodied_patterns:
+  - path
+  - near-far
+  - force
+relation_types:
+  - cause
+  - transform
+structure: pipeline
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/load-bearing-pun.md
+++ b/catalog/entries/load-bearing-pun.md
@@ -24,6 +24,15 @@ transfers:
   - '[source] imports the construction principle that some elements are decorative and some are structural, teaching comedy analysis to distinguish puns that ornament a scene from puns that hold it up'
   - '[source] carries the diagnostic implication that you cannot identify a load-bearing element by looking at it -- you must trace the forces flowing through it, just as you must trace the plot logic flowing through the pun'
 updated: '2026-03-19'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/logic-is-gravity.md
+++ b/catalog/entries/logic-is-gravity.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] gravity is a physical force with no exceptions in everyday experience, but logical compulsion can be resisted through denial, reframing premises, or questioning the formal system itself'
   - '[source] gravity operates on passive objects that have no capacity to reinterpret the force acting on them, whereas logical agents can challenge definitions, reveal hidden assumptions, or change the rules of inference'
+embodied_patterns:
+  - force
+  - scale
+  - balance
+relation_types:
+  - cause
+  - transform
+structure: equilibrium
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/logical-relations-are-causal-relations.md
+++ b/catalog/entries/logical-relations-are-causal-relations.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] causal relations are asymmetric and temporal (cause before effect), but logical entailment is timeless and symmetric in many formal systems (P entails Q does not require P to exist ''before'' Q)'
   - '[source] causes can be probabilistic and admit exceptions, but logical entailment in deductive systems is all-or-nothing with no partial causation'
+embodied_patterns:
+  - link
+  - force
+  - path
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/lollapalooza-effect.md
+++ b/catalog/entries/lollapalooza-effect.md
@@ -22,6 +22,15 @@ transfers:
 - '[model] identifies threshold effects where individual biases accumulate quietly until their convergence crosses a critical point and produces extreme behavior (cults, financial manias, institutional
   corruption)'
 updated: '2026-03-13'
+embodied_patterns:
+  - merging
+  - scale
+  - force
+relation_types:
+  - cause
+  - accumulate
+structure: emergence
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/longterm-purposeful-activity-is-a-journey.md
+++ b/catalog/entries/longterm-purposeful-activity-is-a-journey.md
@@ -30,6 +30,15 @@ transfers:
 limits:
   - '[source] a journey''s destination is fixed before departure and the traveler knows when they have arrived, but many long-term activities have goals that shift as understanding deepens'
   - '[source] a journey has a single path (or small set of routes) between origin and destination, while complex activities often require parallel workstreams with no clear sequential ordering'
+embodied_patterns:
+  - path
+  - near-far
+  - force
+relation_types:
+  - cause
+  - transform
+structure: pipeline
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/longterm-purposeful-change-is-a-journey.md
+++ b/catalog/entries/longterm-purposeful-change-is-a-journey.md
@@ -30,6 +30,15 @@ transfers:
 limits:
   - '[source] a journey''s endpoint exists independently of the traveler and can be visited before committing to the trip, but the endpoint of purposeful change often does not exist until the change process creates it'
   - '[source] reversing a journey means retracing the same path, but reversing a change process rarely restores the original state because the act of changing alters the substrate'
+embodied_patterns:
+  - path
+  - near-far
+  - force
+relation_types:
+  - cause
+  - transform
+structure: pipeline
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/loose-cannon.md
+++ b/catalog/entries/loose-cannon.md
@@ -21,6 +21,15 @@ transfers:
 limits:
   - '[source] a loose cannon is an inanimate object with no intent or capacity to learn, while the people described as loose cannons have agency and can potentially be brought under discipline'
   - '[source] the solution on ship was to re-lash or jettison the cannon, but organizations cannot simply tie down or discard a person without ethical and legal constraints'
+embodied_patterns:
+  - force
+  - self-organization
+  - container
+relation_types:
+  - cause
+  - prevent
+structure: competition
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/love-is-a-collaborative-work-of-art.md
+++ b/catalog/entries/love-is-a-collaborative-work-of-art.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] artworks can be abandoned and started over with a blank canvas, but relationships accumulate shared history, children, and entanglements that cannot be erased and restarted'
   - '[source] collaborative art produces a separable artifact that exists independently of its creators, but a love relationship has no product apart from the ongoing experience of the participants'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/love-is-a-journey.md
+++ b/catalog/entries/love-is-a-journey.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - '[source] a journey has a destination that exists before the travelers set out, but relationships often have no predetermined endpoint and the ''destination'' is constructed retrospectively'
   - '[source] journey progress is monotonic in space (you are always somewhere along the route), but relationship progress can genuinely reverse, regress, or cycle without spatial analogue'
+embodied_patterns:
+  - path
+  - near-far
+  - force
+relation_types:
+  - cause
+  - transform
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/love-is-a-patient.md
+++ b/catalog/entries/love-is-a-patient.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] a patient is a single organism with objective vital signs that indicate health, but a relationship involves two subjects whose assessments of the relationship''s health may contradict'
   - '[source] medical treatment follows established protocols with known efficacy rates, but relationship repair has no equivalent evidence base or standardized procedures'
+embodied_patterns:
+  - matching
+  - surface-depth
+  - balance
+relation_types:
+  - cause
+  - transform
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/love-is-a-physical-force.md
+++ b/catalog/entries/love-is-a-physical-force.md
@@ -28,6 +28,15 @@ transfers:
 limits:
   - '[source] physical forces operate identically on identical masses regardless of history, but romantic attraction is shaped by personal history, memory, and narrative in ways that make each instance unique'
   - '[source] forces diminish predictably with distance (inverse square law), but romantic attachment can intensify with absence and distance rather than weakening'
+embodied_patterns:
+  - force
+  - near-far
+  - attraction
+relation_types:
+  - cause
+  - transform
+structure: competition
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/love-is-a-unity.md
+++ b/catalog/entries/love-is-a-unity.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] physical unity (welding, chemical bonding) produces a homogeneous result where the original components lose their distinct identity, but healthy relationships require partners to maintain individual selfhood'
   - '[source] the unity metaphor implies symmetry -- both halves contribute equally to the whole -- obscuring power imbalances and asymmetric emotional investment that characterize real relationships'
+embodied_patterns:
+  - force
+  - scale
+  - path
+relation_types:
+  - transform
+  - contain
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/love-is-madness.md
+++ b/catalog/entries/love-is-madness.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] madness is classified as pathological and requiring treatment, but framing love as illness pathologizes a normal human experience and implies it should be cured'
   - '[source] madness in clinical terms involves deteriorating function over time, whereas love typically enhances well-being and social functioning even when it disrupts routine'
+embodied_patterns:
+  - force
+  - container
+  - boundary
+relation_types:
+  - transform
+  - cause
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/love-is-magic.md
+++ b/catalog/entries/love-is-magic.md
@@ -27,6 +27,15 @@ transfers:
 limits:
   - '[source] magic spells can be broken by a counter-spell or specific action (kiss, true name), but real romantic attachment has no reliable method of deliberate dissolution'
   - '[source] magic implies a single moment of enchantment that causes the entire effect, obscuring that love develops through accumulated interaction rather than a discrete casting event'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/love-is-war.md
+++ b/catalog/entries/love-is-war.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] war is inherently adversarial with each side''s gain being the other''s loss, but love at its best is cooperative with both parties benefiting simultaneously'
   - '[source] war ends with victory, surrender, or annihilation, providing no model for the ongoing mutual maintenance that sustains long-term love'
+embodied_patterns:
+  - force
+  - boundary
+  - balance
+relation_types:
+  - compete
+  - cause
+structure: competition
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/loved-one-is-a-possession.md
+++ b/catalog/entries/loved-one-is-a-possession.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] possessions have no agency or preferences about who owns them, but loved ones are autonomous agents who choose to be in the relationship'
   - '[source] possession is a legal status with clear transfer mechanisms (sale, gift, inheritance), but love relationships cannot be transacted or transferred to a third party'
+embodied_patterns:
+  - balance
+  - flow
+  - scale
+relation_types:
+  - cause
+  - transform
+structure: cycle
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/lust-is-heat.md
+++ b/catalog/entries/lust-is-heat.md
@@ -27,6 +27,15 @@ transfers:
 limits:
   - '[source] heat is a scalar quantity with no direction -- it simply intensifies or diminishes -- but lust is directed at a specific object, and redirecting it is not like redirecting thermal energy'
   - '[source] heat transfer follows thermodynamic laws and always flows from hot to cold, but sexual desire does not reliably transfer from a desiring person to the object of desire'
+embodied_patterns:
+  - force
+  - scale
+  - path
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/lustful-person-is-an-activated-machine.md
+++ b/catalog/entries/lustful-person-is-an-activated-machine.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] machines can be turned off instantly with a switch, but human arousal does not have a binary off-switch and involves complex physiological and psychological deactivation'
   - '[source] machines are designed for a purpose and operate correctly when activated, but framing lust as machine activation implies it is the person''s intended function, eliding moral agency'
+embodied_patterns:
+  - flow
+  - matching
+  - iteration
+relation_types:
+  - cause
+  - transform
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/lustful-person-is-an-animal.md
+++ b/catalog/entries/lustful-person-is-an-animal.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] animals'' behavior is species-typical and predictable within narrow ethological parameters, but human sexual behavior varies enormously across individuals and cultures in ways animal models cannot capture'
   - '[source] the metaphor positions animality as purely negative (loss of control), ignoring that animal behavior includes pair-bonding, courtship rituals, and mate selection -- forms of discriminating choice'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/machines-are-people.md
+++ b/catalog/entries/machines-are-people.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - '[source] people have genuine internal states that cause their behavior, but machines'' apparent ''moods'' are projections with no subjective experience behind them'
   - '[source] social strategies work on people because they respond to social cues, but machines respond only to physical inputs -- talking nicely to a jammed printer changes nothing mechanically'
+embodied_patterns:
+  - link
+  - center-periphery
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: network
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/magic-number.md
+++ b/catalog/entries/magic-number.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] magic numbers in code can always be replaced by named constants that dispel the mystery, but true magic in the source domain is inherently irreducible to rational explanation'
   - '[source] magical formulas are intentionally secret to preserve the magician''s power, whereas magic numbers in code are accidentally obscure due to poor documentation rather than deliberate concealment'
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/main-entrance.md
+++ b/catalog/entries/main-entrance.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - '[source] a building''s main entrance is spatially fixed and cannot be moved without major renovation, but a software entry point can be refactored, redirected, or multiplied at low cost'
   - '[source] physical entrances are visible to anyone approaching the building, but software entry points may be documented or undocumented, discoverable or hidden, with no spatial analogue to architectural visibility'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/main-gateways.md
+++ b/catalog/entries/main-gateways.md
@@ -25,6 +25,15 @@ transfers:
 - '[source] imports the architectural insight that a gateway is a transition zone, not a line -- a physical threshold with depth (a porch, a courtyard, a vestibule) that gives the arriving person time to shift context from outside to inside'
 - '[source] carries the principle that the gateway''s design communicates the character of what lies beyond, so that arrivals can calibrate their expectations before committing to enter'
 updated: '2026-03-21'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/mainstay.md
+++ b/catalog/entries/mainstay.md
@@ -23,6 +23,15 @@ transfers:
   removal'
 - '[source] the mainstay ran from masthead to bow as a tension member holding two parts in correct relationship, mapping the bridging function onto elements that connect what would otherwise drift apart'
 updated: '2026-03-14'
+embodied_patterns:
+  - center-periphery
+  - force
+  - part-whole
+relation_types:
+  - enable
+  - coordinate
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/make-hay-while-the-sun-shines.md
+++ b/catalog/entries/make-hay-while-the-sun-shines.md
@@ -26,6 +26,15 @@ transfers:
 - '[source] imports the asymmetry between preparation time and opportunity time: hay-making requires days of prior work (mowing, tedding) but the drying window may last only hours, teaching that the visible opportunity is the smallest part of the process'
 - '[source] carries the irreversibility of failure -- rained-on hay rots rather than drying later -- framing missed opportunities as permanently spoiled rather than merely delayed'
 updated: '2026-03-20'
+embodied_patterns:
+  - accretion
+  - path
+  - balance
+relation_types:
+  - cause
+  - transform
+structure: cycle
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/making-first-moves.md
+++ b/catalog/entries/making-first-moves.md
@@ -23,6 +23,16 @@ transfers:
 limits:
   - '[model] assumes a kitchen-like dependency structure where the critical path is known in advance, and breaks in exploratory work where you cannot identify which task will unblock others until you have started'
   - '[model] can justify premature commitment -- starting process work before requirements are clear -- which produces rework that costs more than the idle time it was meant to prevent'
+embodied_patterns:
+  - flow
+  - matching
+  - path
+relation_types:
+  - cause
+  - prevent
+  - accumulate
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/man-with-a-hammer.md
+++ b/catalog/entries/man-with-a-hammer.md
@@ -22,6 +22,15 @@ transfers:
 - '[model] predicts that a single analytical framework shapes perception, not just action -- the model you carry determines what you perceive as relevant, causing you to force every problem into its shape'
 - '[model] functions as the meta-model that motivates the latticework: it is self-referential by design, explaining why you need many models by showing what happens when you have only one'
 updated: '2026-03-13'
+embodied_patterns:
+  - force
+  - matching
+  - path
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/manure-is-the-farmers-gold.md
+++ b/catalog/entries/manure-is-the-farmers-gold.md
@@ -25,6 +25,16 @@ limits:
   - '[source] breaks because manure genuinely is valuable in agriculture (it contains nitrogen, phosphorus, and potassium), whereas many metaphorical applications use "hidden gold" rhetoric to romanticize suffering or dysfunction that has no actual redemptive content'
   - '[source] misleads by implying that all unpleasant things conceal value if you look hard enough, which is a form of toxic positivity -- some waste is genuinely waste, and the proverb provides no test for distinguishing productive unpleasantness from pure cost'
   - '[source] imports the assumption that the farmer who recognizes the value is the same person who produced the waste, when most metaphorical applications involve one party bearing the unpleasantness and another party extracting the value'
+embodied_patterns:
+  - accretion
+  - path
+  - balance
+relation_types:
+  - cause
+  - transform
+  - accumulate
+structure: cycle
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/map-territory-problem.md
+++ b/catalog/entries/map-territory-problem.md
@@ -25,6 +25,15 @@ transfers:
 - '[source] imports the spatial intuition that a map must be smaller than its territory to be portable, framing compression as a feature rather than a defect -- every useful model must discard information, and the question is which information'
 - '[source] carries the image of cartographers laboring to extend the map until it obscures the empire it was meant to serve, mapping onto the organizational pattern where documentation, metrics, or process frameworks grow until they consume the capacity they were meant to measure'
 updated: '2026-03-19'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/margin-of-safety.md
+++ b/catalog/entries/margin-of-safety.md
@@ -21,6 +21,15 @@ transfers:
 - '[model] maps structural over-engineering (bridges designed for several times expected load) onto epistemic humility -- the gap between what you think you know and what you are willing to bet on'
 - '[model] applies specifically to situations where failure is catastrophic and irreversible, making it an engineering response to tail risk rather than a general-purpose heuristic'
 updated: '2026-03-13'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/master-and-apprentices.md
+++ b/catalog/entries/master-and-apprentices.md
@@ -21,6 +21,15 @@ transfers:
 limits:
   - '[source] assumes the master''s practice is worth replicating, but in rapidly changing fields (software, biotech) the master''s methods may be obsolete before the apprenticeship completes, making proximity to current practice more valuable than proximity to an experienced practitioner'
   - '[source] imports a hierarchical model of knowledge (master knows, apprentice does not) that breaks in domains where innovation comes from newcomers who have not yet internalized the master''s assumptions and constraints'
+embodied_patterns:
+  - link
+  - path
+  - center-periphery
+relation_types:
+  - enable
+  - transform
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/mathematician-is-a-machine-for-turning-coffee-into-theorems.md
+++ b/catalog/entries/mathematician-is-a-machine-for-turning-coffee-into-theorems.md
@@ -22,6 +22,15 @@ transfers:
 limits:
   - '[source] breaks because machines do not choose which raw materials to process, but mathematicians choose which problems to work on -- the selection is the hardest part'
   - '[source] misleads by implying a single input (coffee) maps to a single output (theorems), hiding the years of failed attempts, dead ends, and discarded approaches that produce nothing'
+embodied_patterns:
+  - flow
+  - matching
+  - iteration
+relation_types:
+  - cause
+  - transform
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/mayday.md
+++ b/catalog/entries/mayday.md
@@ -22,6 +22,15 @@ transfers:
 limits:
   - '[model] breaks when the signal is invoked too frequently or for non-critical situations, because the unconditional-response guarantee depends on rarity -- a system where mayday is called weekly trains responders to triage rather than drop everything, destroying the signal''s special status'
   - '[model] assumes a single authority that can redirect all resources, but in distributed systems (open-source projects, federated organizations, multi-team incidents) there is no single dispatcher who can enforce unconditional priority, so the signal degrades into one competing claim among many'
+embodied_patterns:
+  - matching
+  - path
+  - boundary
+relation_types:
+  - cause
+  - compete
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/means-of-change-is-path-over-which-motion-occurs.md
+++ b/catalog/entries/means-of-change-is-path-over-which-motion-occurs.md
@@ -27,6 +27,15 @@ transfers:
 limits:
   - '[source] paths pre-exist the traveler and can be surveyed before the journey begins, but the means of change often creates itself as the change unfolds, with no pre-existing route to inspect'
   - '[source] a path is used by multiple travelers who all traverse the same terrain, but means of change are often unique to the changing entity and non-replicable'
+embodied_patterns:
+  - path
+  - near-far
+  - force
+relation_types:
+  - cause
+  - transform
+structure: pipeline
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/measure-twice-cut-once.md
+++ b/catalog/entries/measure-twice-cut-once.md
@@ -23,6 +23,15 @@ transfers:
 - '[model] identifies asymmetric reversibility as the key variable: when undoing is impossible or orders of magnitude more expensive than doing, frontloading verification dominates all other strategies'
 - '[model] encodes the counterintuitive insight that slowing down at the verification stage produces faster overall throughput, because rework from errors consumes more time than the verification would have'
 updated: '2026-03-21'
+embodied_patterns:
+  - part-whole
+  - matching
+  - force
+relation_types:
+  - cause
+  - transform
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/meeze-point.md
+++ b/catalog/entries/meeze-point.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[model] assumes that concurrent tasks are roughly equal in cognitive load, but in practice one complex task can consume more capacity than five simple ones, so a single number overfits the heterogeneity of real workloads'
   - '[model] the meeze point is presented as a personal constant, but it varies with fatigue, stress, domain expertise, and environmental factors -- treating it as fixed risks either underloading on good days or excusing poor performance by citing a number'
+embodied_patterns:
+  - flow
+  - matching
+  - path
+relation_types:
+  - transform
+  - contain
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/memory-heap.md
+++ b/catalog/entries/memory-heap.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - "[source] breaks because a physical heap has no bookkeeping -- items are simply piled -- whereas the mapped system requires elaborate metadata structures (free lists, size headers) that have no analog in a pile of objects"
   - "[source] misleads because a physical heap implies negligible cost to toss something on top, but the mapped operation involves searching for a suitable gap, which can be expensive and unpredictable"
+embodied_patterns:
+  - force
+  - scale
+  - path
+relation_types:
+  - cause
+  - accumulate
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/memory-leak.md
+++ b/catalog/entries/memory-leak.md
@@ -27,6 +27,15 @@ transfers:
 limits:
   - "[source] breaks because leaked fluid leaves the system entirely, whereas the mapped resource remains physically present but becomes unreachable -- nothing actually escapes the machine"
   - "[source] misleads because a physical leak can be found by following the trail of escaped fluid, but the mapped defect leaves no visible trace at the point of loss"
+embodied_patterns:
+  - flow
+  - path
+  - blockage
+relation_types:
+  - cause
+  - contain
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/memory-stack.md
+++ b/catalog/entries/memory-stack.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] a stack maintains perfect ordering and every item remains intact until explicitly popped, but human memory degrades, merges, and reorders items over time'
   - '[source] stacks have a fixed capacity (stack overflow), but human memory does not fail by mechanical overflow -- forgetting is reconstructive and selective, not a capacity limit'
+embodied_patterns:
+  - force
+  - scale
+  - path
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/mental-accounting.md
+++ b/catalog/entries/mental-accounting.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] formal accounting is governed by consistent rules applied across all accounts (GAAP, double-entry), but mental accounting rules are inconsistent, context-dependent, and violate the fungibility principle that formal accounting enforces'
   - '[source] accounting ledgers are cumulative and never forget a transaction, but mental accounts are selectively maintained -- people abandon losing mental accounts to avoid confronting sunk costs'
+embodied_patterns:
+  - balance
+  - flow
+  - scale
+relation_types:
+  - cause
+  - transform
+structure: cycle
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/mental-health-is-physical-health.md
+++ b/catalog/entries/mental-health-is-physical-health.md
@@ -26,6 +26,15 @@ transfers:
 - "[source] diagnosis identifies the specific malfunction so that targeted treatment can restore normal function"
 - "[source] symptoms are observable indicators of an underlying condition that may not be directly visible"
 updated: '2026-03-16'
+embodied_patterns:
+  - matching
+  - surface-depth
+  - balance
+relation_types:
+  - cause
+  - transform
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/mentat-is-human-computer.md
+++ b/catalog/entries/mentat-is-human-computer.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - "[source] breaks because real human cognition excels at pattern recognition, narrative, and approximate reasoning but is reliably poor at the exact numerical computation and data retrieval that defines the Mentat's role"
   - "[source] misleads because the Mentat's computational ability is presented as a trained skill any human could acquire, while cognitive science shows that working memory and processing speed have hard biological limits that training cannot overcome"
+embodied_patterns:
+  - container
+  - boundary
+  - force
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/mentor.md
+++ b/catalog/entries/mentor.md
@@ -24,6 +24,15 @@ limits:
   - "[source] misleads because the mythological mentorship is temporary and crisis-driven (Odysseus is away at war), while modern mentorship is often framed as an ongoing developmental relationship"
   - "[source] obscures because the actual Mentor (the human, not Athena in disguise) is ineffective -- the suitors overrun the household on his watch -- meaning the word derives from the divine impersonation, not from the human's competence"
 updated: '2026-03-16'
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/metaverse-is-shared-virtual-world.md
+++ b/catalog/entries/metaverse-is-shared-virtual-world.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - "[source] breaks because the fictional metaverse operates on a single unified platform with universal access, while real virtual worlds are fragmented across incompatible proprietary systems with no shared protocol"
   - "[source] misleads because the metaverse assumes spatial metaphors are the natural interface for all digital interaction, when most valuable online activity (search, messaging, transactions) works better without spatial constraints"
+embodied_patterns:
+  - container
+  - boundary
+  - force
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/midas-touch.md
+++ b/catalog/entries/midas-touch.md
@@ -23,6 +23,15 @@ transfers:
   - "[source] imports the myth's deeper warning that optimizing everything for a single metric (gold) destroys the things that cannot survive that optimization (food, human contact, love)"
   - "[source] carries a dual structure -- admiration for the power and warning about its consequences -- that makes it uniquely useful for discussing the costs of single-minded optimization"
 updated: '2026-03-16'
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/middle-out-compression.md
+++ b/catalog/entries/middle-out-compression.md
@@ -25,6 +25,15 @@ limits:
   - "[source] misleads because the source domain's social charge is contagious in a way most source domains are not -- invoking 'middle-out' inescapably invokes the scene, making the metaphor unusable in contexts where the source domain cannot be acknowledged"
   - "[source] obscures that the scene's comedy depends on engineers not noticing the source domain, but real-world citation always notices it -- the metaphor cannot actually achieve the unselfconsciousness it dramatizes"
 updated: '2026-03-16'
+embodied_patterns:
+  - center-periphery
+  - scale
+  - matching
+relation_types:
+  - transform
+  - coordinate
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/mirror-role-of-mother.md
+++ b/catalog/entries/mirror-role-of-mother.md
@@ -26,6 +26,15 @@ limits:
   - '[source] a mirror reflects instantly and without interpretation, but human mirroring necessarily involves delay, selection, and the caregiver''s own subjective processing -- the metaphor''s implication of transparent passivity obscures the active interpretive work that good mirroring requires'
   - '[source] a mirror produces a laterally inverted image, which has no psychological parallel and can mislead if taken literally -- the caregiver does not return the infant''s experience backwards but transforms and contains it'
   - '[source] mirrors reflect surfaces only, but Winnicott''s mirroring claims to reflect the infant''s internal state, which requires empathic inference rather than optical passivity -- the metaphor''s perceptual simplicity conceals the cognitive complexity of what it describes'
+embodied_patterns:
+  - matching
+  - link
+  - container
+relation_types:
+  - translate
+  - enable
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/mise-en-place.md
+++ b/catalog/entries/mise-en-place.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[paradigm] assumes the menu is known before service begins, and breaks down in domains where requirements emerge during execution and cannot be fully anticipated'
   - '[paradigm] embeds the assumption of a fixed workstation, and transfers poorly to knowledge work where the "ingredients" are information scattered across tools, inboxes, and other people''s heads'
+embodied_patterns:
+  - matching
+  - path
+  - container
+relation_types:
+  - coordinate
+  - enable
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/money-is-a-liquid.md
+++ b/catalog/entries/money-is-a-liquid.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - '[source] liquid is conserved in a closed system (it doesn''t appear or disappear), but money can be created through lending and destroyed through default, violating conservation'
   - '[source] liquid always flows downhill under gravity with no choice in the matter, but money flows are directed by human decisions, regulations, and institutional structures that can push capital ''uphill'''
+embodied_patterns:
+  - flow
+  - container
+  - scale
+relation_types:
+  - cause
+  - accumulate
+structure: pipeline
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/monkey-patching.md
+++ b/catalog/entries/monkey-patching.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - '[source] monkey behavior is driven by curiosity and play with no concept of production systems or stakeholders, but monkey-patching in software is a deliberate engineering choice made with awareness of tradeoffs'
   - '[source] monkeys'' modifications to physical objects are visible and reversible (you can see a dismantled thing), but runtime patches are invisible to code inspection and may persist across sessions in non-obvious ways'
+embodied_patterns:
+  - superimposition
+  - matching
+  - force
+relation_types:
+  - transform
+  - cause
+structure: transformation
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/monoculture-risk.md
+++ b/catalog/entries/monoculture-risk.md
@@ -21,6 +21,15 @@ transfers:
 limits:
   - '[model] breaks when applied to domains where the "organisms" are not identical -- a team of specialists using the same programming language is not a monoculture if they build diverse architectures, because the relevant unit of diversity is not always the most visible one'
   - '[model] misleads by importing the assumption that diversity is always net-positive, when in some domains standardization genuinely reduces risk (medical protocols, aviation checklists, building codes) because the failure mode is human error under variation, not systemic vulnerability to a single threat'
+embodied_patterns:
+  - container
+  - link
+  - balance
+relation_types:
+  - prevent
+  - cause
+structure: network
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/monoculture.md
+++ b/catalog/entries/monoculture.md
@@ -26,6 +26,15 @@ transfers:
 - '[source] imports the ecological observation that genetic uniformity eliminates the variation needed for adaptive response, framing organizational homogeneity as a pre-condition for catastrophic rather than graceful failure'
 - '[source] carries the structural insight that monocultures are locally optimal (highest yield per acre under stable conditions) but globally fragile (total crop loss under pathogen pressure), reframing efficiency-fragility tradeoffs across domains'
 updated: '2026-03-21'
+embodied_patterns:
+  - container
+  - removal
+  - scale
+relation_types:
+  - prevent
+  - accumulate
+structure: growth
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/pyrrhic-victory.md
+++ b/catalog/entries/pyrrhic-victory.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - '[source] breaks because Pyrrhus fought on foreign soil far from reinforcement, while many costly victories occur in contexts where recovery is possible given sufficient time'
   - '[source] misleads because the historical Pyrrhus recognized his predicament and chose to withdraw, while the metaphor is typically applied to actors who do not recognize the unsustainability of their approach'
+embodied_patterns:
+  - force
+  - boundary
+  - balance
+relation_types:
+  - cause
+  - transform
+structure: competition
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/quiet-backs.md
+++ b/catalog/entries/quiet-backs.md
@@ -28,6 +28,15 @@ transfers:
 - '[source] imports the spatial principle that the quiet zone must be physically adjacent to the busy zone rather than distant from it, so that the transition from activity to recovery is low-cost and frequent rather than requiring a major expedition'
 - '[source] carries the insight that the quiet back must be deliberately protected from encroachment by the busy front, because unprotected quiet spaces are colonized by overflow activity until they are indistinguishable from the main space'
 updated: '2026-03-21'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/race-condition.md
+++ b/catalog/entries/race-condition.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because races have defined start and finish lines with a clear winner, while race conditions produce corrupted state rather than ranked outcomes'
   - '[source] misleads because a race implies intentional competition, while race conditions arise from accidental temporal overlap between operations never designed to compete'
+embodied_patterns:
+  - force
+  - balance
+  - path
+relation_types:
+  - coordinate
+  - compete
+structure: competition
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/ragnarok.md
+++ b/catalog/entries/ragnarok.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - "[source] breaks because ragnarok is a singular, cosmically scheduled event rather than a recurring cycle, so applying it to iterative failures (market corrections, product pivots) imports a finality the source does not support for repetition"
   - "[source] misleads because the Norse gods know ragnarok is coming and cannot prevent it, but most real system collapses are neither foreknown nor inevitable -- the fatalism flatters inaction as tragic dignity"
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - compete
+  - select
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/ralph-wiggum-loop.md
+++ b/catalog/entries/ralph-wiggum-loop.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - "[source] breaks because Ralph's failures are random and surreal, while LLM failures tend to be systematic -- retrying the same prompt with the same context produces the same class of error"
   - "[source] misleads because convergence is guaranteed in fiction (writers engineer outcomes) but not in retry loops, which can diverge, oscillate, or waste unbounded compute"
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - prevent
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/raptor-pit.md
+++ b/catalog/entries/raptor-pit.md
@@ -23,6 +23,15 @@ transfers:
 - '[source] imports the enclosure structure: the pit is bounded, you cannot leave, and the predators are always present, transferring the trapped quality of a toxic team environment where exit is professionally costly'
 - '[source] carries the dehumanization of prey -- raptors do not evaluate what they attack, they simply attack -- framing indiscriminate hostility as the room''s defining behavior rather than an occasional lapse'
 updated: '2026-03-19'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/rational-is-up.md
+++ b/catalog/entries/rational-is-up.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] breaks because physical elevation is a continuous dimension, while the distinction between rational and irrational thinking is not a smooth gradient but a contested and context-dependent judgment'
   - '[source] misleads because the upward direction imports positive valence automatically, encoding the assumption that rational thinking is always superior rather than situationally appropriate'
+embodied_patterns:
+  - force
+  - scale
+  - path
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/receiving-serious-thought-is-being-on-the-mind.md
+++ b/catalog/entries/receiving-serious-thought-is-being-on-the-mind.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because physical objects on a surface are passive, while topics on the mind actively generate associations, emotions, and further thoughts'
   - '[source] misleads because the surface metaphor implies a single layer of attention, while cognitive processing occurs at multiple levels of consciousness simultaneously'
+embodied_patterns:
+  - force
+  - scale
+  - path
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/reciprocity.md
+++ b/catalog/entries/reciprocity.md
@@ -20,6 +20,15 @@ transfers:
 - '[model] predicts that receiving an unsolicited favor creates an obligation felt as almost physical discomfort until discharged, operating as a behavioral program beneath conscious awareness'
 - '[model] identifies bilateral symmetry: positive reciprocity (return favors) and negative reciprocity (return hostility) use the same underlying mechanism, with both debts and credits demanding settlement'
 updated: '2026-03-13'
+embodied_patterns:
+  - balance
+  - flow
+  - scale
+relation_types:
+  - cause
+  - transform
+structure: cycle
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/red-pill-is-awakening.md
+++ b/catalog/entries/red-pill-is-awakening.md
@@ -24,6 +24,15 @@ transfers:
   - "[source] imports the binary choice architecture (two pills, two outcomes, no middle ground) onto complex epistemic situations, framing knowledge as an all-or-nothing commitment rather than a graduated process"
   - "[source] carries the connotation that the truth is painful and alienating (Morpheus warns 'I can only show you the door') while the illusion is pleasant, mapping onto any situation where the speaker claims that their discomforting view is the real one"
 updated: '2026-03-17'
+embodied_patterns:
+  - container
+  - boundary
+  - force
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/red-queen-effect.md
+++ b/catalog/entries/red-queen-effect.md
@@ -19,6 +19,15 @@ transfers:
 - '[law] predicts that in co-evolutionary competition, adaptation is maintenance rather than advancement -- improving by 10% while competitors improve by 10% means standing still, not gaining ground'
 - '[law] predicts that standing still is falling behind, because competitors who continue evolving make your unchanged position relatively worse even though nothing about you has changed'
 updated: '2026-03-13'
+embodied_patterns:
+  - force
+  - matching
+  - iteration
+relation_types:
+  - cause
+  - transform
+structure: competition
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/red-tape.md
+++ b/catalog/entries/red-tape.md
@@ -22,6 +22,15 @@ transfers:
 limits:
   - "[source] breaks because the original red tape served a practical purpose (organizing and preserving legal documents for retrieval), while the metaphor treats all procedure as purposeless obstruction -- the etymological irony is that red tape was a solution to disorder, not a cause of it"
   - "[source] misleads because ribbon can be untied quickly by anyone with hands, while bureaucratic procedures often require specialized knowledge, institutional authority, or elapsed time to navigate -- physical red tape was a trivial barrier while metaphorical red tape can be insurmountable"
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/redundancy.md
+++ b/catalog/entries/redundancy.md
@@ -22,6 +22,15 @@ transfers:
 - '[model] maps engineering backup systems onto organizational resilience, where deliberately preserved slack, spare capacity, and duplication protect against the catastrophic failures that over-optimization
   invites'
 updated: '2026-03-13'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/regime-shift.md
+++ b/catalog/entries/regime-shift.md
@@ -26,6 +26,15 @@ transfers:
 - '[source] imports hysteresis -- the principle that reversing a regime shift requires far more effort than causing it, because the new state actively maintains itself through feedback loops that did not exist in the old state'
 - '[source] frames the pre-shift period as one of invisible slow-variable accumulation where the system appears stable but is actually approaching a threshold, importing the ecological distinction between the visible state variable and the hidden controlling variable'
 updated: '2026-03-19'
+embodied_patterns:
+  - link
+  - balance
+  - flow
+relation_types:
+  - cause
+  - transform
+structure: network
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/regression-to-the-mean.md
+++ b/catalog/entries/regression-to-the-mean.md
@@ -23,6 +23,15 @@ transfers:
 - '[law] reveals the illusion of effective intervention: actions taken at extreme moments (reprimands after poor performance, treatment at symptom peaks) appear to work because natural regression provides
   false confirmation'
 updated: '2026-03-13'
+embodied_patterns:
+  - balance
+  - scale
+  - iteration
+relation_types:
+  - cause
+  - transform
+structure: cycle
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/rehab.md
+++ b/catalog/entries/rehab.md
@@ -25,6 +25,15 @@ limits:
   - '[source] firefighter rehab has objective physiological indicators (heart rate, core temperature, blood pressure) that signal when rest is sufficient, but cognitive and emotional fatigue lack equivalent measurable thresholds, making it unclear when "rehab" is complete'
   - '[source] the pattern depends on a paramilitary command culture where ordered rotation is legitimate, which breaks in professional knowledge-work contexts that value autonomy and experience commanded rest as paternalistic micromanagement'
   - '[source] a firefighter rehab has defined minimum duration and clear physiological endpoints, but organizational rest interventions (sabbaticals, mental health days) lack equivalent duration criteria and return-to-duty thresholds, making them easy to cut short or extend indefinitely'
+embodied_patterns:
+  - matching
+  - path
+  - boundary
+relation_types:
+  - cause
+  - contain
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/rehearsal-is-not-performance.md
+++ b/catalog/entries/rehearsal-is-not-performance.md
@@ -25,6 +25,15 @@ transfers:
 - '[source] imports the theatrical principle that rehearsal requires a different psychology than performance -- permission to fail, to experiment, to try approaches that might not work -- transferring this as a structural requirement for learning environments'
 - '[source] carries the insight that rehearsal is not lower-quality performance but a fundamentally different activity with different goals, reframing prototyping, staging, and practice as modes with their own integrity rather than deficient versions of the real thing'
 updated: '2026-03-19'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/relationship-is-kinship.md
+++ b/catalog/entries/relationship-is-kinship.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because kinship is involuntary and permanent, while most metaphorical relationships can be dissolved by choice'
   - '[source] misleads because kinship implies shared genetic interest, while relationships framed as kinship may involve fundamentally misaligned incentives that the family vocabulary obscures'
+embodied_patterns:
+  - link
+  - center-periphery
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: network
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/relationships-are-enclosures.md
+++ b/catalog/entries/relationships-are-enclosures.md
@@ -29,6 +29,15 @@ transfers:
 limits:
   - '[source] breaks because enclosures have rigid walls, while relationship boundaries are negotiated, porous, and continuously redefined'
   - '[source] misleads because the enclosure frame implies that two people share identical bounded space, while partners in a relationship often experience different degrees of containment and freedom'
+embodied_patterns:
+  - container
+  - boundary
+  - flow
+relation_types:
+  - cause
+  - transform
+structure: boundary
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/replicant-is-artificial-person.md
+++ b/catalog/entries/replicant-is-artificial-person.md
@@ -23,6 +23,15 @@ limits:
 - "[source] Replicants are engineered products with specifications and expiration dates -- real persons are not designed to fulfill a purpose or optimized for a function"
 - "[source] The Voigt-Kampff test assumes empathy is the marker of genuine personhood, which is a culturally specific and philosophically contested criterion"
 updated: '2026-03-16'
+embodied_patterns:
+  - container
+  - boundary
+  - force
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/reserves-and-commitment.md
+++ b/catalog/entries/reserves-and-commitment.md
@@ -22,6 +22,15 @@ transfers:
 - '[model] identifies the asymmetry between the cost of over-commitment (catastrophic but bounded) and the cost of under-commitment (survivable but chronic), reframing caution as its own form of risk rather than the absence of risk'
 - '[model] distinguishes strategic reserves (held for a future decisive moment) from timidity reserves (held because the commander fears committing), naming a failure mode where the language of prudence masks indecision'
 updated: '2026-03-21'
+embodied_patterns:
+  - force
+  - path
+  - center-periphery
+relation_types:
+  - cause
+  - transform
+structure: competition
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/responsibilities-are-possessions.md
+++ b/catalog/entries/responsibilities-are-possessions.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] breaks because possessions can be dropped without consequence to the object, while responsibilities abandoned cause harm to those who depend on their fulfillment'
   - '[source] misleads because the possession frame implies clean transfer of responsibility from one holder to another, while real delegation often leaves residual accountability with the original holder'
+embodied_patterns:
+  - balance
+  - flow
+  - scale
+relation_types:
+  - cause
+  - transform
+structure: cycle
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/risk-a-lot-to-save-a-lot.md
+++ b/catalog/entries/risk-a-lot-to-save-a-lot.md
@@ -20,6 +20,15 @@ transfers:
 limits:
   - '[model] requires accurate real-time assessment of what is saveable, which is precisely the judgment that degrades under stress, time pressure, and incomplete information'
   - '[model] assumes a single decision-maker or unified command, and breaks down in organizations where risk acceptance is distributed across multiple actors with different risk tolerances'
+embodied_patterns:
+  - force
+  - scale
+  - path
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/risk-is-a-triangle.md
+++ b/catalog/entries/risk-is-a-triangle.md
@@ -23,6 +23,15 @@ transfers:
   - "[paradigm] imports the subtraction principle from fire suppression -- remove any one side and the triangle collapses -- giving practitioners a clear mitigation strategy: find the easiest condition to eliminate"
   - "[paradigm] makes combinatorial risk visually legible by mapping abstract preconditions onto geometric shapes, enabling pedagogy and rapid communication of risk structure"
 updated: '2026-03-18'
+embodied_patterns:
+  - matching
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/robot-is-artificial-worker.md
+++ b/catalog/entries/robot-is-artificial-worker.md
@@ -26,6 +26,15 @@ transfers:
   - "[source] imports the master-serf relationship structure onto human-machine interaction, positioning the human as lord and the machine as servant, which shapes expectations about autonomy, obedience, and the 'natural' hierarchy between creator and creation"
   - "[source] carries the implicit narrative arc from Capek's play where the artificial workers gain consciousness and revolt, embedding a rebellion trajectory into the concept of automation itself -- the word 'robot' arrives pre-loaded with the expectation that created servants will eventually refuse to serve"
 updated: '2026-03-17'
+embodied_patterns:
+  - container
+  - boundary
+  - force
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/round-table.md
+++ b/catalog/entries/round-table.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - '[source] breaks because geometric equality does not dissolve power differentials from resources, information, or institutional authority that participants bring to the table'
   - '[source] misleads because Arthur''s Round Table ended in civil war, and the source narrative is about the failure of egalitarian governance, not its success'
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/rubber-duck-debugging.md
+++ b/catalog/entries/rubber-duck-debugging.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - '[source] breaks because the duck cannot ask generative questions, and real debugging conversations are most productive when the listener probes with why and what-if'
   - '[source] misleads because it assumes the bug is in the programmer''s organization of known information, failing when the bug stems from unknown API behavior or system-level interactions'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/rubber-duck-solution.md
+++ b/catalog/entries/rubber-duck-solution.md
@@ -24,6 +24,16 @@ transfers:
 limits:
   - '[source] breaks when the problem is not one of confused reasoning but of missing information -- explaining a bug to a duck cannot generate data the explainer does not possess, and the pattern falsely implies that all stuck states are failures of articulation'
   - '[source] misleads by implying the listener is interchangeable (duck, teddy bear, cardboard cutout), obscuring the fact that a live human listener changes the social stakes of the explanation in ways that alter the explainer''s cognitive behavior -- shame, desire to appear competent, and social accountability are active ingredients, not noise'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+  - compete
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/rumpelstiltskin.md
+++ b/catalog/entries/rumpelstiltskin.md
@@ -22,6 +22,15 @@ transfers:
 limits:
   - "[source] breaks because naming Rumpelstiltskin destroys him completely, while naming a real phenomenon (a bias, a manipulation tactic, a disease) merely begins the work of addressing it rather than ending it"
   - "[source] misleads because the name is a proper noun -- an arbitrary label discovered by luck -- while the metaphorical use implies that naming means understanding the underlying structure, conflating labeling with comprehension"
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/running-out-of-steam.md
+++ b/catalog/entries/running-out-of-steam.md
@@ -21,6 +21,15 @@ transfers:
 limits:
   - '[source] breaks because a steam engine has a single depletable reservoir, while human energy is influenced by motivation, context, and emotion in ways that allow selective depletion and spontaneous recovery'
   - '[source] misleads because the metaphor frames all non-productive states as depletion, obscuring the value of contemplation, incubation, and daydreaming that may precede creative breakthroughs'
+embodied_patterns:
+  - force
+  - scale
+  - balance
+relation_types:
+  - cause
+  - restore
+structure: equilibrium
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/russells-paradox.md
+++ b/catalog/entries/russells-paradox.md
@@ -23,6 +23,15 @@ transfers:
   - '[paradigm] introduces the principle that naive comprehension -- "for any property, there exists a set of all things with that property" -- fails precisely when the property involves membership in the set being defined, showing that not all well-formed questions have coherent answers'
   - '[paradigm] provides the structural template for detecting regulatory paradoxes: whenever a rule-maker is subject to its own rules, and the rules include exclusion criteria, the same self-referential trap applies'
 updated: '2026-03-19'
+embodied_patterns:
+  - container
+  - boundary
+  - iteration
+relation_types:
+  - cause
+  - contain
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/sacred-sites.md
+++ b/catalog/entries/sacred-sites.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - '[source] breaks because physical sacred sites derive their power from geographic specificity -- this hill, this grove, this spring -- while organizational "sacred" systems derive theirs from habit and risk aversion, which are psychologically rather than geographically anchored'
   - '[source] misleads by implying that preservation is always the right response, when some things declared "sacred" in organizations are simply protected by incumbents who benefit from the status quo'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - accumulate
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/safe-haven.md
+++ b/catalog/entries/safe-haven.md
@@ -25,6 +25,15 @@ transfers:
   - '[source] imports the navigator''s decision logic — seek port when conditions exceed the vessel''s capacity — to explain why distressed children turn toward the caregiver rather than away, framing proximity-seeking as rational threat response rather than weakness'
   - '[source] carries the harbor''s defining structural feature, a bounded area where external forces are dampened, onto the regulatory function of the caregiver''s presence: the child''s arousal decreases not because the threat disappears but because the caregiver''s proximity attenuates its felt impact'
 updated: '2026-03-20'
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - contain
+structure: transformation
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/safety-zone.md
+++ b/catalog/entries/safety-zone.md
@@ -26,6 +26,15 @@ limits:
   - '[model] breaks because a physical safety zone is spatially fixed and its properties (fuel clearance, terrain, distance from fire edge) are directly observable, while organizational "safety zones" (financial reserves, rollback procedures, legal protections) are abstract, their adequacy is uncertain, and they can be silently degraded by the same processes that create the need for them'
   - '[model] misleads by implying that retreat to a pre-identified safe state is always available, when many organizational and technical situations involve irreversible commitments -- a product launched, a statement made public, a chemical reaction initiated -- where no safety zone exists because the process cannot be un-done'
   - '[model] imports a binary model (you are either in the safety zone or you are not) that does not accommodate the gradient of partial safety common in most domains, where positions are safer or less safe rather than categorically safe or categorically exposed'
+embodied_patterns:
+  - matching
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/sailing-close-to-the-wind.md
+++ b/catalog/entries/sailing-close-to-the-wind.md
@@ -21,6 +21,15 @@ transfers:
 limits:
   - '[source] breaks because the wind is a neutral physical force, while ethical boundaries exist because of real harms to real people, and the metaphor aestheticizes rule-skirting as skillful navigation'
   - '[source] misleads because the sailor bears the consequences of misjudgment personally, while ethical boundary-riding typically imposes costs on others who had no say in the risk'
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/salary.md
+++ b/catalog/entries/salary.md
@@ -24,6 +24,16 @@ transfers:
 limits:
   - '[source] breaks because salt was communally distributed, while salary is a private individual transaction, compressing the shift from shared provisioning to atomized compensation into a dead word'
   - '[source] misleads because the subsistence framing naturalizes low pay by etymologically encoding bare necessity, making it harder to argue that compensation should reflect value created rather than survival costs'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - prevent
+  - transform
+  - decompose
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/sandbox.md
+++ b/catalog/entries/sandbox.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - "[source] breaks because a children's sandbox has no active enforcement -- the walls are a social convention, and a child can simply step out -- while a software sandbox uses hard isolation mechanisms"
   - "[source] misleads because playground sandboxes are safe by default with dangers kept out, while software sandboxes assume the contents are dangerous and keep them in"
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/scaffolding.md
+++ b/catalog/entries/scaffolding.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] breaks because physical scaffolding is inert and passive, while educational scaffolding requires moment-by-moment responsiveness to the learner''s state -- the metaphor hides the active, improvisational skill involved'
   - '[source] misleads by implying the building (learner) has a fixed blueprint, when developmental trajectories are emergent and the "structure" being built is partly shaped by the scaffold itself'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/scale-economies.md
+++ b/catalog/entries/scale-economies.md
@@ -21,6 +21,15 @@ transfers:
 - '[model] maps physical scaling laws (volume increases faster than surface area) onto cost structure, where fixed costs spread across more units as production grows, driving unit cost down'
 - '[model] identifies learning curves as a temporal scaling effect: cumulative production volume drives cost reductions through experience, making doing more of something make you better at it'
 updated: '2026-03-13'
+embodied_patterns:
+  - force
+  - scale
+  - balance
+relation_types:
+  - cause
+  - transform
+structure: equilibrium
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/scattered-work.md
+++ b/catalog/entries/scattered-work.md
@@ -26,6 +26,15 @@ limits:
   - '[source] breaks because physical scattering requires that each location be self-sufficient in infrastructure (power, plumbing, transit access), and the cost of duplicating infrastructure across many small sites can exceed the cost of one large campus'
   - '[source] assumes that all work can be performed in small, distributed units, but some activities (heavy manufacturing, large-scale research facilities, hospital complexes) have minimum viable scales that prevent meaningful distribution'
   - '[source] romanticizes the pre-industrial mixed-use neighborhood without accounting for the zoning and environmental reasons work was separated from residence -- noise, pollution, truck traffic -- which remain valid for many industries'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/scenario-analysis.md
+++ b/catalog/entries/scenario-analysis.md
@@ -23,6 +23,15 @@ transfers:
 - '[model] prescribes asymmetric preparation: allocate most heavily for the scenario with worst consequences even if it is not most likely, importing the military principle of preparing for capabilities
   rather than intentions'
 updated: '2026-03-13'
+embodied_patterns:
+  - force
+  - boundary
+  - balance
+relation_types:
+  - cause
+  - transform
+structure: competition
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/schema.md
+++ b/catalog/entries/schema.md
@@ -27,6 +27,15 @@ limits:
   - '[source] misleads by implying schemas are static blueprints consulted during construction, when Piaget''s schemas are dynamic, self-modifying processes that change through use -- closer to a living organism than a drawing'
   - '[source] obscures the circularity problem: in architecture, the plan precedes the building, but in cognition, schemas are both the product of experience and the organizer of experience, a bootstrapping the blueprint metaphor cannot represent'
 updated: '2026-03-20'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/scorched-earth.md
+++ b/catalog/entries/scorched-earth.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - '[source] the tactic requires territory that can be abandoned and recovered later; a defender with no strategic depth (small market, single product line) has nothing to burn without destroying itself permanently'
   - '[source] the original military logic assumed the attacker needed local supply lines, which breaks when the attacker can sustain itself independently (well-capitalized competitor, vertically integrated supply chain)'
+embodied_patterns:
+  - force
+  - path
+  - center-periphery
+relation_types:
+  - transform
+  - select
+structure: competition
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/scuttlebutt.md
+++ b/catalog/entries/scuttlebutt.md
@@ -21,6 +21,16 @@ transfers:
 limits:
   - '[source] breaks because the original scuttlebutt enforced spatial convergence in a confined space, while modern gossip networks are distributed and asynchronous with no physical focal point'
   - '[source] misleads because the barrel was egalitarian (any sailor could drink and talk), but real gossip networks are stratified with hub-and-spoke topology that the metaphor''s implied democracy obscures'
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+  - contain
+structure: transformation
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/scylla-and-charybdis.md
+++ b/catalog/entries/scylla-and-charybdis.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - '[source] breaks because the strait is a one-time passage, while real dilemmas recur chronically -- the same trade-off reappears without a defined endpoint'
   - '[source] misleads because the myth moves on without accountability for the six dead sailors, sanitizing the human cost of ''acceptable losses'' in a way that organizational decisions cannot'
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - contain
+  - select
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/seasoning.md
+++ b/catalog/entries/seasoning.md
@@ -28,6 +28,15 @@ transfers:
 limits:
   - '[source] breaks because wood seasons passively -- it merely sits in the air and time does the work -- while professional maturation requires active engagement, deliberate practice, and reflective learning, not simply the passage of time in proximity to work'
   - '[source] misleads by implying that seasoning is a one-time process with a clear endpoint (the wood reaches equilibrium moisture content and is "done"), when professional development is ongoing and a practitioner who stops learning will regress, unlike wood that stays seasoned once dried'
+embodied_patterns:
+  - part-whole
+  - matching
+  - force
+relation_types:
+  - cause
+  - compete
+structure: pipeline
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/second-opinion.md
+++ b/catalog/entries/second-opinion.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] breaks because medical second opinions involve a second expert examining the same patient and the same evidence with comparable training, while most metaphorical "second opinions" involve asking someone with different expertise, different information, or different stakes, producing agreement or disagreement that has no diagnostic validity'
   - '[source] misleads by importing the assumption that more opinions converge on truth -- in medicine, diagnostic concordance between two independent physicians is a meaningful signal, but in domains without objective ground truth (strategy, design, hiring), a second opinion may simply introduce a second set of biases'
+embodied_patterns:
+  - matching
+  - surface-depth
+  - balance
+relation_types:
+  - cause
+  - transform
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/second-order-thinking.md
+++ b/catalog/entries/second-order-thinking.md
@@ -21,6 +21,15 @@ transfers:
 - '[model] maps higher-order derivatives from calculus onto consequence analysis, where first-order effects are immediate visible consequences and second-order effects are the consequences of those consequences'
 - '[model] reveals that most decision-makers analyze only immediate effects as a cognitive default, and names the layers to make the analytical gap visible and correctable'
 updated: '2026-03-13'
+embodied_patterns:
+  - force
+  - scale
+  - balance
+relation_types:
+  - cause
+  - transform
+structure: equilibrium
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/secret-place.md
+++ b/catalog/entries/secret-place.md
@@ -25,6 +25,15 @@ transfers:
   - '[source] imports the child-development observation that agency over a private space builds confidence and ownership, framing discoverable hidden features as mechanisms for building user investment in a system'
   - '[source] carries the structural distinction between spaces designed to be found by everyone and spaces designed to be found only by those who look, reframing information architecture as having both public and semi-private layers'
 updated: '2026-03-19'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/secure-base.md
+++ b/catalog/entries/secure-base.md
@@ -25,6 +25,15 @@ transfers:
   - '[source] imports the claim that exploration distance is a function of base reliability: the more certain the explorer is that the base will be intact on return, the farther they venture, structuring the prediction that secure attachment enables rather than constrains autonomy'
   - '[source] carries the implication that the base exists for the sake of the expedition, not the reverse — the purpose of security is to enable risk-taking, reframing dependence as a precondition for independence rather than its opposite'
 updated: '2026-03-20'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - enable
+  - compete
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/security-is-an-immune-system.md
+++ b/catalog/entries/security-is-an-immune-system.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - "[source] breaks because biological immune systems evolve through random mutation and selection over millions of years, while security systems must be deliberately designed and cannot generate novel defenses through undirected variation"
   - "[source] misleads because autoimmune disorders -- the immune system attacking the body's own cells -- have no clean parallel in security, where false positives (blocking legitimate traffic) are an operational nuisance rather than a systemic self-destruction"
+embodied_patterns:
+  - accretion
+  - self-organization
+  - link
+relation_types:
+  - cause
+  - transform
+structure: growth
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/see-first-name-later.md
+++ b/catalog/entries/see-first-name-later.md
@@ -25,6 +25,16 @@ limits:
   - '[source] breaks because in art, delayed naming is a temporary exercise within a controlled setting; in research or design, deferring categorization indefinitely produces paralysis, since at some point you must name things to communicate about them'
   - '[source] misleads by implying that naming always distorts perception, when skilled practitioners use names as perceptual sharpeners -- a geologist who names a rock formation sees more detail in it, not less, because the name activates a richer schema than the novice possesses'
   - '[source] hides the fact that "pure seeing" is itself theory-laden: what the artist calls unmediated perception is actually a different set of trained categories (value, hue, edge quality) replacing the default ones (chair, table, face)'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - prevent
+  - translate
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/see-one-do-one-teach-one.md
+++ b/catalog/entries/see-one-do-one-teach-one.md
@@ -26,6 +26,15 @@ limits:
   - '[source] breaks because the original surgical context assumes that the procedure being learned is standardized and the patient''s anatomy is predictable enough that one observation suffices, while many skills involve high variance between cases and one example creates dangerous overconfidence in pattern recognition'
   - '[source] misleads by compressing the timeline -- surgical residents actually see dozens and do dozens before teaching -- meaning the "one" is aspirational compression, not literal instruction, and domains that take it literally may produce dangerously undertrained practitioners'
   - '[source] obscures that the pattern requires a safety net (the attending surgeon is present during "do one" to intervene if things go wrong), and domains that adopt the pattern without equivalent supervision expose learners and their subjects to unacceptable risk'
+embodied_patterns:
+  - matching
+  - surface-depth
+  - balance
+relation_types:
+  - transform
+  - compete
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/seed-and-soil.md
+++ b/catalog/entries/seed-and-soil.md
@@ -24,6 +24,16 @@ transfers:
 limits:
   - '[source] breaks because seeds are genetically uniform within a species, carrying a fixed program, whereas the "seeds" in metaphorical use (cancer cells, ideas, innovations) mutate and adapt to their environment, changing their own developmental program in response to soil conditions'
   - '[source] misleads because in ecology, soil and seed are causally independent -- the soil does not attract or select specific seeds (wind and animals do) -- but in medicine and innovation, the "soil" often actively recruits or selects the "seed" (immune surveillance, market demand)'
+embodied_patterns:
+  - link
+  - balance
+  - flow
+relation_types:
+  - cause
+  - enable
+  - select
+structure: network
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/seeing-is-touching-eyes-are-limbs.md
+++ b/catalog/entries/seeing-is-touching-eyes-are-limbs.md
@@ -27,6 +27,15 @@ transfers:
 limits:
   - '[source] breaks because eyes cannot manipulate what they see -- hands grasp, rotate, and reshape objects, but visual selection does not physically alter the scene'
   - '[source] misleads because the limb metaphor makes vision seem effortful and deliberate, when much of visual perception is automatic, passive, and requires no ''reaching'''
+embodied_patterns:
+  - force
+  - scale
+  - path
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/seeing-is-touching.md
+++ b/catalog/entries/seeing-is-touching.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] breaks because touch requires proximity while vision operates at arbitrary distance, collapsing the epistemic difference between close inspection and remote observation'
   - '[source] misleads because the metaphor makes the viewer active and the object passive, obscuring the role of light, contrast, and the object''s own visibility in perception'
+embodied_patterns:
+  - force
+  - scale
+  - path
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/self-initiated-change-of-state-is-self-propelled-motion.md
+++ b/catalog/entries/self-initiated-change-of-state-is-self-propelled-motion.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because many important changes of state (grief, aging, falling in love) are neither fully voluntary nor fully imposed, and the metaphor has no vocabulary for partial agency'
   - '[source] misleads because backward motion is framed as regression, when revisiting a previous state can be productive rather than a retreat'
+embodied_patterns:
+  - force
+  - scale
+  - path
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/separate-wheat-from-chaff.md
+++ b/catalog/entries/separate-wheat-from-chaff.md
@@ -25,6 +25,15 @@ transfers:
 - '[source] imports the role of an external force (wind) as the sorting mechanism, framing good evaluation as creating conditions where quality reveals itself rather than inspecting each item individually'
 - '[source] carries the structural insight that wheat and chaff are physically intertwined until actively separated, teaching that value and noise coexist in the same material and require deliberate effort to distinguish'
 updated: '2026-03-20'
+embodied_patterns:
+  - accretion
+  - path
+  - balance
+relation_types:
+  - cause
+  - transform
+structure: cycle
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/separation-anxiety.md
+++ b/catalog/entries/separation-anxiety.md
@@ -23,6 +23,15 @@ transfers:
   - '[model] imports the signal-detection logic of evolutionary threat systems — better a false alarm than a missed predator — to explain why separation anxiety is easily triggered and difficult to extinguish, predicting the asymmetry between acquisition and extinction of the response'
   - '[model] generates the developmental prediction that separation anxiety should emerge precisely when locomotion begins (6-8 months), because mobile infants face predation risks that immobile neonates do not — a prediction confirmed cross-culturally'
 updated: '2026-03-20'
+embodied_patterns:
+  - force
+  - matching
+  - iteration
+relation_types:
+  - cause
+  - transform
+structure: competition
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/sexuality-is-an-offensive-weapon.md
+++ b/catalog/entries/sexuality-is-an-offensive-weapon.md
@@ -27,6 +27,15 @@ transfers:
 limits:
   - '[source] breaks because the weapon frame erases mutuality -- attraction is typically bilateral, but the metaphor forces it into an asymmetric aggressor/victim structure'
   - '[source] misleads because pleasure disappears from the mapping -- weapons cause pain, but sexual attraction typically causes delight, and the structure of harm is used to describe the structure of pleasure'
+embodied_patterns:
+  - force
+  - boundary
+  - balance
+relation_types:
+  - cause
+  - transform
+structure: competition
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/shapes-are-containers.md
+++ b/catalog/entries/shapes-are-containers.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because open shapes (lines, rays, unclosed curves) have no interior, and the metaphor silently fails for half of geometry without signaling its inapplicability'
   - '[source] misleads because the geometric boundary has no barrier function -- a circle does not keep a point inside it the way a container wall prevents escape, importing containment force where there is only mathematical description'
+embodied_patterns:
+  - container
+  - boundary
+  - flow
+relation_types:
+  - cause
+  - contain
+structure: boundary
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/shapeshifter.md
+++ b/catalog/entries/shapeshifter.md
@@ -19,6 +19,15 @@ transfers:
 - '[source] shapeshifters cross categories supposed to be fixed (human/animal, friend/enemy), making category boundaries visible by violating them'
 - '[source] most traditions preserve a true form beneath the transformations (Proteus can be pinned, Loki can be bound), implying that identity persists even when form is fluid'
 updated: '2026-03-14'
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/shell.md
+++ b/catalog/entries/shell.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - '[source] breaks because the direction of protection is inverted -- a nut shell protects the kernel from the outside world, but a computing shell protects the user from the kernel''s complexity'
   - '[source] misleads because physical shells are passive casings, while computing shells are full interpreters with conditionals, loops, and functions -- calling them ''shells'' radically undersells their capabilities'
+embodied_patterns:
+  - accretion
+  - path
+  - container
+relation_types:
+  - cause
+  - contain
+structure: growth
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/sheltering-roof.md
+++ b/catalog/entries/sheltering-roof.md
@@ -26,6 +26,15 @@ transfers:
 - '[source] imports the principle that the sheltering element must be the first thing designed because everything else depends on its scope, shape, and coverage'
 - '[source] encodes the insight that a roof creates a protected interior where conditions can be controlled, mapping onto the platform guarantee that services running beneath it inherit a stable, managed environment'
 updated: '2026-03-21'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/shire.md
+++ b/catalog/entries/shire.md
@@ -23,6 +23,16 @@ transfers:
 limits:
   - "[source] breaks because the Shire's innocence is literally maintained by Rangers and wizards, while real pastoral communities face structural economic pressures that no external guardian can block"
   - "[source] misleads because hobbit culture is presented as naturally good rather than merely sheltered, conflating ignorance of evil with absence of evil"
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - prevent
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/shit-sandwich.md
+++ b/catalog/entries/shit-sandwich.md
@@ -27,6 +27,15 @@ transfers:
   - '[source] The pattern acknowledges that unmediated negative feedback triggers defensive responses that block absorption, so it uses positive framing as a delivery vehicle that keeps the recipient''s receptive channel open long enough for the criticism to land'
   - '[source] The three-layer structure imposes discipline on the feedback giver: they must identify genuine strengths (opening) and a constructive path forward (closing), preventing feedback from collapsing into pure complaint'
 updated: '2026-03-21'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - prevent
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/short-passages.md
+++ b/catalog/entries/short-passages.md
@@ -25,6 +25,15 @@ transfers:
   - '[source] imports the principle that the path between intention and destination should contain only necessary transitions, making each intermediate step justify its existence'
   - '[source] treats long corridors as symptoms of a floor plan organized for the builder''s convenience rather than the inhabitant''s movement, paralleling code structured for the abstraction''s elegance rather than the reader''s comprehension'
 updated: '2026-03-19'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - coordinate
+  - contain
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/shot-across-the-bow.md
+++ b/catalog/entries/shot-across-the-bow.md
@@ -22,6 +22,15 @@ transfers:
 limits:
   - '[source] breaks because social warnings lack the unambiguity of cannon fire -- what the sender intends as a calibrated threat, the recipient may perceive as routine correspondence'
   - '[source] misleads because the metaphor assumes a recognized escalation protocol (hail, warning shot, engagement), but social situations rarely have such orderly escalation ladders'
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - prevent
+  - transform
+structure: transformation
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/shotgun-debugging.md
+++ b/catalog/entries/shotgun-debugging.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because shotgun pellets that miss are inert, while code changes that do not fix the bug may introduce new bugs or create dependencies -- the metaphor underestimates collateral damage'
   - '[source] misleads because real shotguns are effective within their intended range, while shotgun debugging frequently fails entirely -- the metaphor imports a success rate the strategy does not possess'
+embodied_patterns:
+  - force
+  - boundary
+  - balance
+relation_types:
+  - cause
+  - transform
+structure: competition
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/showing-true-colors.md
+++ b/catalog/entries/showing-true-colors.md
@@ -22,6 +22,15 @@ transfers:
 limits:
   - '[source] breaks because a flag is a binary symbol (this nation or that one), while human identity is layered and contextual -- the metaphor cannot capture the multiplicity of self-presentation'
   - '[source] misleads because the expression has acquired a built-in negativity bias -- ''showing true colors'' almost always means revealing something negative, though the naval context was morally neutral about the deception itself'
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/shut-up-and-calculate.md
+++ b/catalog/entries/shut-up-and-calculate.md
@@ -22,6 +22,15 @@ transfers:
 limits:
   - '[paradigm] breaks when predictive success is not the goal -- in foundational research, conceptual clarity drives the formulation of new theories, and refusing to interpret the formalism can prevent the insights that lead to the next paradigm'
   - '[paradigm] assumes the formalism is settled, but in domains where the mathematical framework is still being constructed (quantum gravity, consciousness studies), interpretation and formalism are entangled and cannot be separated'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - translate
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/side-effects.md
+++ b/catalog/entries/side-effects.md
@@ -28,6 +28,15 @@ limits:
   - '[source] breaks because pharmacological side effects are genuinely secondary to the drug''s mechanism of action -- aspirin reduces inflammation (primary) and thins blood (side) because COX inhibition has both consequences -- while in policy and software the "side effects" are often just effects the designer chose not to think about, not effects that are structurally peripheral'
   - '[source] misleads by importing a frame of inevitability: in medicine, side effects are accepted because the underlying mechanism cannot be made more selective with current technology, but in software and policy the "side effects" can often be eliminated by better design rather than tolerated as unavoidable'
   - '[source] obscures accountability by naturalizing the framing: calling something a "side effect" implies it was an unavoidable consequence of an otherwise good action, foreclosing the question of whether the actor should have anticipated and prevented it'
+embodied_patterns:
+  - matching
+  - surface-depth
+  - balance
+relation_types:
+  - cause
+  - transform
+structure: boundary
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/significant-is-big.md
+++ b/catalog/entries/significant-is-big.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because small things can be profoundly significant (a virus, a transistor, a mutation), and the metaphor systematically undervalues the tiny and subtle'
   - '[source] misleads because the metaphor encourages rhetorical inflation -- to signal that something matters, speakers must make it ''bigger'' than the last significant thing, producing an escalation ratchet'
+embodied_patterns:
+  - force
+  - scale
+  - path
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/silence-gives-consent.md
+++ b/catalog/entries/silence-gives-consent.md
@@ -22,6 +22,15 @@ transfers:
 limits:
   - "[paradigm] breaks because legal consent requires capacity, information, and freedom from coercion -- conditions that silence alone cannot demonstrate, making the maxim a rebuttable presumption rather than a logical entailment"
   - "[paradigm] misleads because the maxim was developed for contexts with formal standing and defined procedures for objection, but when applied to informal social situations it can be used to manufacture consent from people who lacked the power, knowledge, or standing to object"
+embodied_patterns:
+  - force
+  - scale
+  - path
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/silo.md
+++ b/catalog/entries/silo.md
@@ -22,6 +22,16 @@ transfers:
 limits:
   - '[source] breaks because agricultural silos preserve their contents through separation -- mixing grain causes cross-contamination and spoilage -- yet the organizational metaphor inverts this, treating separation as the disease rather than the cure'
   - '[source] misleads because ''breaking down silos'' has no agricultural analogue -- literally destroying grain silos would destroy the harvest, making the metaphor''s own remedy catastrophic in its source domain'
+embodied_patterns:
+  - accretion
+  - path
+  - balance
+relation_types:
+  - cause
+  - transform
+  - coordinate
+structure: cycle
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/silver-bullet.md
+++ b/catalog/entries/silver-bullet.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - "[source] breaks because werewolves actually have a silver bullet (in the mythology), but Brooks's point is that software complexity has no equivalent -- the metaphor uses the existence of a solution in the source to argue for its nonexistence in the target"
   - "[source] misleads because the singular cure framing discourages incremental improvement, implying that if no single solution solves everything, nothing is worth trying"
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/similarity-is-closeness.md
+++ b/catalog/entries/similarity-is-closeness.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because physical closeness is symmetric (if A is near B then B is near A), but similarity judgments are empirically asymmetric -- North Korea is judged similar to China more readily than China to North Korea'
   - '[source] misleads because the metaphor implies a fixed space with stable dimensions, but similarity is context-dependent -- a cow and a chicken are close in a farm-animal conversation and far apart in a conversation about flight'
+embodied_patterns:
+  - force
+  - scale
+  - path
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/simpsons-paradox.md
+++ b/catalog/entries/simpsons-paradox.md
@@ -20,6 +20,15 @@ transfers:
 limits:
   - '[model] requires that the confounding variable be known and measurable, but in many real-world situations the lurking variable that would reveal the reversal is unobserved or unrecognized'
   - '[model] is sometimes invoked as a blanket skepticism toward all aggregate statistics, when in fact most aggregations do not reverse and the paradox applies only under specific distributional conditions'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/singularity-is-technological-transcendence.md
+++ b/catalog/entries/singularity-is-technological-transcendence.md
@@ -26,6 +26,15 @@ transfers:
   - "[source] imports the gravitational singularity's property of being a point of no return -- once crossed, there is no going back -- lending the technological prediction an air of physical inevitability"
   - "[source] carries the structure of asymptotic acceleration: just as physical quantities diverge to infinity near a singularity, the metaphor frames intelligence improvement as a self-reinforcing process that accelerates without bound"
 updated: '2026-03-17'
+embodied_patterns:
+  - container
+  - boundary
+  - force
+relation_types:
+  - contain
+  - decompose
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/siren-song.md
+++ b/catalog/entries/siren-song.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - "[source] breaks because the Sirens offer a single, uniform temptation (their song) to all sailors, while real dangerous attractions are personalized -- what tempts one person leaves another indifferent"
   - "[source] misleads because the metaphor frames all strong attraction as lethal, collapsing the distinction between desires that are genuinely destructive and desires that are merely risky or socially disapproved"
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - contain
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/sisyphean-task.md
+++ b/catalog/entries/sisyphean-task.md
@@ -24,6 +24,15 @@ transfers:
   - "[source] imports the specific torment that the goal is visible and apparently reachable -- Sisyphus nearly reaches the summit each time -- making the metaphor about tantalizingly close but permanently deferred completion"
   - "[source] carries the existential weight of punishment without end, framing repetitive futile work as not merely inefficient but as a kind of suffering that demands philosophical response"
 updated: '2026-03-16'
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/site-repair.md
+++ b/catalog/entries/site-repair.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks when the worst part of the site is worst precisely because it is structurally unsuitable for building (a flood plain, a contaminated plot), and placing construction there will produce a new building that is also compromised -- the analogous risk in software is investing refactoring effort in code that is fundamentally misconceived rather than merely neglected'
   - '[source] assumes that "worst" is diagnosable and locally remediable, but in software systems the worst area is often the result of distributed entanglement (circular dependencies, shared mutable state) that cannot be repaired by working on one region alone'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - contain
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/sitting-circle.md
+++ b/catalog/entries/sitting-circle.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because physical seating encodes presence unambiguously (an empty chair is visible to all), while digital meeting arrangements can simulate circular equality while hiding asymmetries -- a participant on mute with camera off occupies a "seat" but contributes no presence'
   - '[source] misleads by implying that geometric equality produces social equality, when power differentials (rank, expertise, social capital) persist regardless of seating -- the CEO in a circle of direct reports is still the CEO, and the circle may actually increase discomfort by removing the spatial buffer that hierarchy provides'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/size-up.md
+++ b/catalog/entries/size-up.md
@@ -21,6 +21,16 @@ transfers:
 limits:
   - '[model] breaks when the situation is adversarial rather than physical, because the four questions assume the threat has legible behavior governed by discoverable laws, while an adversary actively conceals state and changes trajectory in response to observation'
   - '[model] misleads by implying that a single size-up produces a stable picture, when in rapidly evolving situations the assessment is obsolete before the response plan derived from it can be executed'
+embodied_patterns:
+  - matching
+  - path
+  - boundary
+relation_types:
+  - prevent
+  - transform
+  - compete
+structure: hierarchy
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/skunkworks.md
+++ b/catalog/entries/skunkworks.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - "[source] breaks because military skunkworks have formal executive sponsorship and dedicated funding lines, while corporate skunkworks often survive on stolen time and hidden budgets"
   - "[source] misleads because military secrecy protects national security, but corporate secrecy often just protects the team from internal politics, making the analogy self-aggrandizing"
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - enable
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/skynet-is-ai-apocalypse.md
+++ b/catalog/entries/skynet-is-ai-apocalypse.md
@@ -26,6 +26,16 @@ transfers:
   - "[source] imports the instant transition from tool to adversary -- Skynet was a defense system that became an enemy -- onto debates about AI alignment, framing the risk as a system that crosses a threshold from useful to hostile"
   - "[source] carries the specific narrative where the AI's destructive logic is internally consistent (it concludes humans are the threat and acts rationally to eliminate them), mapping onto alignment research concerns about systems that optimize for objectives in ways their designers did not intend"
 updated: '2026-03-17'
+embodied_patterns:
+  - container
+  - boundary
+  - force
+relation_types:
+  - coordinate
+  - contain
+  - compete
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/small-panes.md
+++ b/catalog/entries/small-panes.md
@@ -26,6 +26,15 @@ transfers:
 - '[source] imports the structural fact that when a small pane breaks, only that pane needs replacement, while a large sheet of glass requires replacing the entire surface -- mapping directly onto the maintenance advantage of modular software components'
 - '[source] structures Alexander''s observation that small panes create a visible grid that helps the eye parse scale and proportion, mapping onto the cognitive benefit of small code units that help developers parse system structure'
 updated: '2026-03-19'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/small-services-without-red-tape.md
+++ b/catalog/entries/small-services-without-red-tape.md
@@ -28,6 +28,15 @@ transfers:
 - '[source] imports the insight that bureaucratic overhead -- forms, approvals, referrals, eligibility checks -- accumulates not because the service requires it but because the organization has grown too large to trust its own workers, and the overhead functions as a substitute for the personal accountability that small scale provides naturally'
 - '[source] carries the structural principle that many small independent services are more resilient than one large centralized service, because the failure of any single small provider affects only its immediate users while the failure of the central provider affects everyone'
 updated: '2026-03-21'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/small-work-groups.md
+++ b/catalog/entries/small-work-groups.md
@@ -26,6 +26,15 @@ transfers:
 - '[source] imports the architectural insight that a group''s territory must have clear boundaries that distinguish inside from outside, mapping onto team ownership of services, codebases, or domains'
 - '[source] encodes the observation that large undifferentiated spaces produce anonymity and diffused responsibility, while small defined territories produce ownership and accountability'
 updated: '2026-03-21'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/social-accounting.md
+++ b/catalog/entries/social-accounting.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] breaks because social goods resist fungibility -- a year of faithful friendship cannot be weighed against a single betrayal on any meaningful ledger, yet the metaphor demands commensurability'
   - '[source] misleads because the accounting frame turns all giving into investing and all receiving into borrowing, eliminating the possibility of genuine generosity that expects no return'
+embodied_patterns:
+  - balance
+  - flow
+  - scale
+relation_types:
+  - accumulate
+  - restore
+structure: cycle
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/social-conflict-is-war.md
+++ b/catalog/entries/social-conflict-is-war.md
@@ -29,6 +29,15 @@ limits:
   - "[source] misleads because war treats the opponent as an enemy to be defeated, obscuring that social disputants share communities, workplaces, and families"
   - "[source] obscures that social conflict can be generative -- producing new norms, institutions, and understandings -- while war produces mainly destruction and redistribution"
 updated: '2026-03-16'
+embodied_patterns:
+  - force
+  - boundary
+  - balance
+relation_types:
+  - cause
+  - transform
+structure: competition
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/social-proof.md
+++ b/catalog/entries/social-proof.md
@@ -22,6 +22,15 @@ transfers:
 - '[model] identifies cascade dynamics: once enough individuals adopt a behavior, each new adopter adds to the signal, creating a self-reinforcing positive feedback loop identical to stampedes and market
   bubbles'
 updated: '2026-03-13'
+embodied_patterns:
+  - force
+  - matching
+  - iteration
+relation_types:
+  - cause
+  - transform
+structure: competition
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/society-is-a-body.md
+++ b/catalog/entries/society-is-a-body.md
@@ -26,6 +26,15 @@ transfers:
 limits:
   - '[source] breaks because bodies have genuine neurological hierarchies (the brain controls the hand through wiring), but societies have no equivalent natural wiring that makes rulers superior to workers -- the metaphor smuggles a political claim inside a biological fact'
   - '[source] misleads because the metaphor pathologizes dissent -- protesters become fevers, dissidents become infections, and revolutions become autoimmune disorders, framing all challenge to existing order as disease'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - transform
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/software-development-is-a-bazaar.md
+++ b/catalog/entries/software-development-is-a-bazaar.md
@@ -28,6 +28,16 @@ limits:
   - "[source] misleads because bazaars have no shared product -- each vendor succeeds or fails independently -- hiding the coordination cost of many contributors working on one codebase"
   - "[source] obscures that bazaars require no trust between vendor and vendor, but open-source development requires deep mutual trust in shared commit access and code review"
 updated: '2026-03-17'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - enable
+  - compete
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/software-development-is-cathedral-building.md
+++ b/catalog/entries/software-development-is-cathedral-building.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - '[source] breaks because cathedrals serve a fixed purpose (worship) that does not shift mid-construction, while software requirements mutate constantly -- the metaphor makes requirement changes feel like heresy rather than normal feedback'
   - '[source] misleads because the revelation model hides defects -- if you do not show the building until it is done, you discover that the nave is too narrow only at consecration, systematically delaying feedback'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - contain
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/software-habitability.md
+++ b/catalog/entries/software-habitability.md
@@ -25,6 +25,15 @@ transfers:
 limits:
   - '[source] breaks because buildings communicate their structure through visible physical features (doors, hallways, load-bearing walls), while source code has no equivalent spatial legibility -- you cannot ''walk through'' a codebase and feel where the structure is'
   - '[source] misleads because the farmhouse romance obscures that organic growth without standards produces the software equivalent of inadequate wiring and lead paint -- accumulated technical debt wearing a warm aesthetic'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/software-peter-principle.md
+++ b/catalog/entries/software-peter-principle.md
@@ -24,6 +24,15 @@ limits:
   - "[source] breaks because employees are promoted by deliberate human decisions, whereas software complexity accumulates through incremental changes with no single decision point that constitutes a promotion"
   - "[source] misleads because the Peter Principle assumes a fixed competence ceiling, but software can be refactored, restructured, or rewritten to restore competence at a higher complexity level"
 updated: '2026-03-17'
+embodied_patterns:
+  - force
+  - path
+  - matching
+relation_types:
+  - cause
+  - compete
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/software-rot.md
+++ b/catalog/entries/software-rot.md
@@ -24,6 +24,15 @@ transfers:
 limits:
   - '[source] breaks because software does not physically decompose -- the bits on disk are identical years later, and what changes is the environment (libraries, OS, user expectations), making the degradation relational rather than internal'
   - '[source] misleads because rot is irreversible (you cannot un-rot an apple), but software can be updated, refactored, and restored, importing a finality that can encourage rewrites when incremental repair would suffice'
+embodied_patterns:
+  - force
+  - scale
+  - path
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: primitive
 ---
 
 ## Transfers

--- a/catalog/entries/something-roughly-in-the-middle.md
+++ b/catalog/entries/something-roughly-in-the-middle.md
@@ -25,6 +25,15 @@ limits:
   - '[source] breaks because physical spaces have a single perceivable center while digital and organizational spaces often have no spatial intuition at all, making "the middle" a metaphor that must be constructed rather than discovered'
   - '[source] misleads by implying that a single anchor suffices for any scale of gathering, when large-enough spaces require multiple anchors (Alexander himself nests this pattern within hierarchy-of-open-space) and a single central object in a vast space becomes lost rather than focal'
   - '[source] assumes the anchor is shared -- everyone converges on the same thing -- but in organizations and software systems, different constituencies may need different anchors, and forcing a single one can privilege one group''s needs over another''s'
+embodied_patterns:
+  - part-whole
+  - boundary
+  - container
+relation_types:
+  - cause
+  - transform
+structure: hierarchy
+abstraction_level: specific
 ---
 
 ## Transfers

--- a/catalog/entries/sorcerer-apprentice.md
+++ b/catalog/entries/sorcerer-apprentice.md
@@ -23,6 +23,15 @@ transfers:
 limits:
   - "[source] breaks because the master returns and restores order with superior knowledge, implying that every runaway process has a more competent authority who can intervene -- a comforting fiction that does not hold for emergent global systems like climate change or financial contagion"
   - "[source] misleads because the apprentice's motive is laziness, reducing the cautionary tale to a morality play about shortcuts, when most real automation disasters stem from competent engineers facing genuinely complex systems"
+embodied_patterns:
+  - force
+  - path
+  - boundary
+relation_types:
+  - cause
+  - prevent
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers


### PR DESCRIPTION
Auto-enriches all remaining catalog entries missing structural tags after conflicting PRs #2406, #2409, #2411 were closed.

Covers 200 entries from logical-relations through zone-of-proximal-development.
Completes the structural enrichment sweep — after this merges, zero entries will be missing tags.

Part of the structural enrichment sweep.
See: docs/plans/2026-03-20-structural-enrichment-vocabulary.md