### PR TITLE
Create 16 missing frames referenced by existing entries

### DIFF
--- a/catalog/frames/arts-and-culture.md
+++ b/catalog/frames/arts-and-culture.md
@@ -1,0 +1,8 @@
+---
+slug: arts-and-culture
+name: Arts and Culture
+roles: []
+related: []
+created: '2026-03-26'
+updated: '2026-03-26'
+---

--- a/catalog/frames/cognitive-science.md
+++ b/catalog/frames/cognitive-science.md
@@ -1,0 +1,8 @@
+---
+slug: cognitive-science
+name: Cognitive Science
+roles: []
+related: []
+created: '2026-03-26'
+updated: '2026-03-26'
+---

--- a/catalog/frames/computer-science.md
+++ b/catalog/frames/computer-science.md
@@ -1,0 +1,8 @@
+---
+slug: computer-science
+name: Computer Science
+roles: []
+related: []
+created: '2026-03-26'
+updated: '2026-03-26'
+---

--- a/catalog/frames/cooking.md
+++ b/catalog/frames/cooking.md
@@ -1,0 +1,8 @@
+---
+slug: cooking
+name: Cooking
+roles: []
+related: []
+created: '2026-03-26'
+updated: '2026-03-26'
+---

--- a/catalog/frames/economics-and-trade.md
+++ b/catalog/frames/economics-and-trade.md
@@ -1,0 +1,8 @@
+---
+slug: economics-and-trade
+name: Economics and Trade
+roles: []
+related: []
+created: '2026-03-26'
+updated: '2026-03-26'
+---

--- a/catalog/frames/health-and-disease.md
+++ b/catalog/frames/health-and-disease.md
@@ -1,0 +1,8 @@
+---
+slug: health-and-disease
+name: Health and Disease
+roles: []
+related: []
+created: '2026-03-26'
+updated: '2026-03-26'
+---

--- a/catalog/frames/hospitality.md
+++ b/catalog/frames/hospitality.md
@@ -1,0 +1,8 @@
+---
+slug: hospitality
+name: Hospitality
+roles: []
+related: []
+created: '2026-03-26'
+updated: '2026-03-26'
+---

--- a/catalog/frames/information.md
+++ b/catalog/frames/information.md
@@ -1,0 +1,8 @@
+---
+slug: information
+name: Information
+roles: []
+related: []
+created: '2026-03-26'
+updated: '2026-03-26'
+---

--- a/catalog/frames/investigation.md
+++ b/catalog/frames/investigation.md
@@ -1,0 +1,8 @@
+---
+slug: investigation
+name: Investigation
+roles: []
+related: []
+created: '2026-03-26'
+updated: '2026-03-26'
+---

--- a/catalog/frames/journey.md
+++ b/catalog/frames/journey.md
@@ -1,0 +1,8 @@
+---
+slug: journey
+name: Journey
+roles: []
+related: []
+created: '2026-03-26'
+updated: '2026-03-26'
+---

--- a/catalog/frames/law-and-justice.md
+++ b/catalog/frames/law-and-justice.md
@@ -1,0 +1,8 @@
+---
+slug: law-and-justice
+name: Law and Justice
+roles: []
+related: []
+created: '2026-03-26'
+updated: '2026-03-26'
+---

--- a/catalog/frames/perception.md
+++ b/catalog/frames/perception.md
@@ -1,0 +1,8 @@
+---
+slug: perception
+name: Perception
+roles: []
+related: []
+created: '2026-03-26'
+updated: '2026-03-26'
+---

--- a/catalog/frames/risk-and-failure.md
+++ b/catalog/frames/risk-and-failure.md
@@ -1,0 +1,8 @@
+---
+slug: risk-and-failure
+name: Risk and Failure
+roles: []
+related: []
+created: '2026-03-26'
+updated: '2026-03-26'
+---

--- a/catalog/frames/sports-and-games.md
+++ b/catalog/frames/sports-and-games.md
@@ -1,0 +1,8 @@
+---
+slug: sports-and-games
+name: Sports and Games
+roles: []
+related: []
+created: '2026-03-26'
+updated: '2026-03-26'
+---

--- a/catalog/frames/therapy.md
+++ b/catalog/frames/therapy.md
@@ -1,0 +1,8 @@
+---
+slug: therapy
+name: Therapy
+roles: []
+related: []
+created: '2026-03-26'
+updated: '2026-03-26'
+---

--- a/catalog/frames/visual-arts.md
+++ b/catalog/frames/visual-arts.md
@@ -1,0 +1,8 @@
+---
+slug: visual-arts
+name: Visual Arts
+roles: []
+related: []
+created: '2026-03-26'
+updated: '2026-03-26'
+---


### PR DESCRIPTION
## Summary

- Creates 16 frame files that were referenced in `related:` or `broader:` fields but didn't exist
- Resolves all dangling frame warnings from the validator

## Frames created

health-and-disease (4 refs), economics-and-trade (2 refs), arts-and-culture, hospitality, cooking, investigation, cognitive-science, law-and-justice, computer-science, perception, visual-arts, therapy, risk-and-failure, information, sports-and-games, journey

## Test plan

- [x] `uv run scripts/validate.py validate` passes with 0 frame warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)