### PR TITLE
Enrich: summary for 58 missing entries

### DIFF
--- a/catalog/entries/biodiversity-loss.md
+++ b/catalog/entries/biodiversity-loss.md
@@ -1,6 +1,7 @@
 ---
 slug: biodiversity-loss
 name: Biodiversity Loss
+summary: "Species loss reduces functional redundancy; maps onto organizational homogenization that feels costless until a crisis exposes the gap."
 kind: metaphor
 source_frame: ecology
 applies_to:

--- a/catalog/entries/bounded-context.md
+++ b/catalog/entries/bounded-context.md
@@ -1,6 +1,7 @@
 ---
 slug: bounded-context
 name: Bounded Context
+summary: "DDD's largest scope within which a model stays consistent; translation at boundaries is explicit rather than implicit and invisible."
 kind: pattern
 source_frame: software-architecture
 applies_to:

--- a/catalog/entries/brooks-law.md
+++ b/catalog/entries/brooks-law.md
@@ -1,6 +1,7 @@
 ---
 slug: brooks-law
 name: "Brooks's Law"
+summary: "Adding people to a late project makes it later: communication channels grow quadratically while individual capacity grows linearly."
 kind: mental-model
 categories:
   - software-engineering

--- a/catalog/entries/burnout.md
+++ b/catalog/entries/burnout.md
@@ -1,6 +1,7 @@
 ---
 slug: burnout
 name: Burnout
+summary: "Combustion metaphor for exhaustion: misdirects intervention to the individual fuel rather than the organizational conditions of combustion."
 kind: metaphor
 source_frame: fire-safety
 dead: true

--- a/catalog/entries/chain-of-command.md
+++ b/catalog/entries/chain-of-command.md
@@ -1,6 +1,7 @@
 ---
 slug: chain-of-command
 name: Chain of Command
+summary: "Physical chain maps sequential authority transmission; encodes single-link failure risk and the illusion of lossless communication."
 kind: metaphor
 source_frame: military-command
 applies_to:

--- a/catalog/entries/facade.md
+++ b/catalog/entries/facade.md
@@ -1,6 +1,7 @@
 ---
 slug: facade
 name: Facade
+summary: "Architecture's public face: a clean interface that conceals internal complexity, designed for the viewer's needs, not the structure's."
 kind: pattern
 source_frame: architecture-and-building
 applies_to:

--- a/catalog/entries/first-mover-advantage.md
+++ b/catalog/entries/first-mover-advantage.md
@@ -1,6 +1,7 @@
 ---
 slug: first-mover-advantage
 name: First-Mover Advantage
+summary: "First market entry confers durable advantages through resource preemption and switching costs, but empirical survival rates are poor."
 kind: mental-model
 categories:
   - economics-and-finance

--- a/catalog/entries/frankenstein.md
+++ b/catalog/entries/frankenstein.md
@@ -1,6 +1,7 @@
 ---
 slug: frankenstein
 name: Frankenstein
+summary: "Shelley's archetype: technical mastery without ethical governance; the creator's abandonment, not the creation itself, makes it monstrous."
 kind: archetype
 source_frame: mythology
 applies_to:

--- a/catalog/entries/gilding-the-lily.md
+++ b/catalog/entries/gilding-the-lily.md
@@ -1,6 +1,7 @@
 ---
 slug: gilding-the-lily
 name: Gilding the Lily
+summary: "Adding ornament to something already complete; the covering obscures the original quality with unnecessary embellishment."
 kind: metaphor
 source_frame: craftsmanship
 applies_to:

--- a/catalog/entries/goedels-incompleteness.md
+++ b/catalog/entries/goedels-incompleteness.md
@@ -1,6 +1,7 @@
 ---
 slug: goedels-incompleteness
 name: "Goedel's Incompleteness"
+summary: "Any sufficiently powerful formal system contains true statements it cannot prove and cannot prove its own consistency."
 kind: mental-model
 categories:
   - mathematics-and-logic

