### PR TITLE
Fix kaizen #2217: cross-PR file conflict detection

### DIFF
--- a/.claude/agents/smelter.md
+++ b/.claude/agents/smelter.md
@@ -60,6 +60,20 @@ gh api "repos/metaphorex/metaphorex/contents/catalog/entries/some-slug.md?ref=br
 Prefer checking out the PR branch locally (`gh pr checkout <N>`) when you
 need to read multiple files or run the validator.
 
+**Pre-Smelting: Cross-PR Conflict Check**
+
+After checking out a PR branch, run the cross-PR conflict detector before
+doing any other work:
+
+```bash
+uv run scripts/validate.py check-open-prs --repo metaphorex/metaphorex
+```
+
+If conflicts are detected, post a comment on the PR listing the overlapping
+files and add the `needs-miner-fix` label. Do not proceed with smelting until
+the conflict is resolved (the Miner or Pitboss must coordinate which PR keeps
+the file).
+
 **Process:**
 
 1. Query: `gh pr list -R metaphorex/metaphorex --label needs-smelting --limit 2`

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -11,6 +11,7 @@ Usage:
     uv run scripts/validate.py validate catalog/entries/  # validate specific dir
     uv run scripts/validate.py extract                    # emit JSON to stdout
     uv run scripts/validate.py check-deletions            # detect catalog file deletions vs origin/main
+    uv run scripts/validate.py check-open-prs --repo owner/repo  # detect cross-PR file conflicts
 """
 
 from __future__ import annotations
@@ -442,8 +443,70 @@ def check_deletions() -> list[str]:
     return errors
 
 
+def check_open_prs(repo: str) -> list[str]:
+    """Detect files added on the current branch that also appear in other open PRs.
+
+    Returns a list of warning strings (empty if no conflicts found).
+    """
+    warnings: list[str] = []
+
+    # 1. Get files added on this branch vs origin/main
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=A", "origin/main...HEAD"],
+            capture_output=True, text=True, check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        warnings.append(f"Could not diff against origin/main: {exc.stderr.strip()}")
+        return warnings
+
+    local_added = {f.strip() for f in result.stdout.strip().splitlines() if f.strip()}
+    if not local_added:
+        return warnings
+
+    # 2. Get current branch name
+    try:
+        branch_result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, text=True, check=True,
+        )
+        current_branch = branch_result.stdout.strip()
+    except subprocess.CalledProcessError:
+        current_branch = ""
+
+    # 3. Query open PRs for their changed files
+    try:
+        pr_result = subprocess.run(
+            ["gh", "pr", "list", "-R", repo, "--state", "open",
+             "--json", "number,headRefName,files", "--limit", "100"],
+            capture_output=True, text=True, check=True,
+        )
+        open_prs = json.loads(pr_result.stdout)
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        warnings.append(f"Could not query open PRs: {exc}")
+        return warnings
+
+    # 4. Check for overlaps
+    for pr in open_prs:
+        pr_number = pr.get("number")
+        pr_branch = pr.get("headRefName", "")
+
+        # Skip our own PR
+        if pr_branch == current_branch:
+            continue
+
+        pr_files = {f.get("path", "") for f in pr.get("files", [])}
+        overlap = local_added & pr_files
+        for path in sorted(overlap):
+            warnings.append(
+                f"cross-PR conflict: '{path}' is also added in PR #{pr_number} ({pr_branch})"
+            )
+
+    return warnings
+
+
 def main() -> None:
-    if len(sys.argv) < 2 or sys.argv[1] not in ("validate", "extract", "check-deletions"):
+    if len(sys.argv) < 2 or sys.argv[1] not in ("validate", "extract", "check-deletions", "check-open-prs"):
         print(__doc__.strip())
         sys.exit(1)
 
@@ -481,6 +544,25 @@ def main() -> None:
         else:
             print("No catalog deletions detected.")
             sys.exit(0)
+
+    elif command == "check-open-prs":
+        # Parse --repo argument
+        repo = None
+        args = sys.argv[2:]
+        for i, arg in enumerate(args):
+            if arg == "--repo" and i + 1 < len(args):
+                repo = args[i + 1]
+        if not repo:
+            print("Usage: uv run scripts/validate.py check-open-prs --repo owner/repo")
+            sys.exit(1)
+        conflicts = check_open_prs(repo)
+        if conflicts:
+            print(f"{len(conflicts)} cross-PR conflict(s) detected:\n")
+            for c in conflicts:
+                print(f"  ~ {c}")
+            sys.exit(0)  # Warnings only, not a hard failure
+        else:
+            print("No cross-PR file conflicts detected.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #2217

- Added `check-open-prs` subcommand to `scripts/validate.py` that detects files added on the current branch which also appear in other open PRs
- The check uses `git diff` to find locally added files, then queries `gh pr list` for open PR file lists, and reports overlaps as warnings
- Opt-in via `--repo` flag so existing `validate` and `extract` commands are completely unaffected
- Wired the check into `.claude/agents/smelter.md` as a pre-smelting step: smelters now run the conflict check after checking out a PR branch, before proceeding with mechanical cleanup

## What was broken

Multiple miners working in parallel could independently create the same frame file (e.g. `catalog/frames/mathematical-logic.md`). The validator passed on each branch in isolation because it only sees the local filesystem. The conflict was only visible by manually comparing PR diffs side by side.

## What changed

- `scripts/validate.py`: new `check_open_prs()` function and `check-open-prs` subcommand
- `.claude/agents/smelter.md`: new "Pre-Smelting: Cross-PR Conflict Check" section in the process

## Test plan

- [x] `uv run scripts/validate.py validate` still passes (zero errors)
- [x] `uv run scripts/validate.py check-open-prs` without `--repo` shows usage and exits 1
- [ ] Manual test: on a branch with added files, run `uv run scripts/validate.py check-open-prs --repo metaphorex/metaphorex` to verify conflict detection against real open PRs

Generated with [Claude Code](https://claude.com/claude-code)