### PR TITLE
Fix kaizen #2217: detect cross-PR frame conflicts

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -7,15 +7,17 @@
 """Metaphorex content validator and extractor.
 
 Usage:
-    uv run scripts/validate.py validate          # validate all content
-    uv run scripts/validate.py validate catalog/entries/ # validate specific dir
-    uv run scripts/validate.py extract            # emit JSON to stdout
+    uv run scripts/validate.py validate                        # validate all content
+    uv run scripts/validate.py validate catalog/entries/       # validate specific dir
+    uv run scripts/validate.py validate --check-open-prs       # also check for cross-PR frame conflicts
+    uv run scripts/validate.py extract                         # emit JSON to stdout
 """
 
 from __future__ import annotations
 
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -386,6 +388,83 @@ def validate(target: str | None = None) -> tuple[list[str], list[str]]:
     return errors, warnings
 
 
+def check_open_pr_frame_conflicts() -> list[str]:
+    """Check if frame files on the current branch conflict with frames in other open PRs.
+
+    Requires the `gh` CLI and network access. Returns a list of warnings
+    (never errors) describing any conflicts found.
+    """
+    warnings: list[str] = []
+
+    # Get frame files changed on the current branch vs main
+    try:
+        diff_output = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=A", "origin/main...HEAD"],
+            capture_output=True, text=True, check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        warnings.append("cross-PR check: could not determine branch diff (is origin/main available?)")
+        return warnings
+
+    local_frame_files = {
+        line.strip()
+        for line in diff_output.stdout.splitlines()
+        if line.strip().startswith("catalog/frames/")
+    }
+
+    if not local_frame_files:
+        return warnings  # No new frames on this branch, nothing to conflict
+
+    # Get file lists from all open PRs
+    try:
+        gh_output = subprocess.run(
+            ["gh", "pr", "list", "--json", "files,number,title", "--limit", "200"],
+            capture_output=True, text=True, check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        warnings.append("cross-PR check: `gh pr list` failed (is the gh CLI installed and authenticated?)")
+        return warnings
+
+    try:
+        open_prs = json.loads(gh_output.stdout)
+    except json.JSONDecodeError:
+        warnings.append("cross-PR check: could not parse `gh pr list` output")
+        return warnings
+
+    # Get current PR number (if any) so we skip ourselves
+    try:
+        current_pr = subprocess.run(
+            ["gh", "pr", "view", "--json", "number"],
+            capture_output=True, text=True,
+        )
+        current_pr_number = json.loads(current_pr.stdout).get("number") if current_pr.returncode == 0 else None
+    except (json.JSONDecodeError, FileNotFoundError):
+        current_pr_number = None
+
+    for pr in open_prs:
+        pr_number = pr.get("number")
+        pr_title = pr.get("title", "(untitled)")
+
+        # Skip our own PR
+        if pr_number == current_pr_number:
+            continue
+
+        pr_frame_files = {
+            f["path"]
+            for f in pr.get("files", [])
+            if f["path"].startswith("catalog/frames/")
+        }
+
+        conflicts = local_frame_files & pr_frame_files
+        for path in sorted(conflicts):
+            slug = path.removeprefix("catalog/frames/").removesuffix(".md")
+            warnings.append(
+                f"cross-PR conflict: frame '{slug}' also added/modified in PR #{pr_number} ({pr_title})"
+            )
+
+    return warnings
+
+
 def extract() -> list[dict]:
     results = []
     for f in sorted(ENTRIES_DIR.glob("*.md")):
@@ -406,8 +485,16 @@ def main() -> None:
     command = sys.argv[1]
 
     if command == "validate":
-        target = sys.argv[2] if len(sys.argv) > 2 else None
+        args = sys.argv[2:]
+        check_open_prs = "--check-open-prs" in args
+        remaining = [a for a in args if a != "--check-open-prs"]
+        target = remaining[0] if remaining else None
+
         errors, warnings = validate(target)
+
+        if check_open_prs:
+            warnings.extend(check_open_pr_frame_conflicts())
+
         if warnings:
             print(f"{len(warnings)} warning(s) (dangling references, non-blocking):\n")
             for w in warnings:


### PR DESCRIPTION
## Summary

Closes #2217

- Added `check_open_pr_frame_conflicts()` function to `scripts/validate.py` that uses `gh pr list --json files,number,title` to get file lists from all open PRs, then compares new frame files on the current branch against frames in other PRs
- Wired it into the CLI via an opt-in `--check-open-prs` flag (since it requires network access and the `gh` CLI)
- Conflicts produce warnings (not errors) with the conflicting PR number and title
- The function skips its own PR if one exists, and gracefully degrades if `gh` or `origin/main` are unavailable

## What was broken

The validator had no way to detect when two open PRs both add the same frame file. This could lead to merge conflicts or silent overwrites when PRs land in sequence.

## What the fix does

`uv run scripts/validate.py validate --check-open-prs` now:
1. Finds frame files added on the current branch (via `git diff --name-only --diff-filter=A origin/main...HEAD`)
2. Fetches file lists from all open PRs (via `gh pr list`)
3. Emits a warning for each frame file that appears in both this branch and another open PR

## Test plan

- [x] `uv run scripts/validate.py validate` passes without regressions
- [x] `uv run scripts/validate.py validate --check-open-prs` runs without false positives (this branch has no new frames)
- [x] Flag works correctly when combined with a target directory argument
- [x] Graceful degradation: if `gh` is unavailable or `origin/main` is missing, a warning is emitted instead of a crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)