### PR TITLE
Fix kaizen #2472: filter phantom sub-issues from survey

### DIFF
--- a/scripts/survey.py
+++ b/scripts/survey.py
@@ -81,6 +81,21 @@ def collect(proc: subprocess.Popen) -> list[dict]:
         return []
 
 
+def verify_issue_exists(repo: str, issue_number: int) -> bool:
+    """Check that an issue number resolves via REST API.
+
+    GraphQL subIssues can return phantom issue numbers (draft or
+    not-yet-merged sub-issues) that 404 on REST. This verifies the
+    issue actually exists before we surface it as actionable work.
+    """
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repo}/issues/{issue_number}",
+         "--silent"],
+        capture_output=True, text=True,
+    )
+    return result.returncode == 0
+
+
 def survey(repo: str) -> dict:
     """Run all GitHub queries in parallel and return structured results."""
     owner, name = repo.split("/")
@@ -287,8 +302,17 @@ def survey(repo: str) -> dict:
                 continue
             if si.get("state") != "open":
                 continue
-            si_labels = [l["name"] for l in si.get("labels", [])]
             si_num = si["number"]
+            # Verify the sub-issue actually exists via REST.
+            # GraphQL subIssues can return phantom numbers that 404.
+            if not verify_issue_exists(repo, si_num):
+                print(
+                    f"warning: phantom sub-issue #{si_num} "
+                    f"(child of #{parent_num}) — skipping",
+                    file=sys.stderr,
+                )
+                continue
+            si_labels = [l["name"] for l in si.get("labels", [])]
             priority = parent_priority.get(parent_num, "normal")
             if "in-progress" not in si_labels:
                 unclaimed.append({
@@ -341,6 +365,15 @@ def survey(repo: str) -> dict:
             if tm:
                 matched_parent = prefix_to_parent.get(tm.group(1).lower())
         if matched_parent is None or matched_parent not in surveyed_parent_numbers:
+            continue
+
+        # Verify orphan sub-issue exists via REST (GraphQL can return phantoms)
+        if not verify_issue_exists(repo, inum):
+            print(
+                f"warning: phantom sub-issue #{inum} "
+                f"(orphan of #{matched_parent}) — skipping",
+                file=sys.stderr,
+            )
             continue
 
         si_labels = [l["name"] for l in issue.get("labels", {}).get("nodes", [])]


### PR DESCRIPTION
Closes #2472

## What was broken

The GraphQL `subIssues` API can return issue numbers that don't actually exist via REST (phantom/draft issues). When `scripts/survey.py` fetches sub-issues for surveyed projects, these phantom numbers leak into the `unclaimed` and `stale_in_progress` lists, causing miners to attempt to claim non-existent issues.

## What this changes

Adds a `verify_issue_exists()` function that checks each sub-issue number resolves via REST API (`gh api repos/{repo}/issues/{N}`) before including it in survey output.

Verification is applied in two places:
1. **REST sub_issues endpoint** (line ~302) -- sub-issues fetched for surveyed parent projects
2. **Orphan sub-issue detection** (line ~367) -- GraphQL-sourced orphans matched by body text or title prefix

Phantom issues that return 404 are logged as warnings to stderr and filtered out.

## Test plan

- [x] `uv run scripts/survey.py --repo metaphorex/metaphorex` runs without errors
- [x] Survey output contains only real, resolvable issue numbers
- [x] Phantom issues (if any) are logged as warnings to stderr

— *m4x-fixer*