### PR TITLE
Fix kaizen #2225: miner should validate frame recency before creating PR

### DIFF
--- a/.claude/agents/miner.md
+++ b/.claude/agents/miner.md
@@ -296,6 +296,32 @@ find work.
 
 If any of these three steps is missing, the entry is not done.
 
+
+**Pre-PR Frame Recency Check (REQUIRED before every PR):**
+
+Other miners may have merged frames since you branched. Before creating a PR,
+always rebase onto the latest main and deduplicate frames:
+
+1. Fetch and rebase:
+   ```bash
+   git fetch origin main && git rebase origin/main
+   ```
+2. If the rebase has conflicts on frame files that already exist on main,
+   resolve by accepting main's version (`git checkout --theirs <path>` then
+   `git add <path>`), then `git rebase --continue`.
+3. After rebase, check each frame file you created:
+   ```bash
+   git show origin/main:catalog/frames/<slug>.md 2>/dev/null && echo "EXISTS" || echo "NEW"
+   ```
+4. If a frame already exists on main, delete your copy (`git rm` it and amend
+   the commit) — the existing frame on main is authoritative. Only keep frame
+   files that are genuinely new.
+5. Re-run `uv run scripts/validate.py validate` after removing duplicates to
+   confirm the entry still passes (the existing frame on main satisfies the
+   validator's "frame must exist" rule once rebased).
+
+This prevents duplicate-frame PRs and merge conflicts that stall the pipeline.
+
 **IMPORTANT — No cosmetic changes in entry PRs:**
 
 Only add or modify files directly related to the entries being created — the


### PR DESCRIPTION
## Summary

Fixes #2225

- Added a **Pre-PR Frame Recency Check** section to `.claude/agents/miner.md`
- Before creating a PR, the miner must now `git fetch origin main && git rebase origin/main`
- After rebase, the miner checks each frame file it created against `origin/main` using `git show`
- Frames that already exist on main are removed (`git rm`) from the branch
- Rebase conflicts on existing frames are resolved by preferring main's version
- Validator is re-run after deduplication to confirm the entry still passes

## What was broken

When multiple miners worked in parallel, they would each create the same frame files independently. The second PR to merge would hit merge conflicts on frames that the first PR had already added. This stalled the pipeline and required manual conflict resolution.

## What the fix does

Adds a mandatory pre-PR step in the miner agent instructions that rebases onto latest main and removes any frame files that already exist there. This catches the duplication before the PR is created, eliminating the merge conflict entirely.

## Test plan

- [x] Verified the new section is correctly placed in `miner.md` (after Post-PR Checklist, before the cosmetic changes warning)
- [ ] Next miner run should follow the new instructions when creating a PR with frames

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>