### PR TITLE
Fix kaizen #2229: document fixup commit pattern in assayer

### DIFF
--- a/.claude/agents/assayer.md
+++ b/.claude/agents/assayer.md
@@ -123,7 +123,33 @@ need to read multiple files or run the validator.
      restate common knowledge.
    - **Frames**: roles are meaningful and structural, not just keywords?
 4. For mechanical issues (formatting, missing field, typo), push a fixup
-   commit directly to the PR branch
+   commit directly to the PR branch.
+
+   **Making fixup commits (worktree-safe pattern):**
+
+   The assayer often runs in a worktree context where the parent repo paths
+   may not match Edit/Read tool expectations. To avoid path confusion, clone
+   the PR branch to a temporary directory, make edits there, then push:
+
+   ```bash
+   git clone --branch <branch> https://github.com/metaphorex/metaphorex /tmp/fixup-<pr-number>
+   ```
+
+   Make all edits in `/tmp/fixup-<pr-number>`, then commit and push:
+
+   ```bash
+   cd /tmp/fixup-<pr-number>
+   # ... edit files ...
+   git -c user.name="m4x-reviewer" -c user.email="reviewer@metaphorex.org" \
+     commit -am "fixup: <description>"
+   GH_TOKEN="$M4X_REVIEWER_TOKEN" git push
+   ```
+
+   Clean up when done:
+
+   ```bash
+   rm -rf /tmp/fixup-<pr-number>
+   ```
 5. For substantive issues (shallow analysis, fabricated expressions,
    wrong kind classification), request changes with specific feedback
 6. For quality work, approve with a brief note on what's strong


### PR DESCRIPTION
## Summary

- Adds worktree-safe fixup commit instructions to `.claude/agents/assayer.md`
- Documents the pattern: clone PR branch to `/tmp/fixup-<pr-number>`, edit there, push, clean up
- This is necessary because the assayer runs in a worktree context where parent repo paths may not match Edit/Read tool expectations

Fixes #2229

## What was broken

The assayer prompt told agents to "push a fixup commit directly to the PR branch" but gave no guidance on *how* to do this when running inside a worktree. Agents were discovering the `/tmp` clone workaround on their own, wasting time and sometimes getting it wrong.

## What changed

Added a "Making fixup commits (worktree-safe pattern)" subsection under review process step 4, with explicit clone/edit/push/cleanup instructions.

## Test plan

- [x] Verified the edit is minimal and only touches the fixup commit section
- [x] No other content in the assayer prompt was modified