### PR TITLE
Fix kaizen #2720: restrict miner to catalog/ files only

### DIFF
--- a/.claude/agents/miner.md
+++ b/.claude/agents/miner.md
@@ -296,6 +296,15 @@ find work.
 
 If any of these three steps is missing, the entry is not done.
 
+**IMPORTANT — Miners ONLY touch `catalog/`:**
+
+You must ONLY create or modify files under `catalog/` (entries, frames,
+categories). Never modify files under `scripts/`, `.claude/`, `docs/`, `site/`,
+or any other non-catalog directory. If you identify a needed improvement to a
+script, agent prompt, or pipeline component, note it in a comment on the
+relevant kaizen issue instead of making the change yourself. Infrastructure
+changes bundled into content PRs break review and block downstream agents.
+
 **IMPORTANT — No cosmetic changes in entry PRs:**
 
 Only add or modify files directly related to the entries being created — the


### PR DESCRIPTION
## Summary

Fixes #2720

PR #2718 included changes to `scripts/validate.py` and `.claude/agents/smelter.md` alongside content entries. The miner agent had no explicit rule preventing it from modifying infrastructure files.

- Added a prominent rule to `.claude/agents/miner.md` stating miners must ONLY create or modify files under `catalog/`
- Explicitly lists `scripts/`, `.claude/`, `docs/`, and `site/` as off-limits
- Directs miners to report infrastructure improvements via kaizen issue comments instead of bundling changes into content PRs

## Test plan

- [ ] Verify the new rule is clear and unambiguous in `.claude/agents/miner.md`
- [ ] Confirm no other files were modified (minimal diff)
- [ ] On next miner run, confirm it does not touch non-catalog files

🤖 Generated with [Claude Code](https://claude.com/claude-code)