### PR TITLE
Fix kaizen #2232: add mandatory pre-PR rebase to miner agent

### DIFF
--- a/.claude/agents/miner.md
+++ b/.claude/agents/miner.md
@@ -269,6 +269,36 @@ git -c user.name="m4x-miner" -c user.email="miner@metaphorex.org" commit ...
 
 If the token is NOT set, use default auth (no prefix needed).
 
+**Pre-PR Rebase (MANDATORY):**
+
+Before creating any PR, you MUST ensure your branch is up to date with main.
+Stale branches cause phantom content deletions in the PR diff — recently-merged
+entries appear as deletions when the branch diverged before those merges.
+
+1. Fetch latest main:
+   ```bash
+   git fetch origin main
+   ```
+2. Check if main is already an ancestor of your branch:
+   ```bash
+   git merge-base --is-ancestor origin/main HEAD && echo "UP TO DATE" || echo "NEEDS REBASE"
+   ```
+3. If NOT up to date, rebase onto main:
+   ```bash
+   git rebase origin/main
+   ```
+   If the rebase has conflicts, resolve them, then `git rebase --continue`.
+4. Re-run the validator after rebase:
+   ```bash
+   uv run scripts/validate.py validate
+   ```
+   Fix any errors before proceeding.
+5. Only after the branch is rebased and the validator passes, proceed to
+   `gh pr create`.
+
+Do NOT skip these steps. A PR with phantom deletions will be rejected by the
+Assayer and waste a review cycle.
+
 **Git Workflow:**
 
 - Create a branch: `mine/<project-name>/<slug>`


### PR DESCRIPTION
## Summary

Fixes #2232

- Miner branches created from stale commits cause phantom content deletions in PR diffs. Recently-merged entries appear as deletions when the branch diverged before those merges.
- Added a **Pre-PR Rebase (MANDATORY)** section to `.claude/agents/miner.md` that requires the miner to fetch, check ancestry, rebase if needed, and re-validate before creating any PR.

## What changed

Added a new section between the Identity and Git Workflow sections in the miner agent prompt. The section instructs the miner to:

1. `git fetch origin main`
2. `git merge-base --is-ancestor origin/main HEAD` to check if rebase is needed
3. `git rebase origin/main` if the branch is behind
4. Re-run `uv run scripts/validate.py validate` after rebase
5. Only then proceed to `gh pr create`

## Test plan

- [ ] Verify the miner agent prompt renders correctly
- [ ] Confirm the new section is clear and unambiguous
- [ ] Next miner run should perform the rebase check before PR creation

Generated with [Claude Code](https://claude.com/claude-code)