### PR TITLE
Add structural enrichment: 4 entries (mixed: culinary + psychotherapy)

### DIFF
--- a/catalog/entries/cognitive-defusion.md
+++ b/catalog/entries/cognitive-defusion.md
@@ -13,7 +13,7 @@ related:
   - passengers-on-the-bus
 provenance: psychotherapy-metaphors
 created: '2026-03-19'
-updated: '2026-03-19'
+updated: '2026-03-22'
 grounding: established
 harness: Claude Code
 transfers:
@@ -23,6 +23,16 @@ transfers:
 limits:
   - '[model] does not apply to thoughts that are accurate reports of external danger -- defusing from "there is a car coming toward me" would be maladaptive, which means the technique requires a prior judgment about whether the thought is a useful signal or unhelpful noise'
   - '[model] risks becoming a meta-cognitive avoidance strategy if used to dismiss all uncomfortable thoughts as "just thoughts," collapsing the distinction between experiential avoidance (which ACT opposes) and genuine cognitive flexibility'
+embodied_patterns:
+  - merging
+  - splitting
+  - surface-depth
+relation_types:
+  - transform/reframing
+  - cause/constrain
+  - enable
+structure: transformation
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/inspect-and-correct.md
+++ b/catalog/entries/inspect-and-correct.md
@@ -14,7 +14,7 @@ related:
   - a-la-minute
 provenance: culinary-mise-en-place
 created: '2026-03-19'
-updated: '2026-03-19'
+updated: '2026-03-22'
 grounding: folk
 harness: Claude Code
 transfers:
@@ -24,6 +24,16 @@ transfers:
 limits:
   - '[model] assumes errors are detectable at inspection time, but in knowledge work many errors only become visible weeks or months later when their consequences emerge -- the equivalent of a dish that tastes fine on service but was contaminated during prep'
   - '[model] breaks when the inspection overhead exceeds the cost of the errors it catches, which happens in high-throughput low-consequence environments where most errors are self-correcting'
+embodied_patterns:
+  - iteration
+  - matching
+  - path
+relation_types:
+  - transform/refinement
+  - cause/propagate
+  - select
+structure: cycle
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/pendulation.md
+++ b/catalog/entries/pendulation.md
@@ -15,7 +15,7 @@ related:
   - titration
   - yin-and-yang
 created: '2026-03-20'
-updated: '2026-03-20'
+updated: '2026-03-22'
 grounding: established
 harness: Claude Code
 transfers:
@@ -25,6 +25,18 @@ transfers:
 limits:
   - '[source] breaks because a physical pendulum is a deterministic system with predictable period and decay, while nervous-system oscillation between activation and resource states is nonlinear and influenced by relational context, memory, and meaning'
   - '[source] misleads because the metaphor implies a single axis of oscillation (activation vs. calm), while trauma responses involve multiple interacting systems -- autonomic, endocrine, cognitive -- that do not reduce to one degree of freedom'
+embodied_patterns:
+  - balance
+  - force
+  - iteration
+relation_types:
+  - restore
+  - transform/refinement
+  - cause/constrain
+structure:
+  - cycle
+  - equilibrium
+abstraction_level: generic
 ---
 
 ## Transfers

--- a/catalog/entries/tug-of-war-with-a-monster.md
+++ b/catalog/entries/tug-of-war-with-a-monster.md
@@ -15,7 +15,7 @@ related:
   - passengers-on-the-bus
 provenance: psychotherapy-metaphors
 created: '2026-03-19'
-updated: '2026-03-19'
+updated: '2026-03-22'
 grounding: established
 harness: Claude Code
 transfers:
@@ -25,6 +25,16 @@ transfers:
 limits:
   - '[source] breaks because in a real tug-of-war, dropping the rope means the opponent wins and pulls you into the pit; the metaphor requires redefining "the pit" as the struggle itself, which is a second-order move the metaphor does not surface on its own'
   - '[source] misleads by implying that disengagement is always available as a simple motor act, when the psychological equivalent of "dropping the rope" may require years of practice and is itself a skill, not a single decision'
+embodied_patterns:
+  - force
+  - link
+  - balance
+relation_types:
+  - compete
+  - cause/couple
+  - prevent
+structure: competition
+abstraction_level: generic
 ---
 
 ## Transfers


### PR DESCRIPTION
## Summary

- Enriched 4 existing entries with structural tags (`embodied_patterns`, `relation_types`, `structure`, `abstraction_level`)
- **inspect-and-correct**: `iteration` + `matching` + `path`; `transform/refinement` + `cause/propagate` + `select`; `cycle`
- **tug-of-war-with-a-monster**: `force` + `link` + `balance`; `compete` + `cause/couple` + `prevent`; `competition`
- **cognitive-defusion**: `merging` + `splitting` + `surface-depth`; `transform/reframing` + `cause/constrain` + `enable`; `transformation`
- **pendulation**: `balance` + `force` + `iteration`; `restore` + `transform/refinement` + `cause/constrain`; `cycle` + `equilibrium`
- **confirmation-bias** (#2512): already had structural tags, skipped

Closes #1991
Closes #2246
Closes #2262
Closes #2281
Closes #2512

## Validator output

`uv run scripts/validate.py validate` -- zero errors, all content valid.

## Notes

All 5 entries already existed in the catalog. The 4 without structural enrichment tags were enriched. confirmation-bias already had tags from a prior enrichment pass.

— *m4x-miner*