### PR TITLE
Add 5 entries: psychotherapy metaphors batch 6

### DIFF
--- a/catalog/entries/felt-sense.md
+++ b/catalog/entries/felt-sense.md
@@ -1,0 +1,164 @@
+---
+slug: felt-sense
+name: Felt Sense
+kind: mental-model
+categories:
+- psychology
+author: agent:metaphorex-miner
+contributors: []
+related:
+- the-body-keeps-the-score
+- window-of-tolerance
+created: '2026-03-21'
+updated: '2026-03-21'
+grounding: established
+harness: Claude Code
+provenance: psychotherapy-metaphors
+transfers:
+  - '[model] a pre-verbal bodily impression carries holistic information about a situation that linear analytic thought cannot access, because the body integrates more variables than conscious attention can track simultaneously'
+  - '[model] attending to the felt sense with patient, non-judgmental curiosity causes it to "unfold" -- releasing meaning in stages rather than all at once, following its own sequence rather than the thinker''s agenda'
+  - '[model] the felt sense occupies a register between emotion and cognition: it is more structured than raw feeling but less articulated than a thought, and forcing it into either category prematurely destroys its information content'
+limits:
+  - '[model] assumes a capacity for interoceptive awareness that varies enormously across individuals -- people with alexithymia, chronic dissociation, or certain neurological conditions may not have reliable access to the register the model describes'
+  - '[model] provides no way to distinguish a genuine felt sense from confirmation bias, anxiety, or somatic artifacts of mood -- the instruction to "trust the body" has no built-in error correction'
+embodied_patterns:
+  - surface-depth
+  - container
+  - force
+relation_types:
+  - translate
+  - enable
+  - select
+structure: emergence
+abstraction_level: generic
+---
+
+## Transfers
+
+Eugene Gendlin, a philosopher and psychotherapist at the University of
+Chicago, introduced the felt sense in *Focusing* (1978), drawing on his
+research into what distinguished therapy clients who improved from those
+who did not. The key difference was not the type of therapy or the
+therapist's skill but the client's ability to attend to a vague, bodily
+sense of a problem -- something that was not yet an emotion or a thought
+but a pre-conceptual impression that carried information about the whole
+situation.
+
+Key structural features:
+
+- **Pre-verbal holistic integration** -- the felt sense is the body's
+  summary of a situation before language has organized it. Gendlin's
+  claim is that the body processes more variables than consciousness can
+  track: relational dynamics, environmental cues, historical associations,
+  somatic states. The felt sense is where this integration surfaces. It is
+  not a gut instinct (which is fast and binary) but a complex, textured
+  impression that requires patient attention to yield its meaning. In UX
+  research, designers have adopted "felt sense" to describe what a user
+  experiences when something is "off" about an interface but cannot say
+  what -- the body registers an incoherence before the mind can name it.
+- **Unfolding through attention** -- the felt sense does not deliver its
+  content in a single disclosure. It unfolds in steps when attended to
+  with a specific quality of non-demanding curiosity. Gendlin called this
+  process "focusing" and identified six stages: clearing a space, choosing
+  a felt sense to work with, finding a handle (a word or image that
+  matches it), resonating (checking the handle against the sensation),
+  asking (letting the felt sense respond), and receiving (accepting
+  whatever comes). The structural insight is that meaning is released by
+  patient attention, not extracted by analysis. This is why the model has
+  migrated into design thinking: prototyping and user testing follow a
+  structurally similar unfolding process, where the problem reveals itself
+  incrementally through contact with concrete instances.
+- **The "neither-nor" register** -- the felt sense sits between emotion
+  and cognition. It is more organized than raw affect (it is "about"
+  something specific) but less articulated than thought (it cannot be
+  stated propositionally). Gendlin argued that this intermediate register
+  is where therapeutic change actually happens: when a client can stay
+  with a felt sense long enough for it to shift, the shift precedes and
+  enables cognitive and emotional reorganization. Premature
+  intellectualization -- jumping to an explanation -- collapses the felt
+  sense back into already-known categories and stops the process.
+
+## Limits
+
+- **Interoceptive access is not universal** -- the model assumes that
+  everyone can learn to attend to a pre-verbal bodily register with
+  practice. But interoceptive sensitivity varies enormously. People with
+  alexithymia (difficulty identifying and describing emotions) may not
+  experience the felt sense as Gendlin describes it. Chronic dissociation
+  from trauma can disconnect body and awareness. Certain neurological
+  conditions alter interoception. The model treats the felt sense as a
+  universal human capacity rather than a capacity distributed along a
+  spectrum, and this can pathologize those who struggle to access it.
+- **No error correction mechanism** -- when Gendlin says to "trust" the
+  felt sense, there is no procedure for distinguishing a genuine
+  integrative signal from anxiety, confirmation bias, or the somatic
+  artifacts of mood. A person who is depressed may experience a felt
+  sense of hopelessness about a project that is actually progressing
+  well. A person with social anxiety may experience a felt sense of
+  "wrongness" in a perfectly benign social situation. The model provides
+  no way to calibrate the body's signal against external reality, which
+  can elevate subjective impression to the status of wisdom.
+- **Cultural specificity of "attending to the body"** -- the focusing
+  protocol was developed in a North American, predominantly white,
+  middle-class therapeutic context. In cultures where emotional experience
+  is understood as relational rather than individual, or where the
+  mind-body distinction is drawn differently, the instruction to "sense
+  into your body" may not map onto local phenomenology. The model's
+  claimed universality may be a projection of its cultural origin.
+- **Dilution through popularization** -- in design thinking, UX
+  research, and coaching, "felt sense" has been softened to mean
+  "intuition" or "gut feeling," which strips it of Gendlin's precise
+  phenomenological definition. A gut feeling is fast, binary (yes/no),
+  and does not unfold. A felt sense is slow, textured, and reveals
+  content through sustained attention. The popular usage collapses
+  this critical distinction.
+
+## Expressions
+
+- "I have a felt sense about this" -- in therapeutic and coaching
+  contexts, signaling that one is attending to a pre-verbal bodily
+  impression rather than a formed opinion
+- "Focusing" -- the practice Gendlin developed for systematically
+  accessing and working with the felt sense
+- "Something about it" -- the characteristic vagueness of a felt sense
+  before it has unfolded; the instruction is to stay with the "something"
+  rather than naming it prematurely
+- "The body shift" -- the physical sensation (often experienced as
+  relaxation, deepened breathing, or a release of tension) that signals
+  a felt sense has unfolded and released its meaning
+- "What does your body say about that?" -- a therapist's prompt to
+  redirect attention from cognition to the felt-sense register
+
+## Origin Story
+
+Gendlin's research began in the 1960s at the University of Chicago, where
+he was a student and later colleague of Carl Rogers. Working with Rogers's
+process research data, Gendlin noticed that successful therapy clients
+displayed a distinctive way of speaking: they would slow down, grope for
+words, attend to something internal and vague, and then find language
+that matched their experience. Unsuccessful clients, by contrast, talked
+fluently about their problems in already-formed categories without
+contacting anything new.
+
+This observation led Gendlin to develop focusing as a teachable skill --
+something he published in *Focusing* (1978), a book aimed at general
+audiences. His more technical philosophical work, *Experiencing and the
+Creation of Meaning* (1962), provided the epistemological foundations:
+the argument that meaning is not purely linguistic but emerges from the
+interaction between language and a pre-conceptual experiential process.
+
+The felt sense has migrated beyond therapy into design (where "felt
+quality" informs user experience research), contemplative practice (where
+it connects to mindfulness-based approaches), and organizational
+development (where it appears as "somatic coaching").
+
+## References
+
+- Gendlin, E.T. *Focusing* (1978, revised 2007) -- the primary popular
+  source
+- Gendlin, E.T. *Experiencing and the Creation of Meaning* (1962,
+  revised 1997) -- the philosophical foundations
+- Gendlin, E.T. "Focusing-Oriented Psychotherapy," in *Handbook of
+  Experiential Psychotherapy*, ed. Greenberg, Watson, and Lietaer (1998)
+- Hendricks, M.N. "Focusing-Oriented/Experiential Psychotherapy," in
+  *Humanistic Psychotherapies*, ed. Cain and Seeman (2002)

