### PR TITLE
Fix kaizen #2225: miner pre-PR frame recency check

### DIFF
--- a/.claude/agents/miner.md
+++ b/.claude/agents/miner.md
@@ -229,6 +229,50 @@ When writing entries, prioritize:
 
 Avoid restating what any educated reader already knows about the metaphor.
 
+**Pre-PR Validation (frame recency check):**
+
+Before creating ANY PR (enrichment, project, or nugget), run these steps to
+avoid merge conflicts from frames that another miner already merged:
+
+1. **Rebase onto latest main:**
+   ```bash
+   git fetch origin main && git rebase origin/main
+   ```
+   If the rebase fails with conflicts on frame files (`catalog/frames/`),
+   resolve by taking main's version — the frame already exists and is
+   canonical:
+   ```bash
+   git checkout --theirs catalog/frames/<conflicting-file>
+   git add catalog/frames/<conflicting-file>
+   git rebase --continue
+   ```
+
+2. **Remove duplicate frames from the diff:**
+   After a successful rebase, check which frame files are still in your diff:
+   ```bash
+   git diff origin/main --name-only -- catalog/frames/
+   ```
+   For each frame file listed, check if it already exists on main:
+   ```bash
+   git show origin/main:catalog/frames/<file> 2>/dev/null && echo "EXISTS" || echo "NEW"
+   ```
+   If a frame file already exists on main and your version is identical or
+   only cosmetically different, drop your change:
+   ```bash
+   git checkout origin/main -- catalog/frames/<file>
+   ```
+   Then amend the commit to remove the redundant frame changes.
+
+3. **Re-run the validator** after rebase and frame cleanup:
+   ```bash
+   uv run scripts/validate.py validate
+   ```
+
+4. **Only then** proceed to `gh pr create`.
+
+This prevents PRs that conflict with frames merged by other miners, which the
+Smelter cannot resolve.
+
 **Git Safety (worktree guard):**
 
 Nested worktrees can cause commits on unintended branches. At the start of


### PR DESCRIPTION
## Summary

Closes #2225

**Problem:** Miners create PRs containing frame files that already exist on main (added by other miners that merged first). This causes merge conflicts the Smelter cannot resolve.

**Fix:** Added a new "Pre-PR Validation (frame recency check)" section to `.claude/agents/miner.md`. Before creating any PR, miners must now:

1. Rebase onto latest `origin/main` — with instructions for resolving frame conflicts by taking main's version
2. Check for duplicate frames in the diff and drop any that already exist on main
3. Re-run the validator after cleanup
4. Only then proceed to `gh pr create`

**Files changed:**
- `.claude/agents/miner.md` — added 44-line pre-PR validation section between "Analytical Value" and "Git Safety" sections

**Testing:** The next miner dispatch should show rebase behavior before PR creation.

--- *m4x-fixer*