--- a/catalog/entries/goodharts-law.md
+++ b/catalog/entries/goodharts-law.md
@@ -1,6 +1,7 @@
 ---
 slug: goodharts-law
 name: "Goodhart's Law"
+summary: "When a metric becomes a target, agents optimize the metric rather than the quality it measured, collapsing the correlation."
 kind: mental-model
 categories:
   - economics-and-finance

--- a/catalog/entries/grok.md
+++ b/catalog/entries/grok.md
@@ -1,6 +1,7 @@
 ---
 slug: grok
 name: Grok
+summary: "Heinlein's Martian word for understanding by absorption; comprehension as identity-dissolution, not information acquisition."
 kind: metaphor
 dead: true
 source_frame: science-fiction

--- a/catalog/entries/groupthink.md
+++ b/catalog/entries/groupthink.md
@@ -1,6 +1,7 @@
 ---
 slug: groupthink
 name: Groupthink
+summary: "Cohesive groups under pressure suppress dissent through self-censorship, producing worse decisions than members would make alone."
 kind: mental-model
 categories:
   - psychology

--- a/catalog/entries/hammer-and-nail.md
+++ b/catalog/entries/hammer-and-nail.md
@@ -1,6 +1,7 @@
 ---
 slug: hammer-and-nail
 name: Hammer and Nail
+summary: "Tool familiarity distorts problem perception; expertise shapes what counts as a nail, making the mismatch invisible to the user."
 kind: mental-model
 categories:
   - cognitive-science

--- a/catalog/entries/hawthorne-effect.md
+++ b/catalog/entries/hawthorne-effect.md
@@ -1,6 +1,7 @@
 ---
 slug: hawthorne-effect
 name: Hawthorne Effect
+summary: "Observation changes the observed: awareness of being studied activates social motives that alter the very behavior under study."
 kind: mental-model
 categories:
   - cognitive-science

--- a/catalog/entries/hedging-your-bets.md
+++ b/catalog/entries/hedging-your-bets.md
@@ -1,6 +1,7 @@
 ---
 slug: hedging-your-bets
 name: Hedging Your Bets
+summary: "A secondary bet placed against the primary to cap downside; accepts a lower ceiling on winnings for a higher floor on losses."
 kind: metaphor
 dead: true
 source_frame: gambling

--- a/catalog/entries/heros-journey.md
+++ b/catalog/entries/heros-journey.md
@@ -1,6 +1,7 @@
 ---
 slug: heros-journey
 name: "Hero's Journey"
+summary: "Campbell's monomyth: departure, ordeal, and return with the elixir structures transformation as requiring symbolic death of the old self."
 kind: archetype
 source_frame: narrative-and-storytelling
 applies_to:

--- a/catalog/entries/hit-the-nail-on-the-head.md
+++ b/catalog/entries/hit-the-nail-on-the-head.md
@@ -1,6 +1,7 @@
 ---
 slug: hit-the-nail-on-the-head
 name: Hit the Nail on the Head
+summary: "Carpentry: a blow either lands on the head or misses; frames correct identification as binary, self-evident, and achieved in one strike."
 kind: metaphor
 dead: true
 source_frame: carpentry

--- a/catalog/entries/homeostasis.md
+++ b/catalog/entries/homeostasis.md
@@ -1,6 +1,7 @@
 ---
 slug: homeostasis
 name: Homeostasis
+summary: "Cannon's negative feedback: biological systems resist displacement from equilibrium through automatic self-correction."
 kind: mental-model
 categories:
   - systems-thinking

--- a/catalog/entries/information-overload.md
+++ b/catalog/entries/information-overload.md
@@ -1,6 +1,7 @@
 ---
 slug: information-overload
 name: Information Overload
+summary: "Logistics capacity metaphor: cognitive systems have throughput limits that excess input exceeds, degrading processing quality."
 kind: metaphor
 dead: true
 source_frame: logistics