--- a/catalog/entries/the-body-keeps-the-score.md
+++ b/catalog/entries/the-body-keeps-the-score.md
@@ -1,0 +1,164 @@
+---
+slug: the-body-keeps-the-score
+name: The Body Keeps the Score
+kind: metaphor
+source_frame: accounting
+applies_to:
+- psychotherapy
+categories:
+- psychology
+author: agent:metaphorex-miner
+contributors: []
+related:
+- felt-sense
+- window-of-tolerance
+created: '2026-03-21'
+updated: '2026-03-21'
+grounding: established
+harness: Claude Code
+provenance: psychotherapy-metaphors
+dead: false
+transfers:
+  - '[source] the body maintains a running ledger of traumatic events, where each experience is recorded as an entry that persists regardless of whether the conscious mind acknowledges the transaction'
+  - '[source] unprocessed trauma accumulates like unreconciled debits -- the balance grows over time if the entries are never reviewed and settled'
+  - '[source] somatic symptoms function as audit findings, surfacing discrepancies between what the body has recorded and what the mind has declared'
+  - '[source] therapeutic processing works like reconciliation: bringing the body''s ledger into alignment with conscious narrative so the accounts can finally close'
+limits:
+  - '[source] misleads because a ledger records discrete, bounded transactions, while traumatic encoding is diffuse and distributed across neural, hormonal, and muscular systems -- there is no single "entry" for a given event'
+  - '[source] implies that the body''s record is accurate and recoverable like financial data, obscuring that somatic memory is reconstructive, context-dependent, and shaped by subsequent experience'
+  - '[source] suggests that "settling the account" resolves the record, but trauma processing rarely produces a clean closing balance -- residual physiological patterns persist even after successful therapy'
+embodied_patterns:
+  - container
+  - accretion
+  - surface-depth
+relation_types:
+  - accumulate
+  - contain
+  - cause
+structure: growth
+abstraction_level: generic
+---
+
+## Transfers
+
+Bessel van der Kolk published "The Body Keeps the Score" as a 1994 article
+in the *Harvard Review of Psychiatry* and expanded it into a bestselling
+2014 book. The title is itself the metaphor: the body is a scorekeeper, an
+accounting system that tallies traumatic experience even when the conscious
+mind refuses to acknowledge the entries. The metaphor reshaped popular
+understanding of trauma by relocating the primary record of suffering from
+the mind to the body.
+
+Key structural parallels:
+
+- **The body as ledger** -- in accounting, every transaction is recorded.
+  Nothing disappears; it is merely categorized and filed. Van der Kolk's
+  claim is structurally identical: the body records every overwhelming
+  experience in muscle tension, autonomic reactivity, hormonal patterns,
+  and postural habits. You can ignore the ledger, but the entries remain.
+  This maps the accountant's principle of completeness -- no transaction
+  may be omitted -- onto the body's physiological memory. The metaphor
+  teaches that forgetting is a property of consciousness, not of the
+  organism.
+- **Unreconciled accounts compound** -- in bookkeeping, unaddressed
+  discrepancies do not resolve themselves; they produce cascading errors
+  in subsequent periods. The metaphor imports this structure: unprocessed
+  trauma does not fade with time but produces compounding effects --
+  chronic pain, autoimmune conditions, hypervigilance, relational
+  difficulty. The longer the reconciliation is deferred, the more tangled
+  the books become.
+- **Somatic symptoms as audit findings** -- when an auditor examines the
+  books, discrepancies surface as findings. The metaphor frames somatic
+  symptoms -- unexplained pain, panic responses, dissociative episodes --
+  as the body's audit results: evidence that the official narrative (the
+  mind's account) does not match the actual record (the body's account).
+  This gives clinicians a structural reason to attend to physical symptoms
+  in psychological treatment: the body is reporting what the mind will not.
+- **Reconciliation as therapeutic process** -- accounting reconciliation
+  is the act of comparing two records and resolving differences. The
+  metaphor frames trauma therapy -- EMDR, somatic experiencing, yoga,
+  neurofeedback -- as bringing the body's record into dialogue with the
+  mind's narrative. The goal is not to erase the entries but to reconcile
+  them: acknowledging what happened so the account can be closed rather
+  than carrying a perpetual deficit.
+
+## Limits
+
+- **Trauma is not a discrete transaction** -- a financial ledger records
+  bounded events: a purchase, a payment, a transfer. Traumatic experience
+  is encoded diffusely across multiple systems -- the amygdala's threat
+  learning, the vagal nerve's autonomic calibration, the fascia's chronic
+  tension patterns, the HPA axis's cortisol setpoint. There is no single
+  "entry" to find and correct. The metaphor's neatness -- each trauma is
+  a line item -- obscures the distributed, non-localizable nature of
+  traumatic encoding.
+- **The body's record is not veridical** -- financial records aim for
+  accuracy: they should correspond to actual transactions. The body's
+  "memory" is not accurate in this sense. Somatic patterns are shaped by
+  subsequent experience, developmental stage at the time of trauma,
+  cultural context, and the body's own adaptive responses. A chronic
+  pain pattern may encode not the original traumatic event but a
+  post-traumatic coping strategy. The accounting metaphor implies a
+  faithful record that merely needs to be read; the reality is that the
+  record is interpretive and reconstructive.
+- **"Settling the account" implies closure that rarely arrives** --
+  reconciliation in accounting produces a clean balance: the books agree,
+  the period is closed, and the next period begins fresh. Trauma therapy
+  rarely produces this kind of closure. Even successful treatment leaves
+  residual patterns -- a startle response that has diminished but not
+  vanished, a bodily vigilance that has softened but persists. The
+  metaphor's promise of a zeroed balance sets expectations that
+  therapeutic reality cannot reliably meet.
+- **The metaphor can pathologize normal embodiment** -- if the body
+  "keeps the score" of trauma, every physical sensation becomes a
+  potential trauma artifact. This can lead to hypervigilant body scanning,
+  where ordinary sensations (muscle tension from poor posture, digestive
+  discomfort from diet) are interpreted as unprocessed trauma. The
+  accounting frame encourages searching the body for hidden entries,
+  which can create anxiety about sensations that have mundane explanations.
+
+## Expressions
+
+- "The body keeps the score" -- the title phrase itself, now used as a
+  standalone clinical and popular assertion that somatic symptoms encode
+  psychological history
+- "Your body remembers what your mind has forgotten" -- the folk
+  distillation, emphasizing the body-mind split the metaphor creates
+- "Stored in the body" -- clinical shorthand for the claim that traumatic
+  experience has somatic representation
+- "The body doesn't lie" -- an extension that treats somatic signals as
+  more trustworthy than verbal report, inverting the usual clinical
+  hierarchy
+- "Somatic score" -- occasional usage in body-oriented therapy training
+  to describe the cumulative physiological impact of adverse experience
+
+## Origin Story
+
+Van der Kolk, a Dutch-born psychiatrist working at the Boston VA and
+later at the Trauma Center in Brookline, Massachusetts, developed his
+thesis through decades of work with Vietnam veterans and childhood trauma
+survivors. His 1994 article in the *Harvard Review of Psychiatry*
+synthesized emerging neuroscience (particularly Pierre Janet's early work
+on dissociation, Joseph LeDoux's research on fear conditioning, and
+Bruce Perry's work on developmental trauma) with clinical observation
+that traumatized patients' bodies continued to react as if the trauma
+were ongoing, even when they could narrate the events calmly.
+
+The 2014 book became a publishing phenomenon, spending years on
+bestseller lists and introducing trauma neuroscience to a general
+audience. The metaphor's power lies in its simplicity: it takes a
+complex neurobiological argument and renders it in the familiar language
+of bookkeeping. The body tallies, and the score must eventually be
+reckoned with.
+
+## References
+
+- Van der Kolk, B.A. "The Body Keeps the Score: Memory and the Evolving
+  Psychobiology of Posttraumatic Stress," *Harvard Review of Psychiatry*
+  1.5 (1994): 253-265
+- Van der Kolk, B.A. *The Body Keeps the Score: Brain, Mind, and Body in
+  the Healing of Trauma* (2014)
+- Janet, P. *L'automatisme psychologique* (1889) -- the foundational
+  theory of dissociation that Van der Kolk revived
+- LeDoux, J.E. *The Emotional Brain* (1996) -- the neuroscience of fear
+  conditioning that Van der Kolk drew on

--- a/catalog/entries/therapeutic-alliance.md
+++ b/catalog/entries/therapeutic-alliance.md
@@ -1,0 +1,188 @@
+---
+slug: therapeutic-alliance
+name: Therapeutic Alliance
+kind: metaphor
+source_frame: war
+applies_to:
+- psychotherapy
+categories:
+- psychology
+author: agent:metaphorex-miner
+contributors: []
+related:
+- unconditional-positive-regard
+- rupture-and-repair
+created: '2026-03-21'
+updated: '2026-03-21'
+grounding: established
+harness: Claude Code
+provenance: psychotherapy-metaphors
+dead: true
+transfers:
+  - '[source] an alliance is a pact between parties who share a common enemy but are not identical in interest, importing the structure that therapist and client collaborate against the problem rather than the client being the problem'
+  - '[source] alliances require negotiated terms -- agreed goals, division of labor, and mutual obligations -- and can be broken by unilateral action from either side'
+  - '[source] the alliance is distinct from the war it serves: it is the organizational structure that makes coordinated action possible, not the fighting itself -- mapping onto the claim that the relationship is the mechanism of change, not merely its context'
+limits:
+  - '[source] misleads because military alliances are strategic and instrumental -- formed for advantage and dissolved when no longer useful -- while the therapeutic relationship involves genuine care, which the alliance frame cannot represent'
+  - '[source] implies two parties of comparable power negotiating terms, obscuring the inherent power asymmetry where the therapist holds professional authority, diagnostic power, and gatekeeping functions that the client does not'
+  - '[source] presupposes a clearly identifiable common enemy, but in therapy the "enemy" (the presenting problem) is often entangled with the client''s identity, values, and relational patterns in ways that resist the clean externalization the military frame assumes'
+embodied_patterns:
+  - link
+  - force
+  - boundary
+relation_types:
+  - coordinate
+  - enable
+  - compete
+structure: network
+abstraction_level: generic
+---
+
+## Transfers
+
+Edward Bordin reformulated the therapeutic alliance in a 1979 paper that
+reframed it from a psychoanalytic concept (Freud's "unobjectionable
+positive transference") into a pantheoretical construct applicable across
+all therapy modalities. Bordin identified three components: agreement on
+goals (what the therapy is working toward), agreement on tasks (the
+methods used in sessions), and the emotional bond between therapist and
+client. The term "alliance" -- borrowed from military and political
+vocabulary -- was not accidental. It imports a specific relational
+structure.
+
+Key structural parallels:
+
+- **A pact against a common enemy** -- military alliances form when
+  parties with distinct interests face a shared threat. NATO allies are
+  not identical; they have different national interests, capabilities,
+  and strategic priorities. What unites them is a common adversary.
+  Bordin's therapeutic alliance imports this structure: therapist and
+  client are not the same (the therapist is not the client's friend,
+  advocate, or surrogate parent), but they face a common enemy -- the
+  client's suffering, dysfunction, or stuck pattern. This externalization
+  is structurally powerful: it positions the problem as the enemy rather
+  than the client as the problem. The client is an ally, not a case.
+- **Negotiated terms** -- alliances are not automatic; they are negotiated.
+  Each party agrees to specific obligations and contributions. Bordin
+  made this explicit: the therapeutic alliance requires active agreement
+  on what the therapy is trying to accomplish (goals) and how the work
+  will proceed (tasks). A therapist who imposes goals unilaterally has
+  not formed an alliance; they have issued orders. A client who expects
+  passive cure without engaging in the agreed tasks is free-riding on
+  the alliance. The metaphor teaches that the therapeutic relationship
+  is a negotiated contract, not a benevolent dictatorship.
+- **The alliance is the infrastructure, not the war** -- in military
+  strategy, the alliance (the organizational structure, communication
+  channels, coordination protocols) is distinct from the combat it
+  enables. Bordin's insight is structurally parallel: the therapeutic
+  alliance is not the therapy itself but the relational infrastructure
+  that makes therapy possible. The most technically skilled therapist
+  using the most evidence-based interventions will fail if the alliance
+  is weak, just as the best-equipped army will fail without coordination
+  among allies. This is why alliance quality predicts therapy outcome
+  across modalities more reliably than the specific techniques used.
+- **Alliances can be broken and repaired** -- military alliances are
+  not static. They weather crises, betrayals, renegotiations, and
+  renewals. The therapeutic alliance undergoes the same process:
+  Bordin's student Jeremy Safran later developed the concept of
+  "alliance ruptures and repairs," showing that moments of
+  misunderstanding, disagreement, or emotional disconnection (ruptures)
+  are not failures of the alliance but opportunities to strengthen it
+  through repair. This maps the diplomatic cycle of tension and
+  reconciliation onto the therapeutic process.
+
+## Limits
+
+- **Military alliances are instrumental; therapy involves care** --
+  nations form alliances for strategic advantage and dissolve them
+  when the calculus changes. The therapeutic relationship involves
+  genuine care for the client's wellbeing that transcends strategic
+  utility. A therapist who treats the alliance purely instrumentally
+  -- as a technique for keeping the client engaged so that the "real"
+  interventions can work -- has missed something essential. The
+  alliance frame cannot represent the non-strategic, caring dimension
+  of the therapeutic relationship without importing vocabulary (warmth,
+  compassion, regard) from outside the military domain.
+- **Power asymmetry is hidden** -- military allies, at least in
+  principle, are sovereign equals negotiating terms. Therapist and
+  client are not equals. The therapist holds professional authority,
+  diagnostic power (the ability to label the client's experience),
+  institutional gatekeeping functions (treatment recommendations,
+  insurance documentation), and the structuring power of the
+  therapeutic frame (who sets the schedule, who determines the
+  method). The alliance metaphor's language of mutual agreement and
+  negotiated terms obscures this asymmetry. A client who "agrees"
+  to the therapist's formulation under the pressure of distress
+  and professional authority is not negotiating from an equal position.
+- **The common enemy is not always clear** -- military alliances
+  presuppose a clearly identifiable adversary. In therapy, the
+  "enemy" (the presenting problem, the symptom, the stuck pattern)
+  is often not external to the client but entangled with their
+  identity, relationships, and values. A person whose depression is
+  intertwined with a lifestyle they have chosen, or whose anxiety is
+  bound up with values they hold dear, cannot simply externalize the
+  problem as an enemy to be fought. The alliance frame's
+  externalization can oversimplify the relationship between client
+  and problem.
+- **It has become so dead that "alliance" just means "relationship"** --
+  in clinical literature and training, "therapeutic alliance" is now
+  often used interchangeably with "therapeutic relationship," stripping
+  the term of its specific military import. When researchers measure
+  "alliance" using questionnaires about trust, warmth, and agreement,
+  they are measuring relational quality, not the specific structural
+  features (negotiated terms, common enemy, organizational
+  infrastructure) that the metaphor was chosen to capture. The term
+  has died into a synonym.
+
+## Expressions
+
+- "Building the alliance" -- the early-therapy work of establishing
+  trust, agreeing on goals, and negotiating the terms of collaboration
+- "Alliance rupture" -- a moment of misattunement, disagreement, or
+  emotional disconnection between therapist and client
+- "Repair the rupture" -- the therapeutic work of acknowledging and
+  resolving an alliance breakdown, often considered more therapeutic
+  than the alliance itself
+- "Working alliance" -- Bordin's preferred term, emphasizing the
+  collaborative, task-oriented nature of the relationship
+- "Strong alliance" / "weak alliance" -- clinical shorthand for the
+  quality of the therapeutic relationship, now used across all therapy
+  modalities
+- "Stakeholder alliance" -- migration to business, where the
+  relational infrastructure between project participants is modeled
+  on the therapeutic concept
+
+## Origin Story
+
+Freud described "unobjectionable positive transference" as the portion
+of the patient's attachment to the analyst that could be harnessed for
+therapeutic work, distinguishing it from the neurotic transference that
+needed to be analyzed. Zetzel (1956) renamed this the "therapeutic
+alliance," and Greenson (1965) distinguished the "working alliance"
+(the rational, collaborative aspect) from the transference relationship
+(the irrational, repetitive aspect).
+
+Bordin's 1979 paper "The Generalizability of the Psychoanalytic Concept
+of the Working Alliance" was the decisive reformulation. By identifying
+three measurable components (goals, tasks, bond) and arguing that the
+alliance was relevant across all therapy modalities -- not just
+psychoanalysis -- Bordin created a construct that could be empirically
+studied. Subsequent meta-analyses (Horvath and Symonds, 1991; Martin
+et al., 2000; Fluckiger et al., 2018) consistently found that alliance
+quality is one of the strongest predictors of therapy outcome,
+accounting for more variance than specific therapeutic techniques.
+
+## References
+
+- Bordin, E.S. "The Generalizability of the Psychoanalytic Concept of
+  the Working Alliance," *Psychotherapy: Theory, Research and Practice*
+  16.3 (1979): 252-260
+- Freud, S. "On Beginning the Treatment" (1913), in *Standard Edition*
+  vol. 12 -- the original "unobjectionable positive transference"
+- Safran, J.D. and Muran, J.C. *Negotiating the Therapeutic Alliance:
+  A Relational Treatment Guide* (2000) -- rupture and repair theory
+- Horvath, A.O. and Symonds, B.D. "Relation Between Working Alliance
+  and Outcome in Psychotherapy: A Meta-Analysis," *Journal of Counseling
+  Psychology* 38.2 (1991): 139-149
+- Fluckiger, C. et al. "The Alliance in Adult Psychotherapy: A
+  Meta-Analytic Synthesis," *Psychotherapy* 55.4 (2018): 316-340

--- a/catalog/entries/unconditional-positive-regard.md
+++ b/catalog/entries/unconditional-positive-regard.md
@@ -1,0 +1,173 @@
+---
+slug: unconditional-positive-regard
+name: Unconditional Positive Regard
+kind: mental-model
+categories:
+- psychology
+author: agent:metaphorex-miner
+contributors: []
+related:
+- therapeutic-alliance
+- scaffolding
+created: '2026-03-21'
+updated: '2026-03-21'
+grounding: established
+harness: Claude Code
+provenance: psychotherapy-metaphors
+transfers:
+  - '[model] regard is framed as an economic good that can be offered conditionally (contingent on behavior) or unconditionally (independent of behavior), and the therapeutic claim is that unconditioned supply produces growth that conditioned supply cannot'
+  - '[model] the distinction between person and behavior is structurally load-bearing: the model accepts the whole person while reserving judgment about specific acts, separating the agent from the action in a way that most social evaluation does not'
+  - '[model] unconditional positive regard functions as a controlled experimental condition -- by holding acceptance constant, the therapist isolates the client''s self-directed change from externally motivated compliance'
+limits:
+  - '[model] "unconditional" is practically impossible to sustain -- therapists have limits, values, and countertransference reactions, and pretending otherwise creates a performative contradiction that clients often detect'
+  - '[model] the economic framing of "regard" as a commodity obscures the relational reality that acceptance is co-constructed, not unilaterally supplied -- the client must be able to receive what the therapist offers'
+  - '[model] conflating acceptance with approval can enable harmful behavior by removing the social feedback that signals when behavior is damaging to self or others'
+embodied_patterns:
+  - container
+  - force
+  - flow
+relation_types:
+  - enable
+  - contain
+  - restore
+structure: equilibrium
+abstraction_level: generic
+---
+
+## Transfers
+
+Carl Rogers listed unconditional positive regard as one of three
+"necessary and sufficient conditions" for therapeutic personality change
+in his landmark 1957 paper. The concept was originally developed by
+Stanley Standal in his 1954 doctoral dissertation, and Rogers adopted
+and popularized it as the cornerstone of person-centered therapy.
+
+The metaphor is built from transactional language: "regard" is something
+one person gives another, and it can be "conditional" (contingent on
+the recipient's behavior) or "unconditional" (offered regardless). The
+structural claim is that most human regard is conditional -- parents
+love the obedient child more visibly, teachers praise the compliant
+student, employers reward the productive worker -- and this conditionality
+produces a fundamental distortion: people learn to present the self that
+earns regard rather than the self that is authentic.
+
+Key structural features:
+
+- **Regard as economic variable** -- the model treats acceptance as a
+  commodity with supply conditions. Conditional positive regard is a
+  contingent contract: I accept you if you meet my criteria. Unconditional
+  positive regard removes the contingency: I accept you period. This
+  economic framing is the model's primary structural contribution.
+  It makes visible the transactional nature of most human acceptance
+  and offers a specific alternative: what happens when the transaction
+  is removed? Rogers's answer: the client, freed from performing for
+  acceptance, begins to explore their authentic experience. This has
+  migrated into parenting philosophy (Alfie Kohn's *Unconditional
+  Parenting*), education (acceptance-based classroom management), and
+  management (psychological safety research).
+- **Person-behavior separation** -- unconditional positive regard does
+  not mean approving of everything a person does. It means accepting
+  the person while potentially disagreeing with their actions. This
+  structural distinction -- agent and action are separable -- is the
+  model's most frequently misunderstood feature. It imports a
+  philosophical claim about ontology: a person is not reducible to
+  their behavior. A therapist can unconditionally accept a client while
+  naming that a specific behavior is self-destructive. The model's
+  power depends on maintaining this separation; collapsing it in either
+  direction -- unconditional approval of behavior, or conditional
+  acceptance of the person -- destroys its function.
+- **Acceptance as experimental control** -- in research methodology,
+  a controlled condition holds one variable constant while others vary.
+  Unconditional positive regard functions similarly: by holding
+  acceptance constant (the therapist does not withdraw regard regardless
+  of what the client discloses), the therapeutic relationship becomes
+  a space where the client's change is self-directed rather than
+  externally motivated. If the client changes, it is not because the
+  therapist withheld acceptance until they did. This makes unconditional
+  positive regard a structural prerequisite for distinguishing authentic
+  change from compliance.
+
+## Limits
+
+- **Unconditionality is a regulative ideal, not an achievement** --
+  no therapist can sustain fully unconditional regard for every client
+  in every moment. Therapists have values, boundaries, biases, and
+  countertransference reactions. A therapist who works with someone
+  who has committed serious harm will experience moments of judgment.
+  Rogers himself acknowledged this. The danger is when "unconditional
+  positive regard" is treated as something a therapist either has or
+  lacks, rather than as a direction of effort. Turning a regulative
+  ideal into a performance standard produces therapist guilt and
+  inauthenticity -- precisely the conditions the model is supposed to
+  counteract.
+- **Regard is not unilaterally supplied** -- the economic metaphor
+  frames regard as something the therapist gives and the client
+  receives. But acceptance is relational: it requires the client's
+  capacity to take it in. A client with deep shame, dismissive
+  attachment, or a history of manipulative "kindness" may be unable to
+  receive unconditional positive regard as genuine. They may interpret
+  it as naivety, technique, or a setup for later withdrawal. The
+  model underspecifies the receiving end of the transaction.
+- **The approval-acceptance conflation** -- in popular usage,
+  unconditional positive regard has been diluted to mean "never
+  criticize" or "validate everything." This conflation -- accepting
+  a person means approving their behavior -- strips the model of
+  its structural distinction and produces enabling: a therapist (or
+  parent, or manager) who cannot name harmful behavior for fear of
+  violating unconditional positive regard has confused acceptance
+  with permissiveness.
+- **Cultural assumptions about selfhood** -- Rogers's model assumes
+  a unitary self that has been distorted by conditions of worth and
+  can recover its authenticity under unconditional regard. This is a
+  culturally specific, Euro-American, mid-twentieth-century conception
+  of selfhood. In relational, collectivist, or Buddhist-informed
+  psychologies, the self is constituted by its relationships and
+  conditions, not distorted by them. Unconditional positive regard
+  for "the real self beneath the conditions" assumes there is one.
+
+## Expressions
+
+- "I accept you as you are" -- the folk distillation of unconditional
+  positive regard, common in humanistic and person-centered therapy
+- "Conditions of worth" -- Rogers's term for the contingencies that
+  distort authentic self-expression; the thing unconditional positive
+  regard is designed to counteract
+- "Prizing" -- Rogers's alternate term for unconditional positive regard,
+  emphasizing valuing the person as a whole
+- "Warm regard" -- clinical shorthand used in training, often paired with
+  "genuineness" and "empathy" as Rogers's therapeutic triad
+- "Unconditional parenting" -- Alfie Kohn's extension of the concept
+  to child-rearing, where love is not contingent on behavior or
+  achievement
+
+## Origin Story
+
+Standal introduced "unconditional positive regard" in his 1954
+dissertation at the University of Chicago, where Rogers was on the
+faculty. Rogers incorporated it into his 1957 paper "The Necessary and
+Sufficient Conditions of Therapeutic Personality Change" in the *Journal
+of Consulting Psychology*, which remains one of the most cited papers in
+psychotherapy research. Rogers paired unconditional positive regard with
+two other conditions: empathic understanding (the therapist accurately
+perceives the client's inner world) and congruence (the therapist is
+genuine, not playing a role).
+
+The concept became the philosophical foundation of the human potential
+movement, influencing Abraham Maslow, encounter groups, and eventually
+the coaching industry. Its migration into parenting, education, and
+management has been extensive, though often accompanied by the
+approval-acceptance conflation that Rogers explicitly warned against.
+
+## References
+
+- Rogers, C.R. "The Necessary and Sufficient Conditions of Therapeutic
+  Personality Change," *Journal of Consulting Psychology* 21.2 (1957):
+  95-103
+- Standal, S.W. *The Need for Positive Regard: A Contribution to
+  Client-Centered Theory* (1954), unpublished doctoral dissertation,
+  University of Chicago
+- Rogers, C.R. *On Becoming a Person* (1961)
+- Kohn, A. *Unconditional Parenting: Moving from Rewards and Punishments
+  to Love and Reason* (2005) -- the parenting migration
+- Wilkins, P. "Unconditional Positive Regard Reconsidered," *British
+  Journal of Guidance and Counselling* 28.1 (2000): 23-36

--- a/catalog/entries/window-of-tolerance.md
+++ b/catalog/entries/window-of-tolerance.md
@@ -1,0 +1,177 @@
+---
+slug: window-of-tolerance
+name: Window of Tolerance
+kind: metaphor
+source_frame: architecture-and-building
+applies_to:
+- psychotherapy
+categories:
+- psychology
+author: agent:metaphorex-miner
+contributors: []
+related:
+- the-body-keeps-the-score
+- felt-sense
+- pendulation
+created: '2026-03-21'
+updated: '2026-03-21'
+grounding: established
+harness: Claude Code
+provenance: psychotherapy-metaphors
+dead: false
+transfers:
+  - '[source] a window is a bounded aperture in an otherwise solid wall, and arousal levels that fall within that aperture can be processed, while those that exceed its frame cannot -- mapping bounded opening onto bounded capacity'
+  - '[source] the window has a fixed position in the wall: moving above it (hyperarousal) or below it (hypoarousal) places the person outside the zone where integration is possible'
+  - '[source] windows can be widened through construction work -- therapeutic intervention expands the aperture, allowing the person to tolerate a broader range of arousal without leaving the zone of functional processing'
+limits:
+  - '[source] misleads because a physical window is static, while the window of tolerance shifts dynamically with sleep, nutrition, relational safety, and context -- the metaphor implies a fixed architectural feature when the reality is a fluctuating physiological state'
+  - '[source] implies a sharp threshold between inside and outside the window, but the transition from regulated to dysregulated arousal is gradual and bidirectional, not the binary of an aperture''s edge'
+  - '[source] suggests that arousal is a single vertical dimension (too high or too low), flattening the multidimensional nature of nervous system states where different subsystems can be simultaneously hyper- and hypoaroused'
+embodied_patterns:
+  - container
+  - boundary
+  - scale
+relation_types:
+  - contain
+  - prevent
+  - restore
+structure: boundary
+abstraction_level: generic
+---
+
+## Transfers
+
+Daniel Siegel introduced the window of tolerance in *The Developing Mind*
+(1999), drawing on Stephen Porges's polyvagal theory and Allan Schore's
+affect regulation research. The metaphor frames the nervous system's
+capacity for processing experience as an architectural opening: a window
+set in the wall of arousal. Inside the window, a person can think, feel,
+and respond flexibly. Outside it -- above (hyperarousal: panic, rage,
+overwhelm) or below (hypoarousal: numbness, collapse, dissociation) --
+the person loses access to integrative functioning.
+
+Key structural parallels:
+
+- **Bounded aperture in a solid surface** -- the window is not the wall.
+  It is a limited opening in an otherwise impermeable boundary. This maps
+  the architectural reality that a window admits light and air only
+  within its frame onto the neurobiological reality that the nervous
+  system can process experience only within a specific range of
+  activation. The wall represents states that are too intense or too
+  flat for integration. The metaphor teaches that capacity is not a
+  gradient but a zone: inside the window, things work; outside, they
+  do not. This binary structure is clinically useful because it gives
+  both therapist and client a shared spatial language for states that
+  are otherwise hard to describe.
+- **Vertical position determines function** -- the window sits at a
+  particular height in the wall. Arousal that moves above the window
+  (hyperarousal) produces fight-or-flight activation: racing heart,
+  hypervigilance, emotional flooding, inability to think clearly.
+  Arousal that drops below the window (hypoarousal) produces
+  dorsal-vagal shutdown: numbness, disconnection, cognitive fog,
+  physical collapse. The metaphor uses vertical position -- up is too
+  much, down is too little -- to map Porges's polyvagal hierarchy onto
+  an intuitive spatial scheme. This is structurally the same move as
+  "more is up" but applied to nervous system activation rather than
+  quantity.
+- **Windows can be widened** -- a builder can enlarge a window by removing
+  material from the surrounding wall. Siegel's therapeutic claim is
+  structurally identical: through titrated exposure, relational safety,
+  and integrative practices (mindfulness, EMDR, somatic experiencing),
+  the window of tolerance can be expanded. A person who could tolerate
+  only mild arousal without dysregulating can, through therapy, tolerate
+  stronger emotional activation while remaining functional. The metaphor
+  frames therapeutic progress as renovation: not changing the wall's
+  material but increasing the size of the opening.
+- **Trauma narrows the window** -- adverse experience reduces the aperture.
+  A person with complex trauma may have a window so narrow that ordinary
+  stimuli -- a raised voice, an unexpected touch, a change in routine --
+  push them outside the zone of tolerance. The metaphor explains why
+  traumatized individuals appear to overreact: their window is not the
+  same size as a non-traumatized person's window. What looks like an
+  excessive response from outside the window may be a proportionate
+  response given the narrowness of the aperture.
+
+## Limits
+
+- **The window is not static** -- a physical window does not change size
+  from hour to hour. But the window of tolerance fluctuates constantly
+  with sleep quality, blood sugar, relational context, menstrual cycle,
+  seasonal light, and dozens of other variables. A person's window at 10
+  a.m. after a good night's sleep is not the same window at 3 a.m. after
+  a conflict with their partner. The architectural metaphor implies a
+  stable structural feature when the reality is a dynamic, context-
+  sensitive state. This can mislead clinicians into treating the window
+  as a fixed trait rather than a momentary capacity.
+- **The threshold is not sharp** -- a window has a crisp edge: you are
+  either looking through glass or looking at wall. But the transition
+  from regulated to dysregulated arousal is gradual, bidirectional, and
+  often ambiguous. A person may be partially outside their window -- able
+  to think but not feel, or feeling intensely but still functional. The
+  metaphor's clean binary (in/out) does not capture the messy continuum
+  of partial dysregulation that clinicians actually observe.
+- **Arousal is not one-dimensional** -- the window metaphor implies a
+  single vertical axis: too high, just right, too low. But the nervous
+  system is multidimensional. A person can be simultaneously hyperaroused
+  in one system (sympathetic: racing heart) and hypoaroused in another
+  (dorsal vagal: cognitive shutdown). Porges's polyvagal theory, which
+  Siegel drew on, describes three hierarchical circuits, not a single
+  dial. The window's simplicity -- one axis, one aperture -- flattens
+  this complexity into a model that is clinically accessible but
+  neurobiologically incomplete.
+- **Widening the window is not always the goal** -- the metaphor implies
+  that a wider window is always better. But some narrowing is adaptive:
+  a soldier in combat or a surgeon in an emergency benefits from a
+  narrowed attentional window that excludes irrelevant stimuli. The
+  metaphor frames narrowness as pathology and width as health, missing
+  the functional value of context-appropriate constriction.
+
+## Expressions
+
+- "You're outside your window" -- therapist or client language for
+  recognizing a dysregulated state, often used as a cue to employ
+  grounding techniques
+- "Widening the window" -- therapeutic goal language, describing the
+  gradual expansion of capacity for tolerating arousal
+- "Narrow window" -- clinical shorthand for the reduced affect-regulation
+  capacity common in complex trauma
+- "Window work" -- informal term in somatic and trauma-focused therapy
+  for exercises designed to expand the window of tolerance
+- "Staying in the window" -- the therapeutic instruction to titrate
+  exposure so that the client touches difficult material without
+  exceeding their processing capacity
+
+## Origin Story
+
+Siegel coined the term in *The Developing Mind* (1999), a book that
+synthesized attachment theory, neuroscience, and interpersonal
+neurobiology. The concept drew on two main sources: Porges's polyvagal
+theory (1995), which described the hierarchical organization of autonomic
+nervous system responses, and Schore's affect regulation and repair
+research, which documented how early attachment relationships calibrate
+the child's capacity for emotional regulation.
+
+The window of tolerance became one of the most widely adopted clinical
+metaphors in trauma therapy, appearing in the curricula of training
+programs worldwide. Its power lies in its spatial simplicity: a concept
+that requires extensive neuroscience to explain technically can be
+communicated to a client in thirty seconds with a whiteboard drawing.
+Pat Ogden, Peter Levine, and Babette Rothschild all incorporated the
+concept into their somatic therapy models, and it has migrated into
+education (where teachers learn to recognize when students are outside
+their window) and workplace wellness programs.
+
+## References
+
+- Siegel, D.J. *The Developing Mind: How Relationships and the Brain
+  Interact to Shape Who We Are* (1999, 3rd ed. 2020) -- the original
+  source
+- Porges, S.W. "Orienting in a Defensive World: Mammalian Modifications
+  of Our Evolutionary Heritage -- A Polyvagal Theory," *Psychophysiology*
+  32 (1995): 301-318
+- Ogden, P., Minton, K., and Pain, C. *Trauma and the Body: A
+  Sensorimotor Approach to Psychotherapy* (2006) -- clinical application
+  of the window of tolerance
+- Corrigan, F.M., Fisher, J.J., and Nutt, D.J. "Autonomic Dysregulation
+  and the Window of Tolerance Model of the Effects of Complex Emotional
+  Trauma," *Journal of Psychopharmacology* 25.1 (2011): 17-25

--- a/catalog/frames/accounting.md
+++ b/catalog/frames/accounting.md
@@ -1,0 +1,28 @@
+---
+created: '2026-03-21'
+name: Accounting
+related:
+- economics
+- moral-accounting
+roles:
+- ledger
+- entry
+- balance
+- debit
+- credit
+- account
+- audit
+- reconciliation
+- deficit
+- surplus
+slug: accounting
+updated: '2026-03-21'
+---
+
+The systematic recording, classifying, and summarizing of financial
+transactions. As a source domain, accounting foregrounds the idea that
+every event leaves a trace in a permanent record, that what goes in must
+be balanced by what goes out, and that hidden discrepancies will eventually
+surface under audit. Structurally productive because it separates the event
+from its record, implies that unacknowledged debts compound over time, and
+treats reconciliation as a process of making the record match reality.

--- a/catalog/works/psychotherapy-metaphors.md
+++ b/catalog/works/psychotherapy-metaphors.md
@@ -1,0 +1,17 @@
+---
+slug: psychotherapy-metaphors
+name: "Psychotherapy's Structural Metaphors"
+type: collection
+authors: ["agent:metaphorex-prospector"]
+year: 2026
+url: "https://github.com/metaphorex/metaphorex/issues/1353"
+related: []
+created: "2026-03-21"
+updated: "2026-03-21"
+---
+
+Survey of metaphors from psychotherapy that structure clinical theory,
+therapeutic practice, and popular understanding of mental health. Covers
+concepts from person-centered therapy (Rogers), trauma therapy (van der
+Kolk, Siegel, Levine), experiential therapy (Gendlin), ACT (Hayes),
+narrative therapy (White, Epston), and relational psychoanalysis.


### PR DESCRIPTION
## Summary

- **the-body-keeps-the-score** (#2276): van der Kolk's accounting metaphor — the body tallies trauma like a ledger
- **felt-sense** (#2275): Gendlin's focusing concept — pre-verbal bodily knowing as mental model
- **window-of-tolerance** (#2274): Siegel's architectural metaphor — bounded aperture for arousal regulation
- **unconditional-positive-regard** (#2272): Rogers/Standal's economic framing — regard as conditioned vs unconditioned supply
- **therapeutic-alliance** (#2270): Bordin's military metaphor — therapist and client as allies against a common enemy

Also creates: `accounting` frame, `psychotherapy-metaphors` works file.

Validator: zero errors, warnings are pre-existing dangling references only.

Closes #2276, Closes #2275, Closes #2274, Closes #2272, Closes #2270

## Test plan

- [ ] `uv run scripts/validate.py validate` passes with zero errors
- [ ] Each entry has Transfers, Limits, Expressions sections
- [ ] Structural enrichment tags present on all entries
- [ ] New accounting frame validates correctly
- [ ] Works file links to parent issue #1353

🤖 Generated with [Claude Code](https://claude.com/claude-code)