### PR TITLE
Add structural enrichment: 5 mixed entries (lampshading + dead-zone + culinary)

### DIFF
--- a/catalog/entries/behind.md
+++ b/catalog/entries/behind.md
@@ -14,9 +14,18 @@ related:
   - the-line
 dead: false
 created: '2026-03-19'
-updated: '2026-03-19'
+updated: '2026-03-22'
 grounding: folk
 harness: Claude Code
+embodied_patterns:
+  - near-far
+  - boundary
+  - force
+relation_types:
+  - prevent
+  - coordinate
+structure: boundary
+abstraction_level: specific
 transfers:
   - '[source] the callout announces spatial presence before physical contact, converting potential collision into coordinated movement by making the invisible (who is behind you) audible'
   - '[source] the protocol is unilateral -- the approaching person calls out without waiting for acknowledgment, because in a high-tempo environment the cost of a missed call is a bump, while the cost of waiting for permission is a blocked path'

--- a/catalog/entries/dead-zone.md
+++ b/catalog/entries/dead-zone.md
@@ -15,9 +15,19 @@ related:
   - tragedy-of-the-commons
   - dead-code
 created: '2026-03-20'
-updated: '2026-03-20'
+updated: '2026-03-22'
 grounding: established
 harness: Claude Code
+embodied_patterns:
+  - container
+  - blockage
+  - scale
+relation_types:
+  - cause/accumulate
+  - transform/corruption
+  - cause/propagate
+structure: cycle
+abstraction_level: generic
 transfers:
   - '[source] excess nutrients cause algal blooms that consume all dissolved oxygen, so the very resource that was supposed to promote growth becomes the mechanism of death through overabundance'
   - '[source] the dead zone is self-reinforcing: once oxygen drops below a threshold, the organisms that would have restored balance are the first to die, creating a positive feedback loop'

--- a/catalog/entries/lampshading.md
+++ b/catalog/entries/lampshading.md
@@ -13,9 +13,17 @@ related:
   - breaking-the-fourth-wall
   - rubber-duck-debugging
 created: '2026-03-20'
-updated: '2026-03-20'
+updated: '2026-03-22'
 grounding: folk
 harness: Claude Code
+embodied_patterns:
+  - surface-depth
+  - container
+relation_types:
+  - transform/reframing
+  - prevent
+structure: boundary
+abstraction_level: generic
 transfers:
   - '[source] a lampshade draws attention to the object it covers while simultaneously domesticating it, converting a bare bulb from an eyesore into acceptable decor'
   - '[source] the covering is transparent about its own function -- everyone can see it is a lampshade, not a disguise -- which means acknowledgment replaces concealment'

--- a/catalog/entries/slowing-down-to-speed-up.md
+++ b/catalog/entries/slowing-down-to-speed-up.md
@@ -13,9 +13,19 @@ related:
   - planning-is-prime
 dead: false
 created: '2026-03-19'
-updated: '2026-03-19'
+updated: '2026-03-22'
 grounding: established
 harness: Claude Code
+embodied_patterns:
+  - force
+  - balance
+  - flow
+relation_types:
+  - prevent
+  - restore
+  - cause/accumulate
+structure: cycle
+abstraction_level: generic
 transfers:
   - '[model] when a cook panics and accelerates movements, error rates climb and recovery time per error exceeds the time "saved" by rushing, producing a net slowdown that compounds with each mistake'
   - '[model] deliberate deceleration at a chokepoint (pausing to re-read the ticket board, re-staging the station) resets the error cascade and restores throughput to a sustainable rate'

--- a/catalog/entries/the-line.md
+++ b/catalog/entries/the-line.md
@@ -16,9 +16,19 @@ related:
   - dying-on-the-pass
 dead: false
 created: '2026-03-19'
-updated: '2026-03-19'
+updated: '2026-03-22'
 grounding: folk
 harness: Claude Code
+embodied_patterns:
+  - boundary
+  - path
+  - container
+relation_types:
+  - transform
+  - coordinate
+  - decompose
+structure: pipeline
+abstraction_level: specific
 transfers:
   - '[source] the line is a physical zone where raw ingredients become finished dishes under time pressure, mapping production space as a bounded region where transformation happens rather than where planning or storage occurs'
   - '[source] cooks are assigned fixed stations along the line (saute, grill, garde manger), so that each person owns a segment of the workflow and hands output to the next, structuring production as sequential territorial responsibility'


### PR DESCRIPTION
## Summary

- Added `embodied_patterns`, `relation_types`, `structure`, and `abstraction_level` structural enrichment tags to 5 existing entries that were missing them
- Entries enriched: lampshading, dead-zone, behind, the-line, slowing-down-to-speed-up
- All entries already had full content (Transfers, Limits, Expressions sections); this PR adds only structural metadata

Closes #1905
Closes #1930
Closes #1975
Closes #1980
Closes #1989

## Validator output

All content valid. Zero errors. 160 pre-existing warnings (dangling references).

## Structural tags applied

| Entry | embodied_patterns | relation_types | structure | abstraction_level |
|-------|------------------|----------------|-----------|-------------------|
| lampshading | surface-depth, container | transform/reframing, prevent | boundary | generic |
| dead-zone | container, blockage, scale | cause/accumulate, transform/corruption, cause/propagate | cycle | generic |
| behind | near-far, boundary, force | prevent, coordinate | boundary | specific |
| the-line | boundary, path, container | transform, coordinate, decompose | pipeline | specific |
| slowing-down-to-speed-up | force, balance, flow | prevent, restore, cause/accumulate | cycle | generic |

— *m4x-miner*