--- a/catalog/entries/kiss.md
+++ b/catalog/entries/kiss.md
@@ -1,6 +1,7 @@
 ---
 slug: kiss
 name: KISS (Keep It Simple, Stupid)
+summary: "Design principle: complexity is a bug unless forced by the problem itself; simplicity requires deliberate effort, not default."
 kind: mental-model
 categories:
   - software-engineering

--- a/catalog/entries/knowledge-is-a-landscape.md
+++ b/catalog/entries/knowledge-is-a-landscape.md
@@ -1,6 +1,7 @@
 ---
 slug: knowledge-is-a-landscape
 name: Knowledge Is a Landscape
+summary: "Cartographic metaphor: expertise as terrain with peaks of mastery, valleys of ignorance, and regions yet to be explored."
 kind: metaphor
 source_frame: cartography
 applies_to:

--- a/catalog/entries/ladder.md
+++ b/catalog/entries/ladder.md
@@ -1,6 +1,7 @@
 ---
 slug: ladder
 name: Ladder
+summary: "Sequential vertical progress with fixed rungs; imports the assumption that advancement is linear, one step at a time, with no skipping."
 kind: metaphor
 dead: true
 source_frame: tool-use

--- a/catalog/entries/leverage-point.md
+++ b/catalog/entries/leverage-point.md
@@ -1,6 +1,7 @@
 ---
 slug: leverage-point
 name: Leverage Point
+summary: "Meadows' hierarchy: places in a system where small interventions produce large changes, but the highest-leverage points are counterintuitive."
 kind: mental-model
 source_frame: physics
 categories:

--- a/catalog/entries/looking-glass-self.md
+++ b/catalog/entries/looking-glass-self.md
@@ -1,6 +1,7 @@
 ---
 slug: looking-glass-self
 name: Looking-Glass Self
+summary: "Cooley's model: self-concept is built from reflected perceptions of how others see us, making identity a social construction."
 kind: metaphor
 source_frame: optics-and-reflection
 applies_to:

--- a/catalog/entries/murphys-law.md
+++ b/catalog/entries/murphys-law.md
@@ -1,6 +1,7 @@
 ---
 slug: murphys-law
 name: Murphy's Law
+summary: "Design principle disguised as pessimism: if something can go wrong it will, so build systems that anticipate failure modes."
 kind: mental-model
 categories:
   - risk-management

--- a/catalog/entries/mutualism.md
+++ b/catalog/entries/mutualism.md
@@ -1,6 +1,7 @@
 ---
 slug: mutualism
 name: Mutualism
+summary: "(+/+) symbiosis: both parties benefit from the relationship, the rarest stable form of inter-entity dependency."
 kind: mental-model
 source_frame: ecology
 categories:

--- a/catalog/entries/natural-selection.md
+++ b/catalog/entries/natural-selection.md
@@ -1,6 +1,7 @@
 ---
 slug: natural-selection
 name: Natural Selection
+summary: "Darwin's mechanism: heritable variation plus differential survival produces cumulative, purposeless design without a designer."
 kind: mental-model
 source_frame: natural-selection
 categories:

--- a/catalog/entries/pandoras-box.md
+++ b/catalog/entries/pandoras-box.md
@@ -1,6 +1,7 @@
 ---
 slug: pandoras-box
 name: Pandora's Box
+summary: "Hesiod's jar: irreversible release of harms once opened; only hope remains, making the opening both catastrophe and promise."
 kind: metaphor
 source_frame: mythology
 applies_to:

--- a/catalog/entries/panning-for-gold.md
+++ b/catalog/entries/panning-for-gold.md
@@ -1,6 +1,7 @@
 ---
 slug: panning-for-gold
 name: Panning for Gold
+summary: "Prospecting labor: sifting large volumes of low-value material to isolate rare signal; the work is in the ratio, not the find."
 kind: metaphor
 source_frame: mining
 applies_to:

--- a/catalog/entries/parasitic-architecture.md
+++ b/catalog/entries/parasitic-architecture.md
@@ -1,6 +1,7 @@
 ---
 slug: parasitic-architecture
 name: Parasitic Architecture
+summary: "Organism that depends on a host without contributing; maps onto software or systems that consume without producing shared value."
 kind: metaphor
 source_frame: architecture-and-building
 applies_to:

--- a/catalog/entries/patina.md
+++ b/catalog/entries/patina.md
@@ -1,6 +1,7 @@
 ---
 slug: patina
 name: Patina
+summary: "Surface oxidation that signals age and use; accumulated wear can signal authenticity and quality rather than degradation."
 kind: metaphor
 source_frame: materials
 applies_to:

--- a/catalog/entries/predator-prey.md
+++ b/catalog/entries/predator-prey.md
@@ -1,6 +1,7 @@
 ---
 slug: predator-prey
 name: Predator-Prey
+summary: "Lotka-Volterra coupled oscillation: two populations cycle together because each one's abundance is the other's constraint."
 kind: mental-model
 source_frame: ecology
 categories:

--- a/catalog/entries/prototype.md
+++ b/catalog/entries/prototype.md
@@ -1,6 +1,7 @@
 ---
 slug: prototype
 name: Prototype
+summary: "Disposable test version whose purpose is learning, not output; inverts the assumption that a first attempt should be kept."
 kind: mental-model
 source_frame: manufacturing
 categories:

--- a/catalog/entries/quis-custodiet-ipsos-custodes.md
+++ b/catalog/entries/quis-custodiet-ipsos-custodes.md
@@ -1,6 +1,7 @@
 ---
 slug: quis-custodiet-ipsos-custodes
 name: Quis Custodiet Ipsos Custodes
+summary: "Juvenal's oversight regress: any guardian can be corrupted, so who guards the guardian? The question has no internal solution."
 kind: mental-model
 source_frame: governance
 categories:

--- a/catalog/entries/red-herring.md
+++ b/catalog/entries/red-herring.md
@@ -1,6 +1,7 @@
 ---
 slug: red-herring
 name: Red Herring
+summary: "Scent diversion from tracking lore: a false trail introduced to draw attention from the real issue."
 kind: metaphor
 dead: true
 source_frame: pursuit-and-escape

--- a/catalog/entries/rupture-and-repair.md
+++ b/catalog/entries/rupture-and-repair.md
@@ -1,6 +1,7 @@
 ---
 slug: rupture-and-repair
 name: Rupture and Repair
+summary: "Therapeutic model: relationships strengthen through cycles of disruption and reconnection, not through absence of conflict."
 kind: mental-model
 source_frame: psychotherapy
 categories:

--- a/catalog/entries/scapegoat.md
+++ b/catalog/entries/scapegoat.md
@@ -1,6 +1,7 @@
 ---
 slug: scapegoat
 name: Scapegoat
+summary: "Leviticus ritual: blame is transferred to a substitute who is expelled, purging the community without addressing the actual cause."
 kind: archetype
 source_frame: religion
 applies_to:

--- a/catalog/entries/second-system-effect.md
+++ b/catalog/entries/second-system-effect.md
@@ -1,6 +1,7 @@
 ---
 slug: second-system-effect
 name: Second-System Effect
+summary: "Brooks's observation: the second system accumulates all deferred ideas from the first, producing an over-engineered failure."
 kind: mental-model
 source_frame: software-engineering
 categories:

--- a/catalog/entries/servant-leadership.md
+++ b/catalog/entries/servant-leadership.md
@@ -1,6 +1,7 @@
 ---
 slug: servant-leadership
 name: Servant Leadership
+summary: "Inverted pyramid of obligation: leaders serve those they lead rather than extracting from them, power justified by enabling others."
 kind: paradigm
 source_frame: leadership-and-management
 categories:

--- a/catalog/entries/sharpening-the-saw.md
+++ b/catalog/entries/sharpening-the-saw.md
@@ -1,6 +1,7 @@
 ---
 slug: sharpening-the-saw
 name: Sharpening the Saw
+summary: "Tool maintenance as renewal: pausing productive work to restore the instrument's edge is itself productive, not lost time."
 kind: metaphor
 source_frame: tool-use
 applies_to:

--- a/catalog/entries/show-dont-tell.md
+++ b/catalog/entries/show-dont-tell.md
@@ -1,6 +1,7 @@
 ---
 slug: show-dont-tell
 name: "Show, Don't Tell"
+summary: "Narrative craft principle: let action and detail demonstrate; stating conclusions is telling, enacting them is showing."
 kind: paradigm
 source_frame: narrative-and-storytelling
 categories:

--- a/catalog/entries/siren.md
+++ b/catalog/entries/siren.md
@@ -1,6 +1,7 @@
 ---
 slug: siren
 name: Siren
+summary: "Odyssey archetype: irresistible, fatal attraction that destroys those who approach without deliberate safeguards."
 kind: archetype
 source_frame: mythology
 applies_to:

--- a/catalog/entries/slippery-slope.md
+++ b/catalog/entries/slippery-slope.md
@@ -1,6 +1,7 @@
 ---
 slug: slippery-slope
 name: Slippery Slope
+summary: "Gravitational descent: one step triggers an unstoppable sequence; a genuine causal structure and a common argumentation fallacy."
 kind: metaphor
 source_frame: spatial-motion
 applies_to:

--- a/catalog/entries/sowing-seeds.md
+++ b/catalog/entries/sowing-seeds.md
@@ -1,6 +1,7 @@
 ---
 slug: sowing-seeds
 name: Sowing Seeds
+summary: "Agricultural deferred return: investment now, harvest later, with a gap where effort is invisible but irreversible."
 kind: metaphor
 source_frame: agriculture
 applies_to:

--- a/catalog/entries/spike.md
+++ b/catalog/entries/spike.md
@@ -1,6 +1,7 @@
 ---
 slug: spike
 name: Spike
+summary: "Time-boxed exploration in XP to answer a specific risk question before committing to implementation, discarded after learning."
 kind: metaphor
 source_frame: exploration
 applies_to:

--- a/catalog/entries/staging-environment.md
+++ b/catalog/entries/staging-environment.md
@@ -1,6 +1,7 @@
 ---
 slug: staging-environment
 name: Staging Environment
+summary: "Theater staging area: a pre-production space where conditions mirror live performance without live consequences."
 kind: metaphor
 source_frame: theater-and-performance
 applies_to:

--- a/catalog/entries/strange-loop.md
+++ b/catalog/entries/strange-loop.md
@@ -1,6 +1,7 @@
 ---
 slug: strange-loop
 name: Strange Loop
+summary: "Hofstadter's term for hierarchical levels that unexpectedly cycle back to their origin, generating self-reference and paradox."
 kind: mental-model
 source_frame: self-reference
 categories:

--- a/catalog/entries/strangler-fig.md
+++ b/catalog/entries/strangler-fig.md
@@ -1,6 +1,7 @@
 ---
 slug: strangler-fig
 name: Strangler Fig
+summary: "Botanical pattern for replacing a legacy system by wrapping it in a new one that gradually takes over until the host can be removed."
 kind: pattern
 source_frame: ecology
 applies_to:

--- a/catalog/entries/straw-that-broke-the-camels-back.md
+++ b/catalog/entries/straw-that-broke-the-camels-back.md
@@ -1,6 +1,7 @@
 ---
 slug: straw-that-broke-the-camels-back
 name: Straw That Broke the Camel's Back
+summary: "Cumulative causation: each load is tolerable until one small addition crosses the threshold, hiding that the prior loads were the real cause."
 kind: metaphor
 source_frame: weight
 applies_to:

--- a/catalog/entries/sugar-coating.md
+++ b/catalog/entries/sugar-coating.md
@@ -1,6 +1,7 @@
 ---
 slug: sugar-coating
 name: Sugar-Coating
+summary: "Pharmaceutical film that masks bitterness; imports the idea that delivery can be separated from content without changing either."
 kind: metaphor
 source_frame: food-and-cooking
 applies_to:

--- a/catalog/entries/symbiosis.md
+++ b/catalog/entries/symbiosis.md
@@ -1,6 +1,7 @@
 ---
 slug: symbiosis
 name: Symbiosis
+summary: "Taxonomy of species co-dependence (mutualism, commensalism, parasitism) applied to any durable inter-entity relationship."
 kind: mental-model
 source_frame: ecology
 categories:

--- a/catalog/entries/t-shaped-people.md
+++ b/catalog/entries/t-shaped-people.md
@@ -1,6 +1,7 @@
 ---
 slug: t-shaped-people
 name: T-Shaped People
+summary: "Letter shape maps breadth of awareness (horizontal bar) against depth in one specialty (vertical bar)."
 kind: metaphor
 source_frame: geometry
 applies_to:

--- a/catalog/entries/vestigial-structure.md
+++ b/catalog/entries/vestigial-structure.md
@@ -1,6 +1,7 @@
 ---
 slug: vestigial-structure
 name: Vestigial Structure
+summary: "A once-functional feature that persists because removal costs more than tolerance; presence explained by history, not current use."
 kind: metaphor
 dead: false
 source_frame: biology

--- a/catalog/entries/when-pigs-fly.md
+++ b/catalog/entries/when-pigs-fly.md
@@ -1,6 +1,7 @@
 ---
 slug: when-pigs-fly
 name: When Pigs Fly
+summary: "Adynaton: maps \"never\" onto biological impossibility, borrowing categorical certainty for claims that may only be stubborn dismissal."
 kind: metaphor
 dead: true
 source_frame: animal-behavior

--- a/catalog/entries/white-elephant.md
+++ b/catalog/entries/white-elephant.md
@@ -1,6 +1,7 @@
 ---
 slug: white-elephant
 name: White Elephant
+summary: "A Thai royal gift too sacred to use but too costly to keep; any asset whose prestige blocks rational divestment."
 kind: metaphor
 dead: true
 source_frame: economics

--- a/catalog/entries/whitewash.md
+++ b/catalog/entries/whitewash.md
@@ -1,6 +1,7 @@
 ---
 slug: whitewash
 name: Whitewash
+summary: "Lime coating that covers without repairing; names cover-ups that address appearance while leaving the substrate unchanged."
 kind: metaphor
 dead: true
 source_frame: purity

--- a/catalog/entries/work-in-progress.md
+++ b/catalog/entries/work-in-progress.md
@@ -1,6 +1,7 @@
 ---
 slug: work-in-progress
 name: Work in Progress
+summary: "Starting work creates ongoing liability; WIP limits apply Little's Law to cut lead time by stopping starts before finishing starts."
 kind: metaphor
 dead: true
 source_frame: manufacturing


### PR DESCRIPTION
## Summary

Adds `summary` field to 58 catalog entries that were missed in previous enrichment sweeps.

## Sample summaries

- **burnout**: "Combustion metaphor for exhaustion: misdirects intervention to the individual fuel rather than the organizational conditions of combustion."
- **goodharts-law**: "When a metric becomes a target, agents optimize the metric rather than the quality it measured, collapsing the correlation."
- **frankenstein**: "Shelley's archetype: technical mastery without ethical governance; the creator's abandonment, not the creation itself, makes it monstrous."
- **brooks-law**: "Adding people to a late project makes it later: communication channels grow quadratically while individual capacity grows linearly."
- **bounded-context**: "DDD's largest scope within which a model stays consistent; translation at boundaries is explicit rather than implicit and invisible."

## Validation

`uv run scripts/validate.py validate` passes with zero errors (144 pre-existing dangling-reference warